### PR TITLE
Add test to catch unnecessary closing of writer

### DIFF
--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -120,6 +120,31 @@ int main()
 
       test.execute( IsFinished { true } );
     }
+
+    // test credit: Tanmay Garg and Agam Mohan Singh Bhatia
+    {
+      ReassemblerTestHarness test { "insert last fully beyond capacity + empty string is last", 2 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "abc", 0 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "", 3 }.is_last() );
+      test.execute( IsFinished { false } );
+
+      test.execute( ReadAll( "ab" ) );
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( ReadAll( "c" ) );
+      test.execute( IsFinished { true } );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
I created this test in collaboration with @agu18dec. The purpose is to catch situations when a reassembler program closes the writer in incorrect cases. For example, if it has a special case of checking when the input data is empty or when capacity is 0, and closes the writer in those situations without checking if the number of bytes pushed is the amount required. 

These kind of errors are covered in this test case: when the available capacity is 0 and the first index of the last substring is beyond the capacity. Please let us know if we should make this test more rigorous and if there are additional similar edge cases we should cover!