### PR TITLE
[Lab 1] Test cases testing edge conditions when `is_last_substring` is called

### DIFF
--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -146,6 +146,42 @@ int main()
       test.execute( ReadAll( "c" ) );
       test.execute( IsFinished { true } );
     }
+
+    // test credit: Parth Sarthi
+    {
+      ReassemblerTestHarness test { "last substring exactly fills capacity", 2 };
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( ReadAll( "c" ) );
+
+      test.execute( Insert { "de", 3 }.is_last() );
+      test.execute( ReadAll( "de" ) );
+
+      test.execute( IsFinished { true } );
+    }
+
+    // test credit: Parth Sarthi
+    {
+      ReassemblerTestHarness test { "last substring called but not all bytes written", 2 };
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( ReadAll( "c" ) );
+
+      test.execute( Insert { "def", 3 }.is_last() );
+      test.execute( ReadAll( "de" ) );
+
+      test.execute( IsFinished { false } );
+    }
+
+
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << "\n";
     return EXIT_FAILURE;


### PR DESCRIPTION
Hi, I've added two new test cases for Lab 1. I was able to write code that was able to pass all existing checks but not these. 
Test 1 tests the case where the last substring fills up the capacity fully.
Test 2 tests if last substring is called but the last indices are partially out of bounds.

sunet: `psarthi`