### PR TITLE
Add new test for TCPReceiver - Make sure correct ackno is sent back when receiving a FIN-only segment

### DIFF
--- a/tests/recv_close.cc
+++ b/tests/recv_close.cc
@@ -45,6 +45,37 @@ int main()
       test.execute( IsFinished { true } );
     }
 
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "fin only segment", 2358 };
+      // Test: FIN-only segment edge-case.
+      // 1. Start connection with SYN.
+      // 2. Receive three bytes of contiguous data.
+      // 3. Receive a FIN-only segment.
+      // Expect: The ACK after the FIN should be ISN + 5.
+      //
+      // Explanation:
+      //   - SYN consumes 1 sequence number.
+      //   - "abc" is 3 bytes (consuming 3 sequence numbers).
+      //   - FIN consumes 1 sequence number.
+      // So, if ISN is the initial sequence number, the final ACK should be:
+      //     ISN + 1 (SYN) + 3 (data) + 1 (FIN) = ISN + 5.
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+
+      // Deliver contiguous data "abc" (which occupies bytes isn+1 through isn+3).
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abc" ) );
+      test.execute( ReadAll { "abc" } );
+      test.execute( BytesPushed { 3 } );
+
+      // Now, send a FIN-only segment.
+      // The FIN should arrive with seqno isn + 4 (after the data).
+      test.execute( SegmentArrives {}.with_seqno( isn + 4 ).with_fin() );
+      // Correct behavior: the ACK should be isn + 5.
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( BytesPending { 0 } );
+    }
+
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return 1;


### PR DESCRIPTION
I was having an issue where my webget using my socket was hanging. I used tcpdump and Wireshark and realized that the external server was sending a packet with only a FIN and no payload or other flags. My socket was subsequently sending an ACK packet back, but the ACK was one less than it should've been. This was not being caught on any other TCPReceiver test. Once I fixed that, my webget worked and I passed all the tests.