### PR TITLE
Trim Padding When Parsing IPv4 Packets

### DIFF
--- a/util/ipv4_datagram.hh
+++ b/util/ipv4_datagram.hh
@@ -16,7 +16,15 @@ struct IPv4Datagram
   void parse( Parser& parser )
   {
     header.parse( parser );
-    parser.all_remaining( payload );
+
+    // The Ethernet frame can have padding on the end. We must ignore it by only
+    // taking the number of bytes specified in the header.
+    //
+    // TODO: Efficiency. There's no need to concatenate all the remaining
+    // elements of the `vector`, as long as we take only the first `N`. This
+    // would save a a few copies.
+    payload.emplace_back( header.payload_length(), '\x00' );
+    parser.string( payload.back() );
   }
 
   void serialize( Serializer& serializer ) const


### PR DESCRIPTION
If an Ethernet frame is smaller than 60 bytes, it will be padded to that length. However, the old code that parsed IPv4 packets assumed that all of the data after the Ethernet header was part of the packet. This led to any padding bytes being treated as part of the payload.

ARP messages are unaffected since their parsing code always reads from the front of the packet and thus implicitly ignores any appended data.

This commit uses the length fields in the IPv4 header to determine the payload length, ignoring any data present after that.