### PR TITLE
Add test for inserting beyond capacity with unacceptable data mixed in

### DIFF
--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -120,6 +120,31 @@ int main()
 
       test.execute( IsFinished { true } );
     }
+
+    {
+      ReassemblerTestHarness test { "insert beyond capacity with unacceptable data mixed", 2 };
+
+      test.execute( Insert { "e", 1 } );
+      test.execute( Insert { "d", 5 }.is_last() ); // unacceptable, so "d" is not remembered
+      test.execute( BytesPending( 1 ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "lelqnk", 0 }.is_last() ); // "lqnk" unacceptable
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "le" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "lat", 2 } ); // "t" unacceptable
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "la" ) );
+
+      test.execute( Insert { "nd", 4 }.is_last() );
+      test.execute( BytesPushed( 6 ) );
+      test.execute( ReadAll( "nd" ) );
+      test.execute( IsFinished { true } );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
This test verifies that the `Reassembler` properly limits its memory usage by tracking the first unacceptable index correctly and discarding any extra data. It also checks that the end of the stream is properly tracked regardless of the unacceptable data being mixed in.

If the test does not pass, it indicates that the `Reassembler` is either retaining more data than necessary, inaccurately keeping track of the final substring, or failing to close the stream correctly.