### PR TITLE
Add bytes-popped-test to show a bug in pop()

### DIFF
--- a/tests/byte_stream_capacity.cc
+++ b/tests/byte_stream_capacity.cc
@@ -97,6 +97,17 @@ int main()
       test.execute( BytesBuffered { 1 } );
     }
 
+    {
+      ByteStreamTestHarness test { "bytes-popped-test", 2 };
+
+      test.execute( Push { "c" } );
+      test.execute( BytesPushed { 1 } );
+      test.execute( Pop { 2 } );
+      test.execute( IsClosed { false } );
+      test.execute( BufferEmpty { true } );
+      test.execute( BytesPopped { 1 } );
+    }
+
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
This test helped me to discover a bug in my `pop()` function. The test checks for the case where caller tries to pop with a `len` greater than what is available. In the case where the implementation chooses to pop the maximum available, this test checks that the `bytes_popped()` function's return value is consistent with what was actually popped from the stream instead of the original `len`. 

Below is the output of `cmake --build build --target check0` with the added `bytes-popped-test` when the `pop()` function is implemented without the above consideration.  

```
The test "bytes-popped-test" failed after these steps:

  0.	Initialized ByteStream with capacity=2
  1.	Action: push "c" to the stream
  2.	Expectation: bytes_pushed = 1
  3.	Action: pop( 2 )
  4.	Expectation: is_closed = false
  5.	Expectation: [buffer is empty] = true
  ***** Unsuccessful Expectation: bytes_popped = 1 *****

ExpectationViolation: The object should have had bytes_popped = 1, but instead it was 2.
```