### PR TITLE
Modified the parameter type of the tick function in the tcp_sender.cc file

### DIFF
--- a/src/tcp_sender.cc
+++ b/src/tcp_sender.cc
@@ -46,7 +46,7 @@ void TCPSender::receive( const TCPReceiverMessage& msg )
   (void)msg;
 }
 
-void TCPSender::tick( const size_t ms_since_last_tick )
+void TCPSender::tick( uint64_t ms_since_last_tick )
 {
   // Your code here.
   (void)ms_since_last_tick;


### PR DESCRIPTION
The parameter type of the function tick in the files "tcp_sender.h" and "tcp_sender.cc" are different, so I modified the parameters of the tick function in the .cc file.