### PR TITLE
added multi-FIN test for receiver

### DIFF
--- a/tests/recv_special.cc
+++ b/tests/recv_special.cc
@@ -278,6 +278,18 @@ int main()
         test.execute( ReadAll { move( data ) } );
       }
     }
+    // credit for test: Danica Xiong
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "second fin should not affect ackno", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "a" ) );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( isn+2 ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( isn+2 ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+    }
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return 1;


### PR DESCRIPTION
**Problem:** For the 1MB challenge, I noticed my code was working when acting as the client and receiving a file from the TCP_Native server, but failed when acting as the client sending the file from the TCP_Native server. This would result in a similar problem as [#784](https://edstem.org/us/courses/71691/discussion/threads/784) , my TCP implementation would get stuck on an ackno 64000 (out of 65540 bytes), and was for some reason, not receiving it. Basically when receiving multiple FINs, I was incrementing my ackno by +1 each time, which caused an disalignment with the server. My websocket would not close because I was sending the wrong ackno and the server would mitigate this by sending an old seqno (I think).

**Solution:** I just added a test case that sends multiple fins and makes sure that the ackno does not increment after the first FIN.

(**TLDR;** Passed all the test cases, failed the 1MB challenge, spent 3 days debugging, glad I finally fixed the issue, heres a testcase for multiple FIN flags but feel free to ignore this if its not necessary).

**Testing:** You can test it on my assignment code! In my TCP_Reciever.cc, if you comment out "finned=true" on line 37 and run the 1MB test, it will fail. But if you add it back in, it will work! The testcase will also fail if finned is commented on my code, and work when it is uncommented!

![image](https://github.com/user-attachments/assets/b1e9e818-d8a5-4670-9741-846eb047907d)
