### PR TITLE
fix CMakeLists.txt for potential "undefined reference to pthread_create"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.24.2)
-
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 project(minnow CXX)
 
 if(${CMAKE_GENERATOR} STREQUAL "Unix Makefiles")


### PR DESCRIPTION
In checkpoint4, when i use "cmake --build build --target check_webget", the cmake failed, and show "undefined reference to pthread_create", and i add "SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")" to CMakeLists.txt, then it passed. im not sure if it is my own mistake.