### PR TITLE
Reassembler Test- Receiving Empty String Last String Before Remaining Data

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_test_exec(reassembler_dup)
 add_test_exec(reassembler_holes)
 add_test_exec(reassembler_overlapping)
 add_test_exec(reassembler_win)
+add_test_exec(reassembler_empty_last_received_first)
 
 add_test_exec(no_skip)
 

--- a/tests/reassembler_empty_last_received_first.cc
+++ b/tests/reassembler_empty_last_received_first.cc
@@ -1,0 +1,27 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "empty last index received first", cap };
+
+      test.execute( Insert { "", 4 }.is_last() );
+      test.execute( Insert { "abc", 0 } );
+
+      test.execute( BytesPushed( 3 ) );
+      test.execute( ReadAll( "abc" ) );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The added test checks that the reassembler correctly receives and pushes remaining data after receiving an empty string that is marked as the last substring. 