### PR TITLE
Add check2 test case to catch wrapping error that arises from storing acknos in 16-bit integers

### DIFF
--- a/tests/recv_transmit.cc
+++ b/tests/recv_transmit.cc
@@ -83,7 +83,7 @@ int main()
     {
       TCPReceiverTestHarness test { "proper wrapping when sending more than 2^16 bytes", 4000 };
       const uint32_t block_size = 1000;
-      const uint32_t n_rounds = 1000;
+      const uint32_t n_rounds = 67;
       const uint32_t isn = 0;
       size_t bytes_sent = 0;
       test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );


### PR DESCRIPTION
**Motivation**
In my TCPReceiver's `send()` function, I stored each ackno as a `uint16_t` before wrapping them. This meant that my TCPReceiver was unable to handle acknos above 2^16. 

**Description**
Unlike the existing test suite, this test case deterministically transmits over 2^16 bytes. This test case will only succeed if the TCPReceiver does not "squash" acknos into a `uint16_t` and instead stores them in a type that is at least 32 bits.