### PR TITLE
Create reassembler_new_test.cc

### DIFF
--- a/tests/reassembler_new_test.cc
+++ b/tests/reassembler_new_test.cc
@@ -1,0 +1,26 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{ 
+  try {
+      ReassemblerTestHarness test { "empty string pushed before byte pushed at "syn bit" location", 4 };
+      test.execute( Insert { "", 0 } );
+      test.execute( Insert { "a", 18446744073709551615 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 0 ) );
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Copying from Ed here: 
My reassembler had a bug, which was actually only caught during this test on the TPCReceiver: 


  0.    Initialized TCPReceiver with capacity=4
  1.    TCPReceiver action: receive message: (seqno=Wrap32<23452> +SYN) with ackno expected
  2.    TCPReceiver action: receive message: (seqno=Wrap32<23452> payload="a") with ackno expected
  3.    Writer expectation: bytes_pushed = 0
  4.    TCPReceiver expectation: ackno = Some(Wrap32<23453>)
  ***** Unsuccessful Reassembler expectation: count_bytes_pending = 0 *****

Unmet Expectation: The Reassembler should have had count_bytes_pending = 0, but instead it was 1.

This new test case that I wrote covers this particular issue for the reassembler -- pushing an empty string, as would be pushed when the SYN bit is first set, and then pushing a single character at the same location as the SYN bit.