### PR TITLE
[Lab 1]: Test reassembler insertion at invalid index that causes integer overflow

### DIFF
--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -146,6 +146,29 @@ int main()
       test.execute( ReadAll( "c" ) );
       test.execute( IsFinished { true } );
     }
+
+    // test credit: Andy Wang
+    {
+      ReassemblerTestHarness test { "insert beyond capacity at uint64max", 3 };
+
+      test.execute( Insert { "b", 1 }.is_last() );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "z", UINT64_MAX } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "xyz", UINT64_MAX - 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished( true ) );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << "\n";
     return EXIT_FAILURE;


### PR DESCRIPTION
I'm hoping to add a new unit test for reassemble that tests the handling of large and invalid indices. 

The reassembler's `first_index` has data type `uint64_t`. This number is so large that the reassembler is not expected to receive UINT64_MAX as `first_index` during normal operations. If anyone sets `first_index` as `UINT64_MAX`, that is invalid and should be ignored. 

What's different about this test is that if `data` isn't empty, some implementations may calculate the last index of the data with `first_index + data.size()`. In that case, the last index will overflow and cause a situation where `first_index` is greater than the last index. I think the correct handling is that the last index should only be calculated if `first_index` is valid. 

My implementation passed all other checkpoint 1 unit tests, but I had to fix this bug to get checkpoint 2 to work in a straightforward manner without checking corner cases. Thanks a lot!

sunet: `wangh275`