### PR TITLE
Deal With Underflow in `roundtrip`

### DIFF
--- a/tests/wrapping_integers_roundtrip.cc
+++ b/tests/wrapping_integers_roundtrip.cc
@@ -9,8 +9,13 @@
 
 using namespace std;
 
-void check_roundtrip( const Wrap32 isn, const uint64_t value, const uint64_t checkpoint )
+void check_roundtrip( const Wrap32 isn, const int64_t offset, const uint64_t checkpoint )
 {
+  uint64_t value = checkpoint + offset;
+  if ( offset < 0 && (uint64_t)-offset > checkpoint ) {
+    value += 1ul << 32;
+  }
+
   if ( Wrap32::wrap( value, isn ).unwrap( isn, checkpoint ) != value ) {
     ostringstream ss;
 
@@ -30,20 +35,20 @@ int main()
     uniform_int_distribution<uint32_t> dist32 { 0, numeric_limits<uint32_t>::max() };
     uniform_int_distribution<uint64_t> dist63 { 0, uint64_t { 1 } << 63 };
 
-    const uint64_t big_offset = ( uint64_t { 1 } << 31 ) - 1;
+    const int64_t big_offset = ( int64_t { 1 } << 31 ) - 1;
 
     for ( unsigned int i = 0; i < 1000000; i++ ) {
       const Wrap32 isn { dist32( rd ) };
       const uint64_t val { dist63( rd ) };
-      const uint64_t offset { dist31minus1( rd ) };
+      const int64_t offset { dist31minus1( rd ) };
 
-      check_roundtrip( isn, val, val );
-      check_roundtrip( isn, val + 1, val );
-      check_roundtrip( isn, val - 1, val );
-      check_roundtrip( isn, val + offset, val );
-      check_roundtrip( isn, val - offset, val );
-      check_roundtrip( isn, val + big_offset, val );
-      check_roundtrip( isn, val - big_offset, val );
+      check_roundtrip( isn, 0, val );
+      check_roundtrip( isn, 1, val );
+      check_roundtrip( isn, -1, val );
+      check_roundtrip( isn, offset, val );
+      check_roundtrip( isn, -offset, val );
+      check_roundtrip( isn, big_offset, val );
+      check_roundtrip( isn, -big_offset, val );
     }
   } catch ( const exception& e ) {
     cerr << e.what() << endl;


### PR DESCRIPTION
It appears the code in the `roundtrip` test doesn't correctly handle offsets from the checkpoint that cause it to underflow below zero. For instance, assuming `isn == 0u` for clarity, suppose `val` is selected to be `0x0000_0000_7fff_fffe`. Then on line 46 of the old file, we would set `value = 0xffff_ffff_ffff_ffff` and `checkpoint = 0x0000_0000_7fff_fffe`. Wrapping `value` would produce `0xffff_ffff`, and unwrapping that with the calculated checkpoint would give `0x0000_0000_ffff_ffff`, which is not equal to `value`.

This happens because the subtraction used to compute `value` underflows, putting it at the opposite end of the representable range. This PR includes a check for that, and corrects for the underflow if it occurs.

Interestingly, this error is caught in other tests. I speculate that it wouldn't have been caught here due to the low probability of it happening - less than 1 in `2**32`.

See: https://edstem.org/us/courses/50052/discussion/4185447