### PR TITLE
Added a test case to expose a bug within router related to default_route and prefix_length.

### DIFF
--- a/tests/router.cc
+++ b/tests/router.cc
@@ -209,10 +209,11 @@ public:
     hs->connect( _router.interface( hs4_id ) );
     hs->connect( host( "hs_router" ).interface() );
 
-    _router.add_route( ip( "0.0.0.0" ), 0, host( "default_router" ).address(), default_id );
+
     _router.add_route( ip( "10.0.0.0" ), 8, {}, eth0_id );
     _router.add_route( ip( "172.16.0.0" ), 16, {}, eth1_id );
     _router.add_route( ip( "192.168.0.0" ), 24, {}, eth2_id );
+    _router.add_route( ip( "0.0.0.0" ), 0, host( "default_router" ).address(), default_id );
     _router.add_route( ip( "198.178.229.0" ), 24, {}, uun3_id );
     _router.add_route( ip( "143.195.0.0" ), 17, host( "hs_router" ).address(), hs4_id );
     _router.add_route( ip( "143.195.128.0" ), 18, host( "hs_router" ).address(), hs4_id );


### PR DESCRIPTION
Buggy Behavior:
I was able to get all of the tests to pass by having the best route that I was keeping track of always be set to the route that had a prefix_length of 0. So that no matter what I had found previously if I found a route with a prefix_length of zero it would be overwritten. Which is not the expected behavior. In addition, this behavior is mimicked for any prefix_length <= 7 due to how the routes are being added in.

Resolution:
The bug was fixed by reordering how the routes were being added. Due to the low number of routes being added in and the first route being added in being the default route, it allowed this buggy behavior to pass. The reordering of the routes makes it so this behavior is no longer able to pass and must be fixed.