### PR TITLE
Add test case for pending timeout expiration

### DIFF
--- a/tests/net_interface.cc
+++ b/tests/net_interface.cc
@@ -320,6 +320,41 @@ int main()
         serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "10.0.0.1", {}, "10.0.0.5" ) ) ) } );
       test.execute( ExpectNoFrame {} );
     }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "datagrams are kept in queue after 5 seconds of pending timeout", local_eth, Address( "4.3.2.1", 0 ) };
+
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+
+      // outgoing datagram should result in an ARP request
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      const EthernetAddress target_eth = random_private_ethernet_address();
+
+      // Let 5+ seconds pass by so that the pending timeout expires
+      test.execute( Tick { 5010 } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP reply should result in the queued datagram getting sent
+      test.execute( ReceiveFrame {
+        make_frame(
+          target_eth,
+          local_eth,
+          EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+          serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ),
+        {} } );
+
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
   } catch ( const exception& e ) {
     cerr << e.what() << endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
This test verifies that a datagram waiting in the queue is kept intact following the 5-second pending timeout initiated by an ARP request.

Example:
- `t=0` Attempts to send a datagram, but no mapping is found so an ARP request is send. Datagram is **queued**.
- `t=5000` Pending ARP request expires after the 5s timeout
- `t=5010` ARP reply received, mapping is created
- `t=5010+` **Queued** datagram should be sent out

My initial implementation linked the ARP mapping with the datagram queue, resulting in the queued datagram being lost after the 5s timeout. This test catches such issues.