### PR TITLE
Test for In-Flight SeqNos and Partial Acks

### DIFF
--- a/tests/send_ack.cc
+++ b/tests/send_ack.cc
@@ -71,6 +71,24 @@ int main()
       test.execute( ExpectSeqnosInFlight { 1 } );
       test.execute( HasError { false } );
     }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Sequence numbers in flight ignores partial ACK", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1024 ) );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "ab" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_payload_size( 2 ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( AckReceived { Wrap32 { isn + 2 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqnosInFlight { 2 } );
+    }
   } catch ( const exception& e ) {
     cerr << e.what() << endl;
     return 1;


### PR DESCRIPTION
The `sequence_numbers_in_flight` method should return the number of sequence numbers that are in the queue for retransmission. If the sender receives a partial acknowlegement, it should still count the acknowleged sequence numbers as in-flight. In other words, it should not naively take the distance between the current sequence number and the left edge of the window.