### PR TITLE
 [Check2 Extra Credit]: Test TCPReceiver + Reassembler if they duplicate overlapping payloads, corrupting the stream

### DIFF
--- a/tests/recv_connect.cc
+++ b/tests/recv_connect.cc
@@ -112,6 +112,28 @@ int main()
       TCPReceiverTestHarness test { "window size at 10M", 10'000'000 };
       test.execute( ExpectWindow { UINT16_MAX } );
     }
+
+    {
+        TCPReceiverTestHarness test { "overlapping payloads", 1000 };
+
+        // sending a SYN to initialize the connection
+        test.execute(SegmentArrives {}.with_syn().with_seqno(0));
+        test.execute(ExpectAckno { Wrap32 { 1 } });
+
+        // Send a small initial payload
+        test.execute(SegmentArrives {}.with_seqno(1).with_data("Hel"));
+        test.execute(ExpectAckno { Wrap32 { 4 } }); 
+
+        // Send an overlapping payload with additional data
+        test.execute(SegmentArrives {}.with_seqno(3).with_data("loo Werld!"));
+        test.execute(ExpectAckno { Wrap32 { 13 } });
+
+        // Verify the stream content and ensure no duplicates
+        test.execute(BytesPushed { 12 }); 
+        test.execute(BytesPending { 0 });
+       
+    }
+
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return 1;


### PR DESCRIPTION
Hello! 

I'm hoping to add a new unit test to recv_connect() for reassembler() and TCPReceiver() that tests the handling of overlapping payloads (2 or more input payloads) and seeing if the reassembler duplicates these payloads or not, which can corrupt the bytestream. This test ensures that TCPReceiver correctly handles the case where overlapping payloads are received out of order. Overlapping payloads can occur when duplicate or redundant segments are sent due to network retransmissions and so the TCP receiver must ensure that the Reassembler properly integrates the overlapping data and does not corrupt or duplicate the byte stream.

What's different about this test is that my test case tests overlapping payloads with smaller segments. My test payloads "Hel" and "loo Werld!" include an overlap of 1-2 bytes ("l" from "Hel" and "llo World!" By testing the key overlapping scenario directly (with two payloads), we can see if Reassembler is robust enough or not to be able to handle string payloads that overlap in bytes. 

This test fills a gap in the suite by testing overlapping data handling, which isn’t explicitly covered in the provided test cases.

My implementation for TCP receiver (Checkpoint2) send() and receive() functions passed all other checkpoint 2 unit tests including this test as well and works in a straightforward manner without checking corner cases (I didn't need to handle specific edge cases explicitly). Thanks!
 
**sunet: julih**
