### PR TITLE
Reassembler Test Case - Insert last substring beyond capacity

### DIFF
--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -97,6 +97,29 @@ int main()
       test.execute( ReadAll( "c" ) );
     }
 
+    {
+      ReassemblerTestHarness test { "insert last beyond capacity", 2 };
+
+      test.execute( Insert { "bc", 1 }.is_last() );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ab" ) );
+      
+      test.execute( IsFinished { false } );
+      
+      test.execute( Insert { "bc", 1 }.is_last() );
+      test.execute( BytesPushed( 3 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( ReadAll( "c" ) );
+
+      test.execute( IsFinished { true } );
+    }
+
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
Test case for Reassembler that inserts a substring that goes beyond capacity with the last flag set. The reassembler should not close the bytestream until the substring that is over capacity is inserted again.

### Purpose
During grading of assignment 1, I noticed a large portion of student's implementations would not handle this edge case. 

### Test Summary
Consider a reassembler with capacity 2. If you insert (substr="bc", idx=1, is_last=true), then only the "b" will be recorded in the buffer. But if an implementation blindly remembers they have seen the last substring, instead of checking that they have included the last substring or using a total length approach, then they wind up with a bug where inserting (substr="a", idx=0) results in "ab" being pushed to bytestream and the bytestream to be closed. In a correct implementation, the reassembler should wait until ("c", 2) is inserted and pushed before closing the bytestream. 

### Risk of Bug in TCP Implementation
Since our TCP implementation uses the remaining capacity as the window size, it is rare that this bug will cause any problems in the wild. This would require another bug in and would only be noticeable by the bytestream closing without all expected data (1 byte less), which would be rare to occur and rarer to notice. 

Yet it is important as a design consideration to enforce students thinking about edge cases like this.