### PR TITLE
[Lab 0] Add Closed Stream Test

### DIFF
--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -23,6 +23,7 @@ ttest(byte_stream_one_write)
 ttest(byte_stream_two_writes)
 ttest(byte_stream_many_writes)
 ttest(byte_stream_stress_test)
+ttest(byte_stream_closed_stream)
 
 ttest(reassembler_single)
 ttest(reassembler_cap)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_test_exec(byte_stream_one_write)
 add_test_exec(byte_stream_two_writes)
 add_test_exec(byte_stream_many_writes)
 add_test_exec(byte_stream_stress_test)
+add_test_exec(byte_stream_closed_stream)
 
 add_test_exec(no_skip)
 

--- a/tests/byte_stream_closed_stream.cc
+++ b/tests/byte_stream_closed_stream.cc
@@ -1,0 +1,44 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+
+#include <algorithm>
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    const size_t CAPACITY = 42;
+
+    // Verify that once the Writer is closed, no more data can be pushed.
+    {
+      ByteStreamTestHarness test { "push after close", CAPACITY };
+
+      test.execute( Push { "144" } );
+      test.execute( BytesPushed { 3 } );
+      test.execute( BufferEmpty { false } );
+      test.execute( IsClosed { false } );
+      test.execute( IsFinished { false } );
+
+      // Close the writer.
+      test.execute( Close {} );
+      test.execute( IsClosed { true } );
+      test.execute( IsFinished { false } );
+
+      // Attempt to push after closed. Should NOT push anything.
+      test.execute( Push { "an_arbitrary_string" } );
+
+      // The total number of pushed bytes should remain 3.
+      test.execute( BytesPushed { 3 } );
+      test.execute( BufferEmpty { false } );
+    }
+
+  } catch ( const exception &e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This PR adds a test to ensure that the ByteStream Writer cannot push to the stream if it's already been closed. This is a plausible correctness bug that students could make that is not already caught by existing tests. A closed byte stream should not allow continued pushes. Verified compilation below.

![Screenshot 2025-01-09 at 11 56 51 PM](https://github.com/user-attachments/assets/f55842b4-356a-4afa-9c3a-ac37dc8f7420)

sunet: sujinesh