### PR TITLE
Add test for a combination of a complete and a partial overlap

### DIFF
--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -120,6 +120,31 @@ int main()
 
       test.execute( IsFinished { true } );
     }
+
+    // test credit: Tanmay Garg and Agam Mohan Singh Bhatia
+    {
+      ReassemblerTestHarness test { "insert last fully beyond capacity + empty string is last", 2 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "abc", 0 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "", 3 }.is_last() );
+      test.execute( IsFinished { false } );
+
+      test.execute( ReadAll( "ab" ) );
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( ReadAll( "c" ) );
+      test.execute( IsFinished { true } );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << endl;
     return EXIT_FAILURE;

--- a/tests/reassembler_overlapping.cc
+++ b/tests/reassembler_overlapping.cc
@@ -272,6 +272,19 @@ int main()
       test.execute( BytesPushed( 5 ) );
       test.execute( BytesPending( 0 ) );
     }
+    
+    {
+      // Credit: Tanmay Garg
+      ReassemblerTestHarness test { "overlapping multiple unassembled sections 3", 30 };
+
+      test.execute( Insert { "world!", 21 } );
+      test.execute( Insert { "hello", 15 } );
+      test.execute( Insert { "I am sentient", 0 } );
+      test.execute( Insert { "am sentient, hello world", 2 } );
+
+      test.execute( BytesPushed( 27 ) );
+      test.execute( BytesPending( 0 ) );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << endl;
     return EXIT_FAILURE;

--- a/tests/reassembler_overlapping.cc
+++ b/tests/reassembler_overlapping.cc
@@ -277,13 +277,13 @@ int main()
       // Credit: Tanmay Garg
       ReassemblerTestHarness test { "overlapping multiple unassembled sections 3", 30 };
 
-      test.execute( Insert { "world!", 21 } );
       test.execute( Insert { "hello", 15 } );
+      test.execute( Insert { "world!", 21 } );
       test.execute( Insert { "I am sentient", 0 } );
-      test.execute( Insert { "am sentient, hello world", 2 } );
+      test.execute( Insert { "sentient, hello world", 5 } );
 
-      test.execute( BytesPushed( 27 ) );
       test.execute( BytesPending( 0 ) );
+      test.execute( BytesPushed( 27 ) );
     }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << endl;


### PR DESCRIPTION
I have a suggestion for another test for the Reassembler. I found that my code was failing the `recv_reorder_more` test and after some testing, I realized that the error was in my Reassembler code when there is an overlapping insert where the substring overlaps fully with a previous inserted section and partially with another. This test case checks for that situation. Please ignore the commit for "Add test for inserting fully beyond capacity", which was part of an older PR.