### PR TITLE
test(check5): multiple datagrams received and sent

### DIFF
--- a/tests/net_interface.cc
+++ b/tests/net_interface.cc
@@ -184,6 +184,46 @@ int main()
 
     {
       const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "sends multiple datagrams", local_eth, Address( "1.2.3.4", 0 ) };
+
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "10.0.0.1", 0 ) } );
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    ETHERNET_BROADCAST,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "1.2.3.4", {}, "10.0.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      // Over 5 seconds has passed, so the mapping should expire
+      test.execute( Tick { 5001 } );
+      const auto datagram2 = make_datagram( "42.41.40.39", "13.12.11.10" );
+      test.execute( SendDatagram { datagram2, Address( "10.0.0.1", 0 ) } );
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    ETHERNET_BROADCAST,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "1.2.3.4", {}, "10.0.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP reply should result in the two queued datagram getting sent.
+      const EthernetAddress target_eth = random_private_ethernet_address();
+      test.execute( ReceiveFrame {
+        make_frame(
+          target_eth,
+          local_eth,
+          EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+          serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "10.0.0.1", local_eth, "4.3.2.1" ) ) ),
+        {} } );
+
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram2 ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
       NetworkInterfaceTestHarness test { "active mappings last 30 seconds", local_eth, Address( "4.3.2.1", 0 ) };
 
       const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );


### PR DESCRIPTION
This test case checks the case when 1) arp broadcast is sent, 2) 5s pass, 3) another arp broadcast is sent, 4) a frame is received,

The expected behavior (i think) is 1) the first datagram is sent, 2) the second datagram is sent