### PR TITLE
Test case - Pushing empty string on closed byte stream

### DIFF
--- a/tests/byte_stream_empty_push_after_close.cc
+++ b/tests/byte_stream_empty_push_after_close.cc
@@ -1,0 +1,44 @@
+#include "byte_stream_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+void all_zeroes( ByteStreamTestHarness& test )
+{
+  test.execute( BytesBuffered { 0 } );
+  test.execute( AvailableCapacity { 15 } );
+  test.execute( BytesPushed { 0 } );
+  test.execute( BytesPopped { 0 } );
+}
+
+int main()
+{
+  try {
+    {
+      ByteStreamTestHarness test { "insert empty string after close", 15 };
+      test.execute( Push { "hello world" } );
+      test.execute( Close {} );
+      test.execute( IsClosed { true });
+      test.execute( Push { "" } );
+      test.execute( HasError { false } );
+      test.execute( IsClosed { true });
+    }
+
+    {
+      ByteStreamTestHarness test { "insert empty string after close empty stream", 15 };
+      test.execute( Close {} );
+      test.execute( IsClosed { true });
+      test.execute( Push { "" } );
+      test.execute( HasError { false } );
+      test.execute( IsFinished { true } );
+      all_zeroes( test );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
In the case where error is set if trying to push byte stream, check that the string being pushed is non empty. ie. this test catches pushing an empty string on a closed byte stream that sets an error (when it shouldn't).
Also, thanks to Hari to help me find the bug this test case is for.