### PR TITLE
New reassembler test

### DIFF
--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -203,6 +203,40 @@ int main()
       test.execute( ReadAll( "ab" ) );
       test.execute( IsFinished( true ) );
     }
+
+    // test credit: Andy Wang with Jasraj Yogesh Kripalani
+    {
+      ReassemblerTestHarness test { "Fully utilize reassembler buffer capacity", 10 };
+
+      test.execute( Insert { "bcde", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 5 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "abcde" ) );
+
+      test.execute( Insert { "ghijklmno", 6 } );
+      test.execute( BytesPushed( 5 ) );
+      test.execute( BytesPending( 9 ) );
+
+      test.execute( Insert { "f", 5 } );
+      test.execute( BytesPushed( 15 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "fghijklmno" ) );
+
+      test.execute( Insert { "rstuvwxy", 17 }.is_last() );
+      test.execute( BytesPushed( 15 ) );
+      test.execute( BytesPending( 8 ) );
+
+      test.execute( Insert { "pq", 15 } );
+      test.execute( BytesPushed( 25 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "pqrstuvwxy" ) );
+
+      test.execute( IsFinished( true ) );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << "\n";
     return EXIT_FAILURE;


### PR DESCRIPTION
I hope to add a new unit test to `reassembler_cap` suite. This test exercises the case the reassembler buffer is entirely filled up and cleared multiple times. There are other tests that exercise this, but the data is inserted sequentially. This test checks if the data is inserted in a non-sequential order. 

My reassemble can pass all other tests but encountered issues when sending a 50MB file to my partner, Jasraj Yogesh Kripalani. This was because there was an indexing bug in the reassembler code that only appears if the entire buffer is filled in a non-sequential manner. If it's filled sequentially, then data would be flushed as soon as it's received by reassembler, bypassing the code that stores the data in the buffer.

Thanks! 
sunet: `wangh275`