### PR TITLE
[Lab 2] Add a Test Case to `wrapping_integers_unwrap`

### DIFF
--- a/tests/wrapping_integers_unwrap.cc
+++ b/tests/wrapping_integers_unwrap.cc
@@ -34,6 +34,10 @@ int main()
     // Nearly big unwrap with non-zero ISN
     test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( 1UL << 31 ), 0 ),
                     static_cast<uint64_t>( UINT32_MAX ) >> 1 );
+
+    // Big unwrap with non-zero ISN and low non-zero checkpoint
+    // test credit: Thanawan Atchariyachanvanit
+    test_should_be( Wrap32( 0 ).unwrap( Wrap32( 1 ), 1 ), static_cast<uint64_t>( UINT32_MAX ) );
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return 1;


### PR DESCRIPTION
This PR adds a test case to identify a bug that occurs when the `checkpoint` is low, but non-zero and a large wraparound is involved. Students who hardcode logic resembling `checkpoint == 0` may pass the existing test cases but fail this one. For this specific test case, such implementations might incorrectly output negative sequence number represented as `UINT64_MAX` (`(uint64_t)0 - 1`) in unsigned type instead of the correct value, `UINT32_MAX`.

sunet: `thanawan`