### PR TITLE
Checkpoint 5: New Test Case

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -22,4 +22,5 @@ endmacro(add_app)
 
 add_app(webget)
 add_app(tcp_native)
+add_app(tcp_ipv4)
 add_app(ip_raw)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -22,3 +22,4 @@ endmacro(add_app)
 
 add_app(webget)
 add_app(tcp_native)
+add_app(ip_raw)

--- a/apps/ip_raw.cc
+++ b/apps/ip_raw.cc
@@ -1,0 +1,16 @@
+#include "socket.hh"
+
+using namespace std;
+
+class RawSocket : public DatagramSocket
+{
+public:
+  RawSocket() : DatagramSocket( AF_INET, SOCK_RAW, IPPROTO_RAW ) {}
+};
+
+int main()
+{
+  // construct an Internet or user datagram here, and send using the RawSocket as in the Jan. 10 lecture
+
+  return 0;
+}

--- a/apps/ip_raw.cc
+++ b/apps/ip_raw.cc
@@ -1,6 +1,6 @@
 #include "socket.hh"
-#include <string>
 #include <iostream>
+#include <string>
 
 using namespace std;
 
@@ -10,38 +10,37 @@ public:
   RawSocket() : DatagramSocket( AF_INET, SOCK_RAW, IPPROTO_RAW ) {}
 };
 
-void send_internet_datagram(const string& payload)
+void send_internet_datagram( const string& payload )
 {
   // construct an Internet or user datagram here, and send using the RawSocket as in the Jan. 10 lecture
   string packet;
 
-  packet += char ( 0b0100'0101 );
-  packet += string(7, 0);
+  packet += char( 0b0100'0101 );
+  packet += string( 7, 0 );
 
-  packet += char(64);
+  packet += char( 64 );
   // protocol number 5->Raw, 17->UDP
-  //packet += char(5);
-  packet += char(17);
-  packet += string(6, 0);
+  // packet += char(5);
+  packet += char( 17 );
+  packet += string( 6, 0 );
 
   // 10.144.0.54
-  packet += char(10);
-  packet += char(144);
-  packet += char(0);
-  packet += char(164);
+  packet += char( 10 );
+  packet += char( 144 );
+  packet += char( 0 );
+  packet += char( 164 );
 
   // UDP INFO
   packet += char( 0 );
   packet += char( 1 );
 
-  packet += char( 4 ); // specify dst port 1024 
+  packet += char( 4 ); // specify dst port 1024
   packet += char( 0 );
 
-  packet += char ( 0 );
-  packet += char (payload.length() + 8); // package size?
+  packet += char( 0 );
+  packet += char( payload.length() + 8 ); // package size?
 
-  packet += string(2, 0);
-
+  packet += string( 2, 0 );
 
   packet += payload;
 
@@ -49,7 +48,7 @@ void send_internet_datagram(const string& payload)
 
   string address = "10.144.0.164";
 
-  RawSocket {}.sendto( Address { address }, packet);
+  RawSocket {}.sendto( Address { address }, packet );
 }
 
 void send_icmp_message( const string& payload )
@@ -61,18 +60,18 @@ void program_body()
 {
   string payload;
   while ( cin.good() ) {
-	getline( cin, payload );
-	send_icmp_message( payload + "\n" );
+    getline( cin, payload );
+    send_icmp_message( payload + "\n" );
   }
 }
 
 int main()
 {
   try {
-	program_body();
+    program_body();
   } catch ( const exception& e ) {
-	cerr << e.what() << "\n";
-	return EXIT_FAILURE;
+    cerr << e.what() << "\n";
+    return EXIT_FAILURE;
   }
 
   return EXIT_SUCCESS;

--- a/apps/ip_raw.cc
+++ b/apps/ip_raw.cc
@@ -1,4 +1,6 @@
 #include "socket.hh"
+#include <string>
+#include <iostream>
 
 using namespace std;
 
@@ -8,7 +10,7 @@ public:
   RawSocket() : DatagramSocket( AF_INET, SOCK_RAW, IPPROTO_RAW ) {}
 };
 
-int main()
+void send_internet_datagram(const string& payload)
 {
   // construct an Internet or user datagram here, and send using the RawSocket as in the Jan. 10 lecture
   string packet;
@@ -18,36 +20,60 @@ int main()
 
   packet += char(64);
   // protocol number 5->Raw, 17->UDP
-  packet += char(5);
-  //packet += char(17);
+  //packet += char(5);
+  packet += char(17);
   packet += string(6, 0);
 
   // 10.144.0.54
   packet += char(10);
   packet += char(144);
   packet += char(0);
-  packet += char(54);
+  packet += char(164);
 
   // UDP INFO
-  // packet += char( 0 );
-  // packet += char( 1 );
+  packet += char( 0 );
+  packet += char( 1 );
 
-  // packet += char( 4 ); // specify dst port 1024 
-  // packet += char( 0 );
+  packet += char( 4 ); // specify dst port 1024 
+  packet += char( 0 );
 
-  // string user_payload = "Hellooo";
+  packet += char ( 0 );
+  packet += char (payload.length() + 8); // package size?
 
-  // packet += char ( 0 );
-  // packet += char (user_payload.length() + 8);
-
-  // packet += string(2, 0);
+  packet += string(2, 0);
 
 
-  packet += "Hellooo";
+  packet += payload;
 
-  printf("sent\n");
+  // printf("sent\n");
 
+  string address = "10.144.0.164";
 
-  RawSocket {}.sendto( Address { "10.144.0.54" }, packet);
-  return 0;
+  RawSocket {}.sendto( Address { address }, packet);
+}
+
+void send_icmp_message( const string& payload )
+{
+  send_internet_datagram( "\x08" + payload );
+}
+
+void program_body()
+{
+  string payload;
+  while ( cin.good() ) {
+	getline( cin, payload );
+	send_icmp_message( payload + "\n" );
+  }
+}
+
+int main()
+{
+  try {
+	program_body();
+  } catch ( const exception& e ) {
+	cerr << e.what() << "\n";
+	return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
 }

--- a/apps/ip_raw.cc
+++ b/apps/ip_raw.cc
@@ -11,6 +11,43 @@ public:
 int main()
 {
   // construct an Internet or user datagram here, and send using the RawSocket as in the Jan. 10 lecture
+  string packet;
 
+  packet += char ( 0b0100'0101 );
+  packet += string(7, 0);
+
+  packet += char(64);
+  // protocol number 5->Raw, 17->UDP
+  packet += char(5);
+  //packet += char(17);
+  packet += string(6, 0);
+
+  // 10.144.0.54
+  packet += char(10);
+  packet += char(144);
+  packet += char(0);
+  packet += char(54);
+
+  // UDP INFO
+  // packet += char( 0 );
+  // packet += char( 1 );
+
+  // packet += char( 4 ); // specify dst port 1024 
+  // packet += char( 0 );
+
+  // string user_payload = "Hellooo";
+
+  // packet += char ( 0 );
+  // packet += char (user_payload.length() + 8);
+
+  // packet += string(2, 0);
+
+
+  packet += "Hellooo";
+
+  printf("sent\n");
+
+
+  RawSocket {}.sendto( Address { "10.144.0.54" }, packet);
   return 0;
 }

--- a/apps/tcp_ipv4.cc
+++ b/apps/tcp_ipv4.cc
@@ -1,0 +1,178 @@
+#include "bidirectional_stream_copy.hh"
+#include "tcp_config.hh"
+#include "tcp_minnow_socket.hh"
+#include "tun.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <random>
+#include <span>
+#include <string>
+#include <tuple>
+
+using namespace std;
+
+constexpr const char* TUN_DFLT = "tun144";
+constexpr const char* LOCAL_ADDRESS_DFLT = "169.254.144.9";
+
+namespace {
+void show_usage( const char* argv0, const char* msg )
+{
+  cout << "Usage: " << argv0 << " [options] <host> <port>\n\n"
+       << "   Option                                                          Default\n"
+       << "   --                                                              --\n\n"
+
+       << "   -l              Server (listen) mode.                           (client mode)\n"
+       << "                   In server mode, <host>:<port> is the address to bind.\n\n"
+
+       << "   -a <addr>       Set source address (client mode only)           " << LOCAL_ADDRESS_DFLT << "\n"
+       << "   -s <port>       Set source port (client mode only)              (random)\n\n"
+
+       << "   -w <winsz>      Use a window of <winsz> bytes                   " << TCPConfig::MAX_PAYLOAD_SIZE
+       << "\n\n"
+
+       << "   -t <tmout>      Set rt_timeout to tmout                         " << TCPConfig::TIMEOUT_DFLT << "\n\n"
+
+       << "   -d <tundev>     Connect to tun <tundev>                         " << TUN_DFLT << "\n\n"
+
+       << "   -Lu <loss>      Set uplink loss to <rate> (float in 0..1)       (no loss)\n"
+       << "   -Ld <loss>      Set downlink loss to <rate> (float in 0..1)     (no loss)\n\n"
+
+       << "   -h              Show this message.\n\n";
+
+  if ( msg != nullptr ) {
+    cout << msg;
+  }
+  cout << "\n";
+}
+
+void check_argc( const span<char*>& args, size_t curr, const char* err )
+{
+  if ( curr + 3 >= args.size() ) {
+    show_usage( args.front(), err );
+    exit( 1 );
+  }
+}
+
+tuple<TCPConfig, FdAdapterConfig, bool, const char*> get_config( const span<char*>& args )
+{
+  TCPConfig c_fsm {};
+  c_fsm.isn = Wrap32 { random_device()() };
+
+  FdAdapterConfig c_filt {};
+  const char* tundev = nullptr;
+
+  size_t curr = 1;
+  bool listen = false;
+  const size_t argc = args.size();
+
+  string source_address = LOCAL_ADDRESS_DFLT;
+  string source_port = to_string( static_cast<uint16_t>( random_device()() ) );
+
+  while ( argc - curr > 2 ) {
+    if ( strncmp( "-l", args[curr], 3 ) == 0 ) {
+      listen = true;
+      curr += 1;
+
+    } else if ( strncmp( "-a", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -a requires one argument." );
+      source_address = args[curr + 1];
+      curr += 2;
+
+    } else if ( strncmp( "-s", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -s requires one argument." );
+      source_port = args[curr + 1];
+      curr += 2;
+
+    } else if ( strncmp( "-w", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -w requires one argument." );
+      c_fsm.recv_capacity = strtol( args[curr + 1], nullptr, 0 );
+      curr += 2;
+
+    } else if ( strncmp( "-t", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -t requires one argument." );
+      c_fsm.rt_timeout = strtol( args[curr + 1], nullptr, 0 );
+      curr += 2;
+
+    } else if ( strncmp( "-d", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -t requires one argument." );
+      tundev = args[curr + 1];
+      curr += 2;
+
+    } else if ( strncmp( "-Lu", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -Lu requires one argument." );
+      const float lossrate = strtof( args[curr + 1], nullptr );
+      using LossRateUpT = decltype( c_filt.loss_rate_up );
+      c_filt.loss_rate_up
+        = static_cast<LossRateUpT>( static_cast<float>( numeric_limits<LossRateUpT>::max() ) * lossrate );
+      curr += 2;
+
+    } else if ( strncmp( "-Ld", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -Lu requires one argument." );
+      const float lossrate = strtof( args[curr + 1], nullptr );
+      using LossRateDnT = decltype( c_filt.loss_rate_dn );
+      c_filt.loss_rate_dn
+        = static_cast<LossRateDnT>( static_cast<float>( numeric_limits<LossRateDnT>::max() ) * lossrate );
+      curr += 2;
+
+    } else if ( strncmp( "-h", args[curr], 3 ) == 0 ) {
+      show_usage( args[0], nullptr );
+      exit( 0 );
+
+    } else {
+      show_usage( args[0], string( "ERROR: unrecognized option " + string( args[curr] ) ).c_str() );
+      exit( 1 );
+    }
+  }
+
+  // parse positional command-line arguments
+  if ( listen ) {
+    c_filt.source = { "0", args[curr + 1] };
+    if ( c_filt.source.port() == 0 ) {
+      show_usage( args[0], "ERROR: listen port cannot be zero in server mode." );
+      exit( 1 );
+    }
+  } else {
+    c_filt.destination = { args[curr], args[curr + 1] };
+    c_filt.source = { source_address, source_port };
+  }
+
+  return make_tuple( c_fsm, c_filt, listen, tundev );
+}
+} // namespace
+
+int main( int argc, char** argv )
+{
+  try {
+    if ( argc <= 0 ) {
+      abort(); // For sticklers: don't try to access argv[0] if argc <= 0.
+    }
+
+    auto args = span( argv, argc );
+
+    if ( argc < 3 ) {
+      show_usage( args.front(), "ERROR: required arguments are missing." );
+      return EXIT_FAILURE;
+    }
+
+    auto [c_fsm, c_filt, listen, tun_dev_name] = get_config( args );
+    LossyTCPOverIPv4MinnowSocket tcp_socket( LossyFdAdapter<TCPOverIPv4OverTunFdAdapter>(
+      TCPOverIPv4OverTunFdAdapter( TunFD( tun_dev_name == nullptr ? TUN_DFLT : tun_dev_name ) ) ) );
+
+    if ( listen ) {
+      tcp_socket.listen_and_accept( c_fsm, c_filt );
+    } else {
+      tcp_socket.connect( c_fsm, c_filt );
+    }
+
+    bidirectional_stream_copy( tcp_socket, tcp_socket.peer_address().to_string() );
+    tcp_socket.wait_until_closed();
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/apps/webget.cc
+++ b/apps/webget.cc
@@ -1,4 +1,5 @@
-#include "socket.hh"
+// #include "socket.hh"
+#include "tcp_minnow_socket.hh"
 
 #include <cstdlib>
 #include <iostream>
@@ -16,7 +17,8 @@ void get_URL( const string& host, const string& path )
   const string service = "http";
   Address addr( host, service );
 
-  TCPSocket webget_socket;
+  CS144TCPSocket webget_socket;
+  // TCPSocket webget_socket;
   webget_socket.connect( addr );
   // send http requests over socket
   const string msgs = "GET " + path + " HTTP/1.1\r\nHost: " + host + "\r\nConnection: close\r\n\r\n";
@@ -29,6 +31,7 @@ void get_URL( const string& host, const string& path )
     webget_socket.read( buffer );
   }
   // final read
+  webget_socket.wait_until_closed();
 }
 
 int main( int argc, char* argv[] )

--- a/apps/webget.cc
+++ b/apps/webget.cc
@@ -4,13 +4,39 @@
 #include <iostream>
 #include <span>
 #include <string>
-
 using namespace std;
 
 void get_URL( const string& host, const string& path )
 {
-  cerr << "Function called: get_URL(" << host << ", " << path << ")\n";
-  cerr << "Warning: get_URL() has not been implemented yet.\n";
+  //cerr << "Function called: get_URL(" << host << ", " << path << ")\n";
+  //cerr << "Warning: get_URL() has not been implemented yet.\n";
+  // open a socket - using an address?
+  // host then service
+
+  /*
+  telnet cs144.keithw.org http .
+  GET /hello HTTP/1.1
+  Host: cs144.keithw.org
+  Connection: close
+  */
+
+  const string service = "http";
+  Address addr(host, service);
+
+  TCPSocket webget_socket;
+  webget_socket.connect(addr);
+  // send http requests over socket
+  const string msgs = "GET " + path + " HTTP/1.1\r\nHost: " + host + "\r\nConnection: close\r\n\r\n";
+  webget_socket.write(msgs);
+
+  string buffer = "";
+  webget_socket.read(buffer);
+  while (webget_socket.eof() != true) 
+  {
+    cout << buffer;
+    webget_socket.read(buffer);
+  }
+  // final read
 }
 
 int main( int argc, char* argv[] )

--- a/apps/webget.cc
+++ b/apps/webget.cc
@@ -8,33 +8,26 @@ using namespace std;
 
 void get_URL( const string& host, const string& path )
 {
-  //cerr << "Function called: get_URL(" << host << ", " << path << ")\n";
-  //cerr << "Warning: get_URL() has not been implemented yet.\n";
-  // open a socket - using an address?
-  // host then service
+  // cerr << "Function called: get_URL(" << host << ", " << path << ")\n";
+  // cerr << "Warning: get_URL() has not been implemented yet.\n";
+  //  open a socket - using an address
+  //  host then service
 
-  /*
-  telnet cs144.keithw.org http .
-  GET /hello HTTP/1.1
-  Host: cs144.keithw.org
-  Connection: close
-  */
 
   const string service = "http";
-  Address addr(host, service);
+  Address addr( host, service );
 
   TCPSocket webget_socket;
-  webget_socket.connect(addr);
+  webget_socket.connect( addr );
   // send http requests over socket
   const string msgs = "GET " + path + " HTTP/1.1\r\nHost: " + host + "\r\nConnection: close\r\n\r\n";
-  webget_socket.write(msgs);
+  webget_socket.write( msgs );
 
   string buffer = "";
-  webget_socket.read(buffer);
-  while (webget_socket.eof() != true) 
-  {
+  webget_socket.read( buffer );
+  while ( webget_socket.eof() != true ) {
     cout << buffer;
-    webget_socket.read(buffer);
+    webget_socket.read( buffer );
   }
   // final read
 }

--- a/apps/webget.cc
+++ b/apps/webget.cc
@@ -13,7 +13,6 @@ void get_URL( const string& host, const string& path )
   //  open a socket - using an address
   //  host then service
 
-
   const string service = "http";
   Address addr( host, service );
 

--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -62,6 +62,8 @@ ttest(no_skip)
 
 add_custom_target (check0 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R 'webget|^byte_stream_|^no_skip')
 
+add_custom_target (check_byte_stream COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^byte_stream_|^no_skip')
+
 add_custom_target (check_webget COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --timeout 15 -R 'webget')
 
 add_custom_target (check1 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^byte_stream_|^reassembler_|^no_skip')
@@ -70,9 +72,9 @@ add_custom_target (check2 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --s
 
 add_custom_target (check3 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^byte_stream_|^reassembler_|^wrapping|^recv|^send|^no_skip')
 
-add_custom_target (check4 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^net_interface|^no_skip')
+add_custom_target (check5 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^net_interface|^no_skip')
 
-add_custom_target (check5 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^net_interface|^router|^no_skip')
+add_custom_target (check6 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^net_interface|^router|^no_skip')
 
 ###
 

--- a/scripts/lines-of-code
+++ b/scripts/lines-of-code
@@ -8,8 +8,8 @@ import sys
 base = sys.argv[1] if len(sys.argv) > 1 else '.'
 modules = [['byte_stream', 'ByteStream'],
            ['reassembler', 'Reassembler'],
-#           ['tcp_receiver', 'TCPReceiver'],
-#           ['wrapping_integers', 'Wrap32'],
+           ['tcp_receiver', 'TCPReceiver'],
+           ['wrapping_integers', 'Wrap32'],
 #           ['tcp_sender', 'TCPSender'],
 #           ['network_interface', 'NetworkInterface'],
 #           ['router', 'Router']

--- a/scripts/lines-of-code
+++ b/scripts/lines-of-code
@@ -8,11 +8,12 @@ import sys
 base = sys.argv[1] if len(sys.argv) > 1 else '.'
 modules = [['byte_stream', 'ByteStream'],
            ['reassembler', 'Reassembler'],
-           ['tcp_receiver', 'TCPReceiver'],
-           ['wrapping_integers', 'Wrap32'],
-           ['tcp_sender', 'TCPSender'],
-           ['network_interface', 'NetworkInterface'],
-           ['router', 'Router']]
+#           ['tcp_receiver', 'TCPReceiver'],
+#           ['wrapping_integers', 'Wrap32'],
+#           ['tcp_sender', 'TCPSender'],
+#           ['network_interface', 'NetworkInterface'],
+#           ['router', 'Router']
+           ]
 longest_module_length = max([len(x[1]) for x in modules])
 
 

--- a/scripts/lines-of-code
+++ b/scripts/lines-of-code
@@ -10,7 +10,7 @@ modules = [['byte_stream', 'ByteStream'],
            ['reassembler', 'Reassembler'],
            ['tcp_receiver', 'TCPReceiver'],
            ['wrapping_integers', 'Wrap32'],
-#           ['tcp_sender', 'TCPSender'],
+           ['tcp_sender', 'TCPSender'],
 #           ['network_interface', 'NetworkInterface'],
 #           ['router', 'Router']
            ]

--- a/scripts/lines-of-code
+++ b/scripts/lines-of-code
@@ -11,8 +11,8 @@ modules = [['byte_stream', 'ByteStream'],
            ['tcp_receiver', 'TCPReceiver'],
            ['wrapping_integers', 'Wrap32'],
            ['tcp_sender', 'TCPSender'],
-#           ['network_interface', 'NetworkInterface'],
-#           ['router', 'Router']
+           ['network_interface', 'NetworkInterface'],
+           ['router', 'Router']
            ]
 longest_module_length = max([len(x[1]) for x in modules])
 

--- a/src/byte_stream.cc
+++ b/src/byte_stream.cc
@@ -53,7 +53,17 @@ string_view Reader::peek() const
 
 void Reader::pop( uint64_t len )
 {
-  (void)len; // Your code here.
+
+  uint64_t idx = len;
+  while (this->data_.size() != 0 && len != 0) {
+    this->data_.pop();
+    len--;
+    this->bytes_popped_++;
+    this->capacity_++;
+  }
+
+  // change this->newRead using substr, saves memory
+  this->newRead_ = this->newRead_.substr(idx);
 }
 
 bool Reader::is_finished() const

--- a/src/byte_stream.cc
+++ b/src/byte_stream.cc
@@ -1,6 +1,5 @@
 #include "byte_stream.hh"
 
-
 using namespace std;
 
 ByteStream::ByteStream( uint64_t capacity ) : capacity_( capacity ), data_(), newRead_() {}
@@ -8,23 +7,21 @@ ByteStream::ByteStream( uint64_t capacity ) : capacity_( capacity ), data_(), ne
 // push one byte at a time
 void Writer::push( string data )
 {
-  uint64_t datasize = 0;
-  for (const char &byte : data) {
+  for ( const char& byte : data ) {
     // break if full
-    if (this->capacity_ == 0) {
+    if ( this->capacity_ == 0 ) {
       break;
     }
     // push one byte at a time, check capacity
-    this->data_.emplace(byte);
+    this->data_.emplace( byte );
     this->capacity_--;
     this->bytes_pushed_++;
     datasize++;
     this->newRead_ += byte;
   }
-  
+
   return;
 }
-
 
 void Writer::close()
 {
@@ -33,29 +30,29 @@ void Writer::close()
 
 bool Writer::is_closed() const
 {
-  return !this->open_; 
+  return !this->open_;
 }
 
 uint64_t Writer::available_capacity() const
 {
-  return this->capacity_; 
+  return this->capacity_;
 }
 
 uint64_t Writer::bytes_pushed() const
 {
-  return this->bytes_pushed_; 
+  return this->bytes_pushed_;
 }
 
 string_view Reader::peek() const
 {
-  return string_view(this->newRead_); 
+  return string_view( this->newRead_ );
 }
 
 void Reader::pop( uint64_t len )
 {
 
   uint64_t idx = len;
-  while (this->data_.size() != 0 && len != 0) {
+  while ( this->data_.size() != 0 && len != 0 ) {
     this->data_.pop();
     len--;
     this->bytes_popped_++;
@@ -63,21 +60,20 @@ void Reader::pop( uint64_t len )
   }
 
   // change this->newRead using substr, saves memory
-  this->newRead_ = this->newRead_.substr(idx);
+  this->newRead_ = this->newRead_.substr( idx );
 }
 
 bool Reader::is_finished() const
 {
-  return this->data_.size() == 0 && !this->open_; 
+  return this->data_.size() == 0 && !this->open_;
 }
 
 uint64_t Reader::bytes_buffered() const
 {
-  return this->bytes_pushed_ - this->bytes_popped_; 
+  return this->bytes_pushed_ - this->bytes_popped_;
 }
 
 uint64_t Reader::bytes_popped() const
 {
-  return this->bytes_popped_; 
+  return this->bytes_popped_;
 }
-

--- a/src/byte_stream.cc
+++ b/src/byte_stream.cc
@@ -2,7 +2,7 @@
 
 using namespace std;
 
-ByteStream::ByteStream( uint64_t capacity ) : capacity_( capacity ) {}
+ByteStream::ByteStream( uint64_t capacity ) : capacity_( capacity ), data_(), newRead_() {}
 
 // push one byte at a time
 void Writer::push( string data )

--- a/src/byte_stream.cc
+++ b/src/byte_stream.cc
@@ -4,9 +4,24 @@ using namespace std;
 
 ByteStream::ByteStream( uint64_t capacity ) : capacity_( capacity ) {}
 
+// push one byte at a time
 void Writer::push( string data )
 {
-  (void)data; // Your code here.
+  uint64_t datasize = 0;
+  for (const char &byte : data) {
+    // break if full
+    if (this->capacity_ == 0) {
+      break;
+    }
+    // push one byte at a time, check capacity
+    this->data_.emplace(byte);
+    this->capacity_--;
+    this->bytes_pushed_++;
+    datasize++;
+    this->newRead_ += byte;
+  }
+  
+  return;
 }
 
 void Writer::close()

--- a/src/byte_stream.cc
+++ b/src/byte_stream.cc
@@ -16,7 +16,6 @@ void Writer::push( string data )
     this->data_.emplace( byte );
     this->capacity_--;
     this->bytes_pushed_++;
-    datasize++;
     this->newRead_ += byte;
   }
 

--- a/src/byte_stream.cc
+++ b/src/byte_stream.cc
@@ -26,22 +26,22 @@ void Writer::push( string data )
 
 void Writer::close()
 {
-  // Your code here.
+  this->open_ = false;
 }
 
 bool Writer::is_closed() const
 {
-  return {}; // Your code here.
+  return !this->open_; 
 }
 
 uint64_t Writer::available_capacity() const
 {
-  return {}; // Your code here.
+  return this->capacity_; 
 }
 
 uint64_t Writer::bytes_pushed() const
 {
-  return {}; // Your code here.
+  return this->bytes_pushed_; 
 }
 
 string_view Reader::peek() const

--- a/src/byte_stream.cc
+++ b/src/byte_stream.cc
@@ -1,5 +1,6 @@
 #include "byte_stream.hh"
 
+
 using namespace std;
 
 ByteStream::ByteStream( uint64_t capacity ) : capacity_( capacity ), data_(), newRead_() {}
@@ -24,6 +25,7 @@ void Writer::push( string data )
   return;
 }
 
+
 void Writer::close()
 {
   this->open_ = false;
@@ -46,7 +48,7 @@ uint64_t Writer::bytes_pushed() const
 
 string_view Reader::peek() const
 {
-  return {}; // Your code here.
+  return string_view(this->newRead_); 
 }
 
 void Reader::pop( uint64_t len )
@@ -56,16 +58,16 @@ void Reader::pop( uint64_t len )
 
 bool Reader::is_finished() const
 {
-  return {}; // Your code here.
+  return this->data_.size() == 0 && !this->open_; 
 }
 
 uint64_t Reader::bytes_buffered() const
 {
-  return {}; // Your code here.
+  return this->bytes_pushed_ - this->bytes_popped_; 
 }
 
 uint64_t Reader::bytes_popped() const
 {
-  return {}; // Your code here.
+  return this->bytes_popped_; 
 }
 

--- a/src/byte_stream.hh
+++ b/src/byte_stream.hh
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <cstdint>
+#include <queue>
 #include <string>
 #include <string_view>
-#include <queue>
 
 class Reader;
 class Writer;
@@ -28,7 +28,6 @@ protected:
   bool error_ {};
   // new datastructure
   std::queue<char> data_;
-  //std::queue<int> msg_size_;
   bool open_ = true;
   uint64_t bytes_pushed_ = 0;
   uint64_t bytes_popped_ = 0;

--- a/src/byte_stream.hh
+++ b/src/byte_stream.hh
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <queue>
 
 class Reader;
 class Writer;
@@ -25,6 +26,13 @@ protected:
   // Please add any additional state to the ByteStream here, and not to the Writer and Reader interfaces.
   uint64_t capacity_;
   bool error_ {};
+  // new datastructure
+  std::queue<char> data_;
+  //std::queue<int> msg_size_;
+  bool open_ = true;
+  uint64_t bytes_pushed_ = 0;
+  uint64_t bytes_popped_ = 0;
+  std::string newRead_;
 };
 
 class Writer : public ByteStream

--- a/src/network_interface.cc
+++ b/src/network_interface.cc
@@ -1,0 +1,49 @@
+#include <iostream>
+
+#include "arp_message.hh"
+#include "debug.hh"
+#include "ethernet_frame.hh"
+#include "exception.hh"
+#include "helpers.hh"
+#include "network_interface.hh"
+
+using namespace std;
+
+//! \param[in] ethernet_address Ethernet (what ARP calls "hardware") address of the interface
+//! \param[in] ip_address IP (what ARP calls "protocol") address of the interface
+NetworkInterface::NetworkInterface( string_view name,
+                                    shared_ptr<OutputPort> port,
+                                    const EthernetAddress& ethernet_address,
+                                    const Address& ip_address )
+  : name_( name )
+  , port_( notnull( "OutputPort", move( port ) ) )
+  , ethernet_address_( ethernet_address )
+  , ip_address_( ip_address )
+{
+  cerr << "DEBUG: Network interface has Ethernet address " << to_string( ethernet_address_ ) << " and IP address "
+       << ip_address.ip() << "\n";
+}
+
+//! \param[in] dgram the IPv4 datagram to be sent
+//! \param[in] next_hop the IP address of the interface to send it to (typically a router or default gateway, but
+//! may also be another host if directly connected to the same network as the destination) Note: the Address type
+//! can be converted to a uint32_t (raw 32-bit IP address) by using the Address::ipv4_numeric() method.
+void NetworkInterface::send_datagram( const InternetDatagram& dgram, const Address& next_hop )
+{
+  debug( "unimplemented send_datagram called" );
+  (void)dgram;
+  (void)next_hop;
+}
+
+//! \param[in] frame the incoming Ethernet frame
+void NetworkInterface::recv_frame( EthernetFrame frame )
+{
+  debug( "unimplemented recv_frame called" );
+  (void)frame;
+}
+
+//! \param[in] ms_since_last_tick the number of milliseconds since the last call to this method
+void NetworkInterface::tick( const size_t ms_since_last_tick )
+{
+  debug( "unimplemented tick({}) called", ms_since_last_tick );
+}

--- a/src/network_interface.cc
+++ b/src/network_interface.cc
@@ -7,6 +7,9 @@
 #include "helpers.hh"
 #include "network_interface.hh"
 
+#define five_sec 5000
+#define thirty_sec 30000
+
 using namespace std;
 
 //! \param[in] ethernet_address Ethernet (what ARP calls "hardware") address of the interface
@@ -37,9 +40,8 @@ void NetworkInterface::send_datagram( const InternetDatagram& dgram, const Addre
     Package
     Transmit
   */
-  // INIT Map Key
+  // INIT Vars
   uint32_t key = next_hop.ipv4_numeric();
-  // INIT Ethernet Frame
   EthernetFrame toSend;
   toSend.header.type = toSend.header.TYPE_IPv4;
   toSend.header.src = ethernet_address_;
@@ -47,46 +49,50 @@ void NetworkInterface::send_datagram( const InternetDatagram& dgram, const Addre
   if (ip_cache_.find(key) != ip_cache_.end() && !ip_cache_[key].isARP) {
     toSend.header.dst = ip_cache_[key].eth;
     transmit(toSend);
-    // Update Cache
-    ip_cache_[key].last_dg_sent = clock_;
     return;
   }
   // CASE 2: DST_IP is unkown; transmit an ARP and queue the datagram
   /*
     Check Map
     Check ARP Recency
-    Queue Somewhere?
+    Queue Somewhere? (N/A)
   */
  // If ARP has been sent and is recent enough
   if (ip_cache_.find(key) != ip_cache_.end() && ip_cache_[key].isARP) {
-    if (ip_cache_[key].last_dg_sent >= clock_ - 5) {
+    if (ip_cache_[key].last_arp_sent + five_sec >= clock_) {
+      std::pair<size_t, EthernetFrame> queued_dg = {clock_, toSend};
+      ip_cache_[key].ARP_msgs.push(queued_dg);
       return;
     } 
   }
   // Assume we need to resend / send for the first time
-  ARPMessage arp;
+  ARPMessage arp; // INIT Arp Message
   arp.target_ip_address = next_hop.ipv4_numeric();
   arp.sender_ethernet_address = ethernet_address_;
   arp.sender_ip_address = ip_address_.ipv4_numeric();
   arp.opcode = arp.OPCODE_REQUEST;
-  EthernetFrame arp_eth;
+  EthernetFrame arp_eth; // INIT Eth Frame
   arp_eth.header.type = arp_eth.header.TYPE_ARP;
   arp_eth.header.src = ethernet_address_;
   arp_eth.header.dst = ETHERNET_BROADCAST;
   arp_eth.payload = serialize ( arp );
   transmit( arp_eth );
-  ip_cache_[key].last_dg_sent = clock_;
-  ip_cache_[key].ARP_msgs.push(toSend);
+  ip_cache_[key].last_arp_sent = clock_; // Update State
+  std::pair<size_t, EthernetFrame> queued_dg = {clock_, toSend};
+  ip_cache_[key].ARP_msgs.push(queued_dg);
+  ip_cache_[key].isARP = true;
 }
 
 //! \param[in] frame the incoming Ethernet frame
 void NetworkInterface::recv_frame( EthernetFrame frame )
 {
   // CASE 1: Recieve an IPV4; parse and push to datagrams_recieved queue (given)
-  if (frame.header.type == frame.header.TYPE_IPv4) {
+  if (frame.header.type == frame.header.TYPE_IPv4 && frame.header.dst == ethernet_address_) {
     InternetDatagram internet_datagram;
     if ( parse( internet_datagram, frame.payload ) ) {
-      datagrams_received_.push(internet_datagram);
+      //if (internet_datagram.header.dst == ip_address_.ipv4_numeric()) {
+        datagrams_received_.push(internet_datagram);
+      //}
     }
     // Return if success or failiure
     return;
@@ -101,13 +107,15 @@ void NetworkInterface::recv_frame( EthernetFrame frame )
       Send the queued messages?
   */
   ARPMessage arp;
-  if ( parse( arp, frame.payload ) ) {
-    // Save arp information
+  if ( parse( arp, frame.payload ) ) { // Attempt Parse
+    // Save arp information regardless of type
     uint32_t key = arp.sender_ip_address;
     ip_cache_[key].eth = arp.sender_ethernet_address;
     ip_cache_[key].isARP = false;
-    ip_cache_[key].last_dg_sent = clock_;
-    // If Reply
+    ip_cache_[key].last_arp_sent = clock_;
+    pair<int, uint32_t> queue_entry {clock_, key};
+    ip_time_queue_.push(queue_entry);
+    // If Request && We are target
     if (arp.opcode == arp.OPCODE_REQUEST && arp.target_ip_address == ip_address_.ipv4_numeric()) {
       // SEND: Arp Reply
       ARPMessage reply;
@@ -122,18 +130,36 @@ void NetworkInterface::recv_frame( EthernetFrame frame )
       arp_eth.header.dst = arp.sender_ethernet_address;
       arp_eth.payload = serialize ( reply );
       transmit( arp_eth );
-    } else {
-      // Send stalled messages
-      while (ip_cache_[key].ARP_msgs.size() != 0) {
-        EthernetFrame msg = ip_cache_[key].ARP_msgs.front();
-        ip_cache_[key].ARP_msgs.pop();
-        msg.header.dst = arp.sender_ethernet_address;
-        transmit( msg );
-      }
     }
+      // Send stalled messages 
+      // CORRECT SECTION BELOW
+      while (ip_cache_[key].ARP_msgs.size() != 0) {
+        std::pair<size_t, EthernetFrame> queued_dg = ip_cache_[key].ARP_msgs.front();
+        // EthernetFrame msg = ip_cache_[key].ARP_msgs.front();
+        ip_cache_[key].ARP_msgs.pop();
+        // Only want to send up to date messages
+        if (queued_dg.first + five_sec > clock_) {
+          queued_dg.second.header.dst = arp.sender_ethernet_address;
+        transmit( queued_dg.second );
+        }
+      }
+      // CORRECT SECTION ABOVE
+    // Incorrect Section  (included for my custom test case) UNCOMMENT SECTION BELOW
+    // } else {
+    // // Send stalled messages 
+    //   while (ip_cache_[key].ARP_msgs.size() != 0) {
+    //     std::pair<size_t, EthernetFrame> queued_dg = ip_cache_[key].ARP_msgs.front();
+    //     // EthernetFrame msg = ip_cache_[key].ARP_msgs.front();
+    //     ip_cache_[key].ARP_msgs.pop();
+    //     // Only want to send up to date messages
+    //     if (queued_dg.first + five_sec > clock_) {
+    //       queued_dg.second.header.dst = arp.sender_ethernet_address;
+    //     transmit( queued_dg.second );
+    //     }
+    //   }
+    // }
+    // Incorrect Section UNCOMMENT SECTION ABOVE
   }
-  debug( "unimplemented recv_frame called" );
-  (void)frame;
 }
 
 //! \param[in] ms_since_last_tick the number of milliseconds since the last call to this method
@@ -144,11 +170,12 @@ void NetworkInterface::tick( const size_t ms_since_last_tick )
 
   // Expire any expired IP(s); >30 seconds storage time
   // Keep popping from queue until lead entry has insertion time >= curTime - 30
-  while (ip_time_queue_.size() != 0 && ip_time_queue_.front().first < clock_ - 30) {
+  while (ip_time_queue_.size() != 0 && ip_time_queue_.front().first + thirty_sec < clock_) {
     std::pair<size_t, uint32_t> front_elem = ip_time_queue_.front();
     ip_time_queue_.pop();
     // Expire IPs if they are not ARP
-    if (front_elem.first ==  ip_cache_[front_elem.second].last_dg_sent && !ip_cache_[front_elem.second].isARP) {
+    if (front_elem.first ==  ip_cache_[front_elem.second].last_arp_sent && !ip_cache_[front_elem.second].isARP) {
+    // if (!ip_cache_[front_elem.second].isARP) {
       ip_cache_.erase(front_elem.second);
     }
   }

--- a/src/network_interface.cc
+++ b/src/network_interface.cc
@@ -19,6 +19,7 @@ NetworkInterface::NetworkInterface( string_view name,
   , port_( notnull( "OutputPort", move( port ) ) )
   , ethernet_address_( ethernet_address )
   , ip_address_( ip_address )
+  , clock_( 0 )
 {
   cerr << "DEBUG: Network interface has Ethernet address " << to_string( ethernet_address_ ) << " and IP address "
        << ip_address.ip() << "\n";
@@ -30,14 +31,107 @@ NetworkInterface::NetworkInterface( string_view name,
 //! can be converted to a uint32_t (raw 32-bit IP address) by using the Address::ipv4_numeric() method.
 void NetworkInterface::send_datagram( const InternetDatagram& dgram, const Address& next_hop )
 {
-  debug( "unimplemented send_datagram called" );
-  (void)dgram;
-  (void)next_hop;
+  // CASE 1: DST_IP is known; then package and transmit
+  /*
+    Check Map
+    Package
+    Transmit
+  */
+  // INIT Map Key
+  uint32_t key = next_hop.ipv4_numeric();
+  // INIT Ethernet Frame
+  EthernetFrame toSend;
+  toSend.header.type = toSend.header.TYPE_IPv4;
+  toSend.header.src = ethernet_address_;
+  toSend.payload = serialize( dgram );
+  if (ip_cache_.find(key) != ip_cache_.end() && !ip_cache_[key].isARP) {
+    toSend.header.dst = ip_cache_[key].eth;
+    transmit(toSend);
+    // Update Cache
+    ip_cache_[key].last_dg_sent = clock_;
+    return;
+  }
+  // CASE 2: DST_IP is unkown; transmit an ARP and queue the datagram
+  /*
+    Check Map
+    Check ARP Recency
+    Queue Somewhere?
+  */
+ // If ARP has been sent and is recent enough
+  if (ip_cache_.find(key) != ip_cache_.end() && ip_cache_[key].isARP) {
+    if (ip_cache_[key].last_dg_sent >= clock_ - 5) {
+      return;
+    } 
+  }
+  // Assume we need to resend / send for the first time
+  ARPMessage arp;
+  arp.target_ip_address = next_hop.ipv4_numeric();
+  arp.sender_ethernet_address = ethernet_address_;
+  arp.sender_ip_address = ip_address_.ipv4_numeric();
+  arp.opcode = arp.OPCODE_REQUEST;
+  EthernetFrame arp_eth;
+  arp_eth.header.type = arp_eth.header.TYPE_ARP;
+  arp_eth.header.src = ethernet_address_;
+  arp_eth.header.dst = ETHERNET_BROADCAST;
+  arp_eth.payload = serialize ( arp );
+  transmit( arp_eth );
+  ip_cache_[key].last_dg_sent = clock_;
+  ip_cache_[key].ARP_msgs.push(toSend);
 }
 
 //! \param[in] frame the incoming Ethernet frame
 void NetworkInterface::recv_frame( EthernetFrame frame )
 {
+  // CASE 1: Recieve an IPV4; parse and push to datagrams_recieved queue (given)
+  if (frame.header.type == frame.header.TYPE_IPv4) {
+    InternetDatagram internet_datagram;
+    if ( parse( internet_datagram, frame.payload ) ) {
+      datagrams_received_.push(internet_datagram);
+    }
+    // Return if success or failiure
+    return;
+  }
+  // CASE 2A/B: Recieve an ARP Message; parse and remember the IP for 30 seconds
+  /*
+    Check if Reply/Recieve (How?)
+    Update IP
+      Update Dictionary Entry
+      Re-Add entry to queue (potentially stores duplicates)
+    If Recieve:
+      Send the queued messages?
+  */
+  ARPMessage arp;
+  if ( parse( arp, frame.payload ) ) {
+    // Save arp information
+    uint32_t key = arp.sender_ip_address;
+    ip_cache_[key].eth = arp.sender_ethernet_address;
+    ip_cache_[key].isARP = false;
+    ip_cache_[key].last_dg_sent = clock_;
+    // If Reply
+    if (arp.opcode == arp.OPCODE_REQUEST && arp.target_ip_address == ip_address_.ipv4_numeric()) {
+      // SEND: Arp Reply
+      ARPMessage reply;
+      reply.target_ip_address = arp.sender_ip_address;
+      reply.target_ethernet_address = arp.sender_ethernet_address;
+      reply.sender_ip_address = ip_address_.ipv4_numeric();
+      reply.sender_ethernet_address = ethernet_address_;
+      reply.opcode = arp.OPCODE_REPLY;
+      EthernetFrame arp_eth;
+      arp_eth.header.type = arp_eth.header.TYPE_ARP;
+      arp_eth.header.src = ethernet_address_;
+      arp_eth.header.dst = arp.sender_ethernet_address;
+      arp_eth.payload = serialize ( reply );
+      transmit( arp_eth );
+    } else {
+      // Send stalled messages
+      while (ip_cache_[key].ARP_msgs.size() != 0) {
+        EthernetFrame msg = ip_cache_[key].ARP_msgs.front();
+        ip_cache_[key].ARP_msgs.pop();
+        msg.header.dst = arp.sender_ethernet_address;
+        transmit( msg );
+      }
+    }
+  }
   debug( "unimplemented recv_frame called" );
   (void)frame;
 }
@@ -45,5 +139,17 @@ void NetworkInterface::recv_frame( EthernetFrame frame )
 //! \param[in] ms_since_last_tick the number of milliseconds since the last call to this method
 void NetworkInterface::tick( const size_t ms_since_last_tick )
 {
-  debug( "unimplemented tick({}) called", ms_since_last_tick );
+  // update time
+  clock_ += ms_since_last_tick;
+
+  // Expire any expired IP(s); >30 seconds storage time
+  // Keep popping from queue until lead entry has insertion time >= curTime - 30
+  while (ip_time_queue_.size() != 0 && ip_time_queue_.front().first < clock_ - 30) {
+    std::pair<size_t, uint32_t> front_elem = ip_time_queue_.front();
+    ip_time_queue_.pop();
+    // Expire IPs if they are not ARP
+    if (front_elem.first ==  ip_cache_[front_elem.second].last_dg_sent && !ip_cache_[front_elem.second].isARP) {
+      ip_cache_.erase(front_elem.second);
+    }
+  }
 }

--- a/src/network_interface.hh
+++ b/src/network_interface.hh
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "address.hh"
+#include "ethernet_frame.hh"
+#include "ipv4_datagram.hh"
+
+#include <memory>
+#include <queue>
+
+// A "network interface" that connects IP (the internet layer, or network layer)
+// with Ethernet (the network access layer, or link layer).
+
+// This module is the lowest layer of a TCP/IP stack
+// (connecting IP with the lower-layer network protocol,
+// e.g. Ethernet). But the same module is also used repeatedly
+// as part of a router: a router generally has many network
+// interfaces, and the router's job is to route Internet datagrams
+// between the different interfaces.
+
+// The network interface translates datagrams (coming from the
+// "customer," e.g. a TCP/IP stack or router) into Ethernet
+// frames. To fill in the Ethernet destination address, it looks up
+// the Ethernet address of the next IP hop of each datagram, making
+// requests with the [Address Resolution Protocol](\ref rfc::rfc826).
+// In the opposite direction, the network interface accepts Ethernet
+// frames, checks if they are intended for it, and if so, processes
+// the the payload depending on its type. If it's an IPv4 datagram,
+// the network interface passes it up the stack. If it's an ARP
+// request or reply, the network interface processes the frame
+// and learns or replies as necessary.
+class NetworkInterface
+{
+public:
+  // An abstraction for the physical output port where the NetworkInterface sends Ethernet frames
+  class OutputPort
+  {
+  public:
+    virtual void transmit( const NetworkInterface& sender, const EthernetFrame& frame ) = 0;
+    virtual ~OutputPort() = default;
+  };
+
+  // Construct a network interface with given Ethernet (network-access-layer) and IP (internet-layer)
+  // addresses
+  NetworkInterface( std::string_view name,
+                    std::shared_ptr<OutputPort> port,
+                    const EthernetAddress& ethernet_address,
+                    const Address& ip_address );
+
+  // Sends an Internet datagram, encapsulated in an Ethernet frame (if it knows the Ethernet destination
+  // address). Will need to use [ARP](\ref rfc::rfc826) to look up the Ethernet destination address for the next
+  // hop. Sending is accomplished by calling `transmit()` (a member variable) on the frame.
+  void send_datagram( const InternetDatagram& dgram, const Address& next_hop );
+
+  // Receives an Ethernet frame and responds appropriately.
+  // If type is IPv4, pushes the datagram to the datagrams_in queue.
+  // If type is ARP request, learn a mapping from the "sender" fields, and send an ARP reply.
+  // If type is ARP reply, learn a mapping from the "sender" fields.
+  void recv_frame( EthernetFrame frame );
+
+  // Called periodically when time elapses
+  void tick( size_t ms_since_last_tick );
+
+  // Accessors
+  const std::string& name() const { return name_; }
+  const OutputPort& output() const { return *port_; }
+  OutputPort& output() { return *port_; }
+  std::queue<InternetDatagram>& datagrams_received() { return datagrams_received_; }
+
+private:
+  // Human-readable name of the interface
+  std::string name_;
+
+  // The physical output port (+ a helper function `transmit` that uses it to send an Ethernet frame)
+  std::shared_ptr<OutputPort> port_;
+  void transmit( const EthernetFrame& frame ) const { port_->transmit( *this, frame ); }
+
+  // Ethernet (known as hardware, network-access-layer, or link-layer) address of the interface
+  EthernetAddress ethernet_address_;
+
+  // IP (known as internet-layer or network-layer) address of the interface
+  Address ip_address_;
+
+  // Datagrams that have been received
+  std::queue<InternetDatagram> datagrams_received_ {};
+};

--- a/src/network_interface.hh
+++ b/src/network_interface.hh
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <queue>
+#include <unordered_map>
 
 // A "network interface" that connects IP (the internet layer, or network layer)
 // with Ethernet (the network access layer, or link layer).
@@ -82,4 +83,29 @@ private:
 
   // Datagrams that have been received
   std::queue<InternetDatagram> datagrams_received_ {};
+
+  // Struct to bundle information for a given DST IP to prevent using parallel Datastructures
+  struct IP_info {
+    EthernetAddress eth;
+    bool isARP;
+    size_t last_dg_sent;
+    std::queue<EthernetFrame> ARP_msgs{};
+
+    // Constructor
+    IP_info() 
+        : eth()
+        , isARP(false)
+        , last_dg_sent(0)
+        , ARP_msgs() 
+    {}
+  };
+
+  // Stores IP->Ethernet Recent Info
+  std::unordered_map<uint32_t, IP_info> ip_cache_ {};
+
+  // Stores Addresses in order of most recently added
+  std::queue<std::pair<size_t, uint32_t>> ip_time_queue_ {};
+
+  // Clock func
+  size_t clock_;
 };

--- a/src/network_interface.hh
+++ b/src/network_interface.hh
@@ -88,14 +88,14 @@ private:
   struct IP_info {
     EthernetAddress eth;
     bool isARP;
-    size_t last_dg_sent;
-    std::queue<EthernetFrame> ARP_msgs{};
+    size_t last_arp_sent; // Used to determine if a ARP should be resent
+    std::queue<std::pair<size_t, EthernetFrame>> ARP_msgs{};
 
     // Constructor
     IP_info() 
         : eth()
         , isARP(false)
-        , last_dg_sent(0)
+        , last_arp_sent(0)
         , ARP_msgs() 
     {}
   };

--- a/src/network_interface.hh
+++ b/src/network_interface.hh
@@ -85,19 +85,15 @@ private:
   std::queue<InternetDatagram> datagrams_received_ {};
 
   // Struct to bundle information for a given DST IP to prevent using parallel Datastructures
-  struct IP_info {
+  struct IP_info
+  {
     EthernetAddress eth;
     bool isARP;
     size_t last_arp_sent; // Used to determine if a ARP should be resent
-    std::queue<std::pair<size_t, EthernetFrame>> ARP_msgs{};
+    std::queue<std::pair<size_t, EthernetFrame>> ARP_msgs {};
 
     // Constructor
-    IP_info() 
-        : eth()
-        , isARP(false)
-        , last_arp_sent(0)
-        , ARP_msgs() 
-    {}
+    IP_info() : eth(), isARP( false ), last_arp_sent( 0 ), ARP_msgs() {}
   };
 
   // Stores IP->Ethernet Recent Info

--- a/src/reassembler.cc
+++ b/src/reassembler.cc
@@ -1,0 +1,17 @@
+#include "reassembler.hh"
+#include "debug.hh"
+
+using namespace std;
+
+void Reassembler::insert( uint64_t first_index, string data, bool is_last_substring )
+{
+  debug( "unimplemented insert({}, {}, {}) called", first_index, data, is_last_substring );
+}
+
+// How many bytes are stored in the Reassembler itself?
+// This function is for testing only; don't add extra state to support it.
+uint64_t Reassembler::count_bytes_pending() const
+{
+  debug( "unimplemented count_bytes_pending() called" );
+  return {};
+}

--- a/src/reassembler.cc
+++ b/src/reassembler.cc
@@ -8,9 +8,11 @@ void Reassembler::insert( uint64_t first_index, string data, bool is_last_substr
   // Initialize a index for looping through the data string
   size_t data_index = 0;
 
+
+
   // CASE: if data string overlaps with data that has already been added to the reassembler/bytestream
   //    -> skip bytes until we reach new information
-  while ( (int64_t)first_index <= recent_index && data_index < data.length() ) {
+  while ( (int64_t)first_index <= recent_index && data_index < data.length() && recent_index != -1) {
     // Remove from saved -> lower storage cost
     saved_bytes.erase( first_index );
     // Update indexes to traverse data

--- a/src/reassembler.cc
+++ b/src/reassembler.cc
@@ -8,57 +8,59 @@ void Reassembler::insert( uint64_t first_index, string data, bool is_last_substr
   // Initialize a index for looping through the data string
   size_t data_index = 0;
 
-  // CASE: if data string overlaps with data that has already been added to the reassembler/bytestream 
+  // CASE: if data string overlaps with data that has already been added to the reassembler/bytestream
   //    -> skip bytes until we reach new information
-  while ((int64_t) first_index <= recent_index && data_index < data.length()) {
+  while ( (int64_t)first_index <= recent_index && data_index < data.length() ) {
     // Remove from saved -> lower storage cost
-    saved_bytes.erase(first_index);
+    saved_bytes.erase( first_index );
     // Update indexes to traverse data
     first_index++;
     data_index++;
   }
-  
-  // Update data + data_index for simplicity. Does not increase runtime since we are looping through all data bytes anyway O(n)
-  data = data.substr(data_index);
+
+  // Update data + data_index for simplicity. Does not increase runtime since we are looping through all data bytes
+  // anyway O(n)
+  data = data.substr( data_index );
   data_index = 0;
 
-  // CASE: insert relevent data bytes into the bytestream only if there is capacity and our string has the first_index starting position
-  if (data_index < data.length() && (int64_t)first_index == recent_index + 1) {
+  // CASE: insert relevent data bytes into the bytestream only if there is capacity and our string has the
+  // first_index starting position
+  if ( data_index < data.length() && (int64_t)first_index == recent_index + 1 ) {
     // derive stream capacity to update index information
     size_t stream_capacity = output_.writer().available_capacity();
     // attempt to insert data; data not guarenteed to be all added
-    output_.writer().push( data ); 
+    output_.writer().push( data );
 
     // calculate update_size : min(capacity, stringSize), represents number of bytes added to stream
-    uint64_t update_size = min(stream_capacity, data.length());
+    uint64_t update_size = min( stream_capacity, data.length() );
 
     // remove from storage -> reduce storage space
-    for (uint64_t i = first_index; i < first_index + update_size; i++) {
-      saved_bytes.erase(i);
+    for ( uint64_t i = first_index; i < first_index + update_size; i++ ) {
+      saved_bytes.erase( i );
     }
 
-    //update counters using update_size var
+    // update counters using update_size var
     first_index += update_size;
     data_index += update_size;
     recent_index = first_index - 1; // first_index represents unadded
   }
 
   // CASE: All Data skipped or added to stream + lastSubstring flag raised
-  if (data_index == data.length() && is_last_substring) {
+  if ( data_index == data.length() && is_last_substring ) {
     output_.writer().close();
     return;
   }
 
   // CASE: Could not add bytes (ie. holes) -> store as many as capacity allows
-  if (data_index < data.length() && output_.writer().available_capacity() != 0) {
-    // max_index stores max index (inclusive) of bytes that fit in our reassembler 
+  if ( data_index < data.length() && output_.writer().available_capacity() != 0 ) {
+    // max_index stores max index (inclusive) of bytes that fit in our reassembler
     uint64_t max_index = recent_index + output_.writer().available_capacity();
     // loop from beginning, storing foremost bytes first, loop ends at max_index
-    while (data_index < data.length() && first_index <= max_index) {
+    while ( data_index < data.length() && first_index <= max_index ) {
       // check if we are storing the "lastByte" of our message
-      bool isLastByte = data_index == (data.length() - 1) && is_last_substring;
+      bool isLastByte = data_index == ( data.length() - 1 ) && is_last_substring;
       // store data in reassembler
-      std::pair<char, bool> info = {data[data_index], isLastByte};
+      std::pair<char, bool> info = { data[data_index], isLastByte };
       saved_bytes[first_index] = info;
 
       // update counters
@@ -67,20 +69,20 @@ void Reassembler::insert( uint64_t first_index, string data, bool is_last_substr
     }
   }
 
-
-  // CASE: Update Bytestream with relevant saved bytes from Reassembler, starting from recent_index+1 or the first index missing
+  // CASE: Update Bytestream with relevant saved bytes from Reassembler, starting from recent_index+1 or the first
+  // index missing
   //      -> useful for holes being filled
-  while (saved_bytes.contains(recent_index + 1)) {
+  while ( saved_bytes.contains( recent_index + 1 ) ) {
     // store saved bytes locally and push
     std::pair<char, bool> info = saved_bytes[recent_index + 1];
     bool isLast = info.second;
-    string this_msg = string(1, info.first);
-    output_.writer().push(this_msg);
+    string this_msg = string( 1, info.first );
+    output_.writer().push( this_msg );
     // remove from storage -> save storage space
-    saved_bytes.erase(recent_index + 1);
+    saved_bytes.erase( recent_index + 1 );
     recent_index++;
     // if we add the last byte -> end connection and close
-    if (isLast) {
+    if ( isLast ) {
       output_.writer().close();
       return;
     }

--- a/src/reassembler.cc
+++ b/src/reassembler.cc
@@ -8,11 +8,9 @@ void Reassembler::insert( uint64_t first_index, string data, bool is_last_substr
   // Initialize a index for looping through the data string
   size_t data_index = 0;
 
-
-
   // CASE: if data string overlaps with data that has already been added to the reassembler/bytestream
   //    -> skip bytes until we reach new information
-  while ( (int64_t)first_index <= recent_index && data_index < data.length() && recent_index != -1) {
+  while ( (int64_t)first_index <= recent_index && data_index < data.length() && recent_index != -1 ) {
     // Remove from saved -> lower storage cost
     saved_bytes.erase( first_index );
     // Update indexes to traverse data

--- a/src/reassembler.cc
+++ b/src/reassembler.cc
@@ -5,55 +5,60 @@ using namespace std;
 
 void Reassembler::insert( uint64_t first_index, string data, bool is_last_substring )
 {
-  //debug( "unimplemented insert({}, {}, {}) called", first_index, data, is_last_substring );
-
+  // Initialize a index for looping through the data string
   size_t data_index = 0;
-  // case: overlap
+  // CASE: if data string overlaps with data that has already been added to the reassembler/bytestream 
+  //    -> skip bytes until we reach new information
   while ((int64_t) first_index <= recent_index && data_index < data.length()) {
-    // skip and remove from saved
+    // Remove from saved -> lower storage cost
     saved_bytes.erase(first_index);
+    // Update indexes to traverse data
     first_index++;
     data_index++;
   }
   
-  // update data + data_index
+  // Update data + data_index for simplicity. Does not increase runtime since we are looping through all data bytes anyway O(n)
   data = data.substr(data_index);
   data_index = 0;
 
-  // case: insert
+  // CASE: insert relevent data bytes into the bytestream only if there is capacity and our string has the first_index starting position
   if (data_index < data.length() && (int64_t)first_index == recent_index + 1) {
-    // insert data
+    // derive stream capacity to update index information
     size_t stream_capacity = output_.writer().available_capacity();
+    // attempt to insert data; data not guarenteed to be all added
     output_.writer().push( data ); 
 
-    // calculate update size : min(capacity, stringSize)
+    // calculate update_size : min(capacity, stringSize), represents number of bytes added to stream
     uint64_t update_size = min(stream_capacity, data.length());
 
-    // remove from storage
+    // remove from storage -> reduce storage space
     for (uint64_t i = first_index; i < first_index + update_size; i++) {
       saved_bytes.erase(i);
     }
 
-    //update counters
+    //update counters using update_size var
     first_index += update_size;
     data_index += update_size;
     recent_index = first_index - 1; // first_index represents unadded
 
     
   }
-  // if we were able to read all + we got last flag
+
+  // CASE: All Data skipped or added to stream + lastSubstring flag raised
   if (data_index == data.length() && is_last_substring) {
     output_.writer().close();
     return;
   }
 
-  // case: gap data -> store valid bytes
+  // CASE: Could not add bytes (ie. holes) -> store as many as capacity allows
   if (data_index < data.length() && output_.writer().available_capacity() != 0) {
-    // max_index stores max index inclusive
+    // max_index stores max index (inclusive) of bytes that fit in our reassembler 
     uint64_t max_index = recent_index + output_.writer().available_capacity();
+    // loop from beginning, storing foremost bytes first, loop ends at max_index
     while (data_index < data.length() && first_index <= max_index) {
-      // store data
+      // check if we are storing the "lastByte" of our message
       bool isLastByte = data_index == (data.length() - 1) && is_last_substring;
+      // store data in reassembler
       std::pair<char, bool> info = {data[data_index], isLastByte};
       saved_bytes[first_index] = info;
 
@@ -63,36 +68,29 @@ void Reassembler::insert( uint64_t first_index, string data, bool is_last_substr
     }
   }
 
-  // if last string, close string, not if there is extra stored
-  // if (is_last_substring) {
-  //   output_.writer().close();
-  //   return;
-  // }
 
-
-  // case: gap data -> pop from dict
+  // CASE: Update Bytestream with relevant saved bytes from Reassembler, starting from recent_index+1 or the first index missing
+  //      -> useful for holes being filled
   while (saved_bytes.contains(recent_index + 1)) {
+    // store saved bytes locally and push
     std::pair<char, bool> info = saved_bytes[recent_index + 1];
     bool isLast = info.second;
     string this_msg = string(1, info.first);
     output_.writer().push(this_msg);
-    // remove from storage
+    // remove from storage -> save storage space
     saved_bytes.erase(recent_index + 1);
     recent_index++;
-
+    // if we add the last byte -> end connection and close
     if (isLast) {
       output_.writer().close();
       return;
     }
   }
-
-  // edit: find first unpopped index using reader.bytespopped (if 0 then 0, etc), and use that to find the first unacceptableindex
 }
 
 // How many bytes are stored in the Reassembler itself?
 // This function is for testing only; don't add extra state to support it.
 uint64_t Reassembler::count_bytes_pending() const
 {
-  // debug( "unimplemented count_bytes_pending() called" );
   return saved_bytes.size();
 }

--- a/src/reassembler.cc
+++ b/src/reassembler.cc
@@ -5,13 +5,75 @@ using namespace std;
 
 void Reassembler::insert( uint64_t first_index, string data, bool is_last_substring )
 {
-  debug( "unimplemented insert({}, {}, {}) called", first_index, data, is_last_substring );
+  //debug( "unimplemented insert({}, {}, {}) called", first_index, data, is_last_substring );
+
+  size_t data_index = 0;
+  // case: overlap
+  while (first_index <= recent_index) {
+    // skip and remove from saved
+    saved_bytes.erase(first_index);
+    first_index++;
+    data_index++;
+  }
+  
+  // update data
+  data = data.substr(data_index);
+
+  // case: insert
+  if (data_index < data.length()) {
+    // insert data
+    size_t stream_capacity = output_.writer().available_capacity();
+    output_.writer().push( data ); 
+
+    // calculate update size : min(capacity, stringSize)
+    uint64_t update_size = min(stream_capacity, data.length());
+
+    // remove from storage
+    for (uint64_t i = first_index; i < first_index + update_size; i++) {
+      saved_bytes.erase(i);
+    }
+
+    //update counters
+    first_index += update_size;
+    data_index += update_size;
+    recent_index = first_index - 1; // first_index represents unadded
+  }
+
+  // case: gap data -> store valid bytes
+  if (data_index < data.length() && output_.writer().available_capacity() != 0) {
+    // max_index stores max index inclusive
+    uint64_t max_index = recent_index + output_.writer().available_capacity();
+    while (data_index < data.length() && first_index <= max_index) {
+      // store data
+      saved_bytes[first_index] = data[data_index];
+
+      // update counters
+      first_index++;
+      data_index++;
+    }
+  }
+
+  // if last string, close string, even if there is extra stored
+  if (is_last_substring) {
+    output_.writer().close();
+    return;
+  }
+
+
+  // case: gap data -> pop from dict
+  while (saved_bytes.contains(recent_index + 1)) {
+    string this_msg = string(1, saved_bytes[recent_index + 1]);
+    output_.writer().push(this_msg);
+    // remove from storage
+    saved_bytes.erase(recent_index + 1);
+    recent_index++;
+  }
 }
 
 // How many bytes are stored in the Reassembler itself?
 // This function is for testing only; don't add extra state to support it.
 uint64_t Reassembler::count_bytes_pending() const
 {
-  debug( "unimplemented count_bytes_pending() called" );
-  return {};
+  // debug( "unimplemented count_bytes_pending() called" );
+  return { saved_bytes.size() };
 }

--- a/src/reassembler.cc
+++ b/src/reassembler.cc
@@ -7,6 +7,7 @@ void Reassembler::insert( uint64_t first_index, string data, bool is_last_substr
 {
   // Initialize a index for looping through the data string
   size_t data_index = 0;
+
   // CASE: if data string overlaps with data that has already been added to the reassembler/bytestream 
   //    -> skip bytes until we reach new information
   while ((int64_t) first_index <= recent_index && data_index < data.length()) {
@@ -40,8 +41,6 @@ void Reassembler::insert( uint64_t first_index, string data, bool is_last_substr
     first_index += update_size;
     data_index += update_size;
     recent_index = first_index - 1; // first_index represents unadded
-
-    
   }
 
   // CASE: All Data skipped or added to stream + lastSubstring flag raised

--- a/src/reassembler.hh
+++ b/src/reassembler.hh
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "byte_stream.hh"
+
+class Reassembler
+{
+public:
+  // Construct Reassembler to write into given ByteStream.
+  explicit Reassembler( ByteStream&& output ) : output_( std::move( output ) ) {}
+
+  /*
+   * Insert a new substring to be reassembled into a ByteStream.
+   *   `first_index`: the index of the first byte of the substring
+   *   `data`: the substring itself
+   *   `is_last_substring`: this substring represents the end of the stream
+   *   `output`: a mutable reference to the Writer
+   *
+   * The Reassembler's job is to reassemble the indexed substrings (possibly out-of-order
+   * and possibly overlapping) back into the original ByteStream. As soon as the Reassembler
+   * learns the next byte in the stream, it should write it to the output.
+   *
+   * If the Reassembler learns about bytes that fit within the stream's available capacity
+   * but can't yet be written (because earlier bytes remain unknown), it should store them
+   * internally until the gaps are filled in.
+   *
+   * The Reassembler should discard any bytes that lie beyond the stream's available capacity
+   * (i.e., bytes that couldn't be written even if earlier gaps get filled in).
+   *
+   * The Reassembler should close the stream after writing the last byte.
+   */
+  void insert( uint64_t first_index, std::string data, bool is_last_substring );
+
+  // How many bytes are stored in the Reassembler itself?
+  // This function is for testing only; don't add extra state to support it.
+  uint64_t count_bytes_pending() const;
+
+  // Access output stream reader
+  Reader& reader() { return output_.reader(); }
+  const Reader& reader() const { return output_.reader(); }
+
+  // Access output stream writer, but const-only (can't write from outside)
+  const Writer& writer() const { return output_.writer(); }
+
+private:
+  ByteStream output_;
+};

--- a/src/reassembler.hh
+++ b/src/reassembler.hh
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "byte_stream.hh"
+#include <unordered_map>
+
 
 class Reassembler
 {
 public:
   // Construct Reassembler to write into given ByteStream.
-  explicit Reassembler( ByteStream&& output ) : output_( std::move( output ) ) {}
+  explicit Reassembler( ByteStream&& output ) : output_( std::move( output ) ), recent_index(-1), saved_bytes() {}
 
   /*
    * Insert a new substring to be reassembled into a ByteStream.
@@ -43,4 +45,8 @@ public:
 
 private:
   ByteStream output_;
+
+  uint64_t recent_index;
+  std::unordered_map<uint64_t, char> saved_bytes;
+
 };

--- a/src/reassembler.hh
+++ b/src/reassembler.hh
@@ -3,12 +3,11 @@
 #include "byte_stream.hh"
 #include <unordered_map>
 
-
 class Reassembler
 {
 public:
   // Construct Reassembler to write into given ByteStream.
-  explicit Reassembler( ByteStream&& output ) : output_( std::move( output ) ), recent_index(-1), saved_bytes() {}
+  explicit Reassembler( ByteStream&& output ) : output_( std::move( output ) ), recent_index( -1 ), saved_bytes() {}
 
   /*
    * Insert a new substring to be reassembled into a ByteStream.
@@ -49,5 +48,4 @@ private:
   int64_t recent_index;
   // save bytes that cannot be added yet
   std::unordered_map<uint64_t, std::pair<char, bool>> saved_bytes;
-
 };

--- a/src/reassembler.hh
+++ b/src/reassembler.hh
@@ -46,7 +46,7 @@ public:
 private:
   ByteStream output_;
 
-  uint64_t recent_index;
-  std::unordered_map<uint64_t, char> saved_bytes;
+  int64_t recent_index;
+  std::unordered_map<uint64_t, std::pair<char, bool>> saved_bytes;
 
 };

--- a/src/reassembler.hh
+++ b/src/reassembler.hh
@@ -45,8 +45,9 @@ public:
 
 private:
   ByteStream output_;
-
+  // store the most recent index seen -> used to find the next index that should be added
   int64_t recent_index;
+  // save bytes that cannot be added yet
   std::unordered_map<uint64_t, std::pair<char, bool>> saved_bytes;
 
 };

--- a/src/router.cc
+++ b/src/router.cc
@@ -1,0 +1,30 @@
+#include "router.hh"
+#include "debug.hh"
+
+#include <iostream>
+
+using namespace std;
+
+// route_prefix: The "up-to-32-bit" IPv4 address prefix to match the datagram's destination address against
+// prefix_length: For this route to be applicable, how many high-order (most-significant) bits of
+//    the route_prefix will need to match the corresponding bits of the datagram's destination address?
+// next_hop: The IP address of the next hop. Will be empty if the network is directly attached to the router (in
+//    which case, the next hop address should be the datagram's final destination).
+// interface_num: The index of the interface to send the datagram out on.
+void Router::add_route( const uint32_t route_prefix,
+                        const uint8_t prefix_length,
+                        const optional<Address> next_hop,
+                        const size_t interface_num )
+{
+  cerr << "DEBUG: adding route " << Address::from_ipv4_numeric( route_prefix ).ip() << "/"
+       << static_cast<int>( prefix_length ) << " => " << ( next_hop.has_value() ? next_hop->ip() : "(direct)" )
+       << " on interface " << interface_num << "\n";
+
+  debug( "unimplemented add_route() called" );
+}
+
+// Go through all the interfaces, and route every incoming datagram to its proper outgoing interface.
+void Router::route()
+{
+  debug( "unimplemented route() called" );
+}

--- a/src/router.hh
+++ b/src/router.hh
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "exception.hh"
+#include "network_interface.hh"
+
+#include <optional>
+
+// \brief A router that has multiple network interfaces and
+// performs longest-prefix-match routing between them.
+class Router
+{
+public:
+  // Add an interface to the router
+  // \param[in] interface an already-constructed network interface
+  // \returns The index of the interface after it has been added to the router
+  size_t add_interface( std::shared_ptr<NetworkInterface> interface )
+  {
+    interfaces_.push_back( notnull( "add_interface", std::move( interface ) ) );
+    return interfaces_.size() - 1;
+  }
+
+  // Access an interface by index
+  std::shared_ptr<NetworkInterface> interface( const size_t N ) { return interfaces_.at( N ); }
+
+  // Add a route (a forwarding rule)
+  void add_route( uint32_t route_prefix,
+                  uint8_t prefix_length,
+                  std::optional<Address> next_hop,
+                  size_t interface_num );
+
+  // Route packets between the interfaces
+  void route();
+
+private:
+  // The router's collection of network interfaces
+  std::vector<std::shared_ptr<NetworkInterface>> interfaces_ {};
+};

--- a/src/tcp_minnow_socket.cc
+++ b/src/tcp_minnow_socket.cc
@@ -1,0 +1,5 @@
+#include "tcp_minnow_socket_impl.hh"
+
+//! Specializations of TCPMinnowSocket for TCPOverIPv4OverTunFdAdapter and its lossy version
+template class TCPMinnowSocket<TCPOverIPv4OverTunFdAdapter>;
+template class TCPMinnowSocket<LossyFdAdapter<TCPOverIPv4OverTunFdAdapter>>;

--- a/src/tcp_receiver.cc
+++ b/src/tcp_receiver.cc
@@ -1,0 +1,18 @@
+#include "tcp_receiver.hh"
+#include "debug.hh"
+
+using namespace std;
+
+void TCPReceiver::receive( TCPSenderMessage message )
+{
+  // Your code here.
+  debug( "unimplemented receive() called" );
+  (void)message;
+}
+
+TCPReceiverMessage TCPReceiver::send() const
+{
+  // Your code here.
+  debug( "unimplemented send() called" );
+  return {};
+}

--- a/src/tcp_receiver.cc
+++ b/src/tcp_receiver.cc
@@ -6,7 +6,7 @@ using namespace std;
 void TCPReceiver::receive( TCPSenderMessage message )
 {
   // check for SYN flag and store ISN properly
-  if (message.SYN && !this->received_isn_) {
+  if ( message.SYN && !this->received_isn_ ) {
     this->received_isn_ = true;
     this->zero_point_ = message.seqno;
     // update index to count ISN index
@@ -14,45 +14,43 @@ void TCPReceiver::receive( TCPSenderMessage message )
   }
 
   // set error if RST flag and return
-  if (message.RST) {
+  if ( message.RST ) {
     reassembler_.reader().set_error();
     this->received_rst_ = true;
     return;
   }
 
   // cannot write if no isn; return
-  if (!this->received_isn_) {
+  if ( !this->received_isn_ ) {
     return;
   }
 
   // calculate first_index by unwrapping message; update if this is the message where we received syn
-  uint64_t first_index = message.seqno.unwrap(this->zero_point_, this->first_unassembled_index_);
-  if (message.SYN && message.payload.size() != 0) {
+  uint64_t first_index = message.seqno.unwrap( this->zero_point_, this->first_unassembled_index_ );
+  if ( message.SYN && message.payload.size() != 0 ) {
     first_index++;
   }
   // insert message to reassembler, and update state; -1 since SYN does not count for reassembler
   uint64_t reassembler_capacity_pre = reassembler_.writer().available_capacity();
-  reassembler_.insert(first_index - 1, message.payload, message.FIN);
+  reassembler_.insert( first_index - 1, message.payload, message.FIN );
   uint64_t reassembler_capacity_post = reassembler_.writer().available_capacity();
   this->first_unassembled_index_ += reassembler_capacity_pre - reassembler_capacity_post;
-  
+
   // add FIN byte index if needed
-  if (reassembler_.writer().is_closed()) {
+  if ( reassembler_.writer().is_closed() ) {
     this->first_unassembled_index_++;
   }
-
-  
 }
 
 TCPReceiverMessage TCPReceiver::send() const
 {
   TCPReceiverMessage message;
   // Add optional ackno if we have recieved an ISN
-  if (this->received_isn_) {
-    message.ackno = Wrap32::wrap(this->first_unassembled_index_, this->zero_point_);
+  if ( this->received_isn_ ) {
+    message.ackno = Wrap32::wrap( this->first_unassembled_index_, this->zero_point_ );
   }
   // WINDOWSIZE = MAX_SIZE - USED_INDEXES(not including syn/fin)
-  message.window_size = min((uint64_t)UINT16_MAX, reassembler_.writer().available_capacity());
+  message.window_size = min( (uint64_t)UINT16_MAX, reassembler_.writer().available_capacity() );
 
   // RST is true if bytestream detected error or Receiver had an error packet
   message.RST = this->reassembler_.writer().has_error() || this->received_rst_;

--- a/src/tcp_receiver.cc
+++ b/src/tcp_receiver.cc
@@ -9,17 +9,18 @@ void TCPReceiver::receive( TCPSenderMessage message )
   if (message.SYN && !this->received_isn_) {
     this->received_isn_ = true;
     this->zero_point_ = message.seqno;
+    // update index to count ISN index
     this->first_unassembled_index_++;
   }
 
-  // set error if RST flag?
+  // set error if RST flag and return
   if (message.RST) {
     reassembler_.reader().set_error();
     this->received_rst_ = true;
     return;
   }
 
-  // cannot write if no isn; return and (raise error?)
+  // cannot write if no isn; return
   if (!this->received_isn_) {
     return;
   }
@@ -35,7 +36,7 @@ void TCPReceiver::receive( TCPSenderMessage message )
   uint64_t reassembler_capacity_post = reassembler_.writer().available_capacity();
   this->first_unassembled_index_ += reassembler_capacity_pre - reassembler_capacity_post;
   
-  // add FIN byte if needed
+  // add FIN byte index if needed
   if (reassembler_.writer().is_closed()) {
     this->first_unassembled_index_++;
   }

--- a/src/tcp_receiver.cc
+++ b/src/tcp_receiver.cc
@@ -5,14 +5,56 @@ using namespace std;
 
 void TCPReceiver::receive( TCPSenderMessage message )
 {
-  // Your code here.
-  debug( "unimplemented receive() called" );
-  (void)message;
+  // check for SYN flag and store ISN properly
+  if (message.SYN && !this->received_isn_) {
+    this->received_isn_ = true;
+    this->zero_point_ = message.seqno;
+    this->first_unassembled_index_++;
+  }
+
+  // set error if RST flag?
+  if (message.RST) {
+    reassembler_.reader().set_error();
+    this->received_rst_ = true;
+    return;
+  }
+
+  // cannot write if no isn; return and (raise error?)
+  if (!this->received_isn_) {
+    return;
+  }
+
+  // calculate first_index by unwrapping message; update if this is the message where we received syn
+  uint64_t first_index = message.seqno.unwrap(this->zero_point_, this->first_unassembled_index_);
+  if (message.SYN && message.payload.size() != 0) {
+    first_index++;
+  }
+  // insert message to reassembler, and update state; -1 since SYN does not count for reassembler
+  uint64_t reassembler_capacity_pre = reassembler_.writer().available_capacity();
+  reassembler_.insert(first_index - 1, message.payload, message.FIN);
+  uint64_t reassembler_capacity_post = reassembler_.writer().available_capacity();
+  this->first_unassembled_index_ += reassembler_capacity_pre - reassembler_capacity_post;
+  
+  // add FIN byte if needed
+  if (reassembler_.writer().is_closed()) {
+    this->first_unassembled_index_++;
+  }
+
+  
 }
 
 TCPReceiverMessage TCPReceiver::send() const
 {
-  // Your code here.
-  debug( "unimplemented send() called" );
-  return {};
+  TCPReceiverMessage message;
+  // Add optional ackno if we have recieved an ISN
+  if (this->received_isn_) {
+    message.ackno = Wrap32::wrap(this->first_unassembled_index_, this->zero_point_);
+  }
+  // WINDOWSIZE = MAX_SIZE - USED_INDEXES(not including syn/fin)
+  message.window_size = min((uint64_t)UINT16_MAX, reassembler_.writer().available_capacity());
+
+  // RST is true if bytestream detected error or Receiver had an error packet
+  message.RST = this->reassembler_.writer().has_error() || this->received_rst_;
+
+  return message;
 }

--- a/src/tcp_receiver.hh
+++ b/src/tcp_receiver.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "reassembler.hh"
+#include "tcp_receiver_message.hh"
+#include "tcp_sender_message.hh"
+
+class TCPReceiver
+{
+public:
+  // Construct with given Reassembler
+  explicit TCPReceiver( Reassembler&& reassembler ) : reassembler_( std::move( reassembler ) ) {}
+
+  /*
+   * The TCPReceiver receives TCPSenderMessages, inserting their payload into the Reassembler
+   * at the correct stream index.
+   */
+  void receive( TCPSenderMessage message );
+
+  // The TCPReceiver sends TCPReceiverMessages to the peer's TCPSender.
+  TCPReceiverMessage send() const;
+
+  // Access the output
+  const Reassembler& reassembler() const { return reassembler_; }
+  Reader& reader() { return reassembler_.reader(); }
+  const Reader& reader() const { return reassembler_.reader(); }
+  const Writer& writer() const { return reassembler_.writer(); }
+
+private:
+  Reassembler reassembler_;
+};

--- a/src/tcp_receiver.hh
+++ b/src/tcp_receiver.hh
@@ -27,4 +27,10 @@ public:
 
 private:
   Reassembler reassembler_;
+
+  bool received_isn_ = false;
+  uint64_t first_unassembled_index_ = 0;
+  Wrap32 zero_point_ = Wrap32( 0 );
+  bool received_rst_ = false;
+  // uint64_t window_size_ = UINT16_MAX;
 };

--- a/src/tcp_receiver.hh
+++ b/src/tcp_receiver.hh
@@ -32,5 +32,4 @@ private:
   uint64_t first_unassembled_index_ = 0;
   Wrap32 zero_point_ = Wrap32( 0 );
   bool received_rst_ = false;
-  // uint64_t window_size_ = UINT16_MAX;
 };

--- a/src/tcp_sender.cc
+++ b/src/tcp_sender.cc
@@ -1,0 +1,43 @@
+#include "tcp_sender.hh"
+#include "debug.hh"
+#include "tcp_config.hh"
+
+using namespace std;
+
+// This function is for testing only; don't add extra state to support it.
+uint64_t TCPSender::sequence_numbers_in_flight() const
+{
+  debug( "unimplemented sequence_numbers_in_flight() called" );
+  return {};
+}
+
+// This function is for testing only; don't add extra state to support it.
+uint64_t TCPSender::consecutive_retransmissions() const
+{
+  debug( "unimplemented consecutive_retransmissions() called" );
+  return {};
+}
+
+void TCPSender::push( const TransmitFunction& transmit )
+{
+  debug( "unimplemented push() called" );
+  (void)transmit;
+}
+
+TCPSenderMessage TCPSender::make_empty_message() const
+{
+  debug( "unimplemented make_empty_message() called" );
+  return {};
+}
+
+void TCPSender::receive( const TCPReceiverMessage& msg )
+{
+  debug( "unimplemented receive() called" );
+  (void)msg;
+}
+
+void TCPSender::tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit )
+{
+  debug( "unimplemented tick({}, ...) called", ms_since_last_tick );
+  (void)transmit;
+}

--- a/src/tcp_sender.cc
+++ b/src/tcp_sender.cc
@@ -18,16 +18,71 @@ uint64_t TCPSender::consecutive_retransmissions() const
   return log2( curr_RTO_ms_ / initial_RTO_ms_);
 }
 
+void TCPSender::push_packet(uint64_t size, TCPSenderMessage &cur_message, const TransmitFunction& transmit, bool false_window) {
+  string_view bytestream_state = input_.reader().peek();
+  cur_message.payload = bytestream_state.substr(0, size);
+  // seqno -> bytes popped from stream
+  cur_message.seqno = Wrap32::wrap(reader().bytes_popped(), isn_);
+  if (false_window) {
+    input_.reader().pop(size);
+  }
+  cur_message.FIN = (input_.reader().is_finished() && input_.reader().bytes_buffered() == 0);
+  transmit(cur_message);
+}
+
 void TCPSender::push( const TransmitFunction& transmit )
 {
-  debug( "unimplemented push() called" );
-  (void)transmit;
+  uint64_t bytes_buffered_init = input_.reader().bytes_buffered();
+  // return if input is empty or bytestream is closed
+  if ( bytes_buffered_init == 0 ) {
+    return;
+  }
+
+  TCPSenderMessage cur_message;
+  size_t empty_message_size = cur_message.sequence_length();
+  // if window_size is 0 and this is not the first message, always send a packet of size one to recieve new window size information
+  if (window_size == 0 && connection_started) {
+    push_packet(1, cur_message, transmit, true);
+  }
+
+  // otherwise, transmit as big of a message as you can
+  size_t curr_space_in_connection = window_size - bytes_outstanding - empty_message_size; // 7 bytes of non-payload info
+  size_t payload_size = min(TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection);
+
+  // assuming window_size is bytes free in the bytestream; if less then 7 bytes if available cannot create a TCPMessage
+  while (window_size - bytes_outstanding > empty_message_size) {
+    curr_space_in_connection = window_size - bytes_outstanding - empty_message_size; // 7 bytes of non-payload info
+    payload_size = min(TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection);
+    push_packet(payload_size, cur_message, transmit, false);
+    // add to dictionary - assuming passing by value here
+    outstanding_segments[last_segment_sent_] = cur_message;
+    bytes_outstanding += cur_message.sequence_length();
+    last_segment_sent_ += cur_message.sequence_length();
+  }
 }
 
 TCPSenderMessage TCPSender::make_empty_message() const
 {
-  debug( "unimplemented make_empty_message() called" );
-  return {};
+  TCPSenderMessage cur_message;
+  cur_message.seqno = Wrap32::wrap(reader().bytes_popped(), isn_);
+  return cur_message;
+}
+
+/*
+Goal of this function is to find the ackno of the first byte of the first, unacknowledged segment.
+The first unackno. segment is always the key before, a key k s.t. k > msg_ackno.
+*/
+void TCPSender::update_expected_ackno_and_clean(uint64_t msg_ackno) {
+  for (auto& pair : outstanding_segments) {
+    uint64_t key = pair.first;
+    if (key >= msg_ackno) {
+      break;
+    }
+    // decrement bytes_outstanding can clean map
+    bytes_outstanding -= outstanding_segments[expected_ackno_].sequence_length();
+    outstanding_segments.erase(expected_ackno_);
+    expected_ackno_ = key;
+  }
 }
 
 void TCPSender::receive( const TCPReceiverMessage& msg )
@@ -36,26 +91,32 @@ void TCPSender::receive( const TCPReceiverMessage& msg )
   if (!msg.ackno.has_value()) {
     return;
   }
+
+  // TODO: Clean collection of outstanding segments; add below to a helper function under RTO + decrement bytes_outstanding
+  connection_started = true;
+  window_size = msg.window_size;
+
   uint64_t msg_ackno = msg.ackno.value().unwrap(isn_, expected_ackno_);
   // RTO Timer: If all outstanding data has been acknowledged stop the retransmission timer
   if (expected_ackno_ <= msg_ackno && msg_ackno == last_segment_sent_) {
     stop_rto_alarm();
-    expected_ackno_++;
+    update_expected_ackno_and_clean(msg_ackno);
     return;
   }
 
   // RTO Timer: If we confirm receipt of new data
   if (expected_ackno_ <= msg_ackno) {
-    expected_ackno_ = msg_ackno + 1;
+    update_expected_ackno_and_clean(msg_ackno);
     stop_rto_alarm();
 
     // If there is outstanding data leftover -> set_RTO_alarm + reset consec retransmissions
     if (expected_ackno_ <= last_segment_sent_) {
       set_rto_alarm();
     }
-
     // Else: all outstanding data has been acknowledged
   }
+
+  
 }
 
 void TCPSender::tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit )

--- a/src/tcp_sender.cc
+++ b/src/tcp_sender.cc
@@ -8,8 +8,7 @@ using namespace std;
 // This function is for testing only; don't add extra state to support it.
 uint64_t TCPSender::sequence_numbers_in_flight() const
 {
-  debug( "unimplemented sequence_numbers_in_flight() called" );
-  return {};
+  return last_segment_sent_ - last_ackno_received;
 }
 
 // This function is for testing only; don't add extra state to support it.
@@ -18,53 +17,93 @@ uint64_t TCPSender::consecutive_retransmissions() const
   return log2( curr_RTO_ms_ / initial_RTO_ms_);
 }
 
-void TCPSender::push_packet(uint64_t size, TCPSenderMessage &cur_message, const TransmitFunction& transmit, bool false_window) {
+void TCPSender::push_packet(uint64_t size, TCPSenderMessage &cur_message, const TransmitFunction& transmit, bool rst, bool can_add_fin_bit) {
   string_view bytestream_state = input_.reader().peek();
-  cur_message.payload = bytestream_state.substr(0, size);
-  // seqno -> bytes popped from stream
-  cur_message.seqno = Wrap32::wrap(reader().bytes_popped(), isn_);
-  if (false_window) {
-    input_.reader().pop(size);
+  
+  cur_message.SYN = last_segment_sent_ == 0;
+  if (cur_message.SYN && size != 0) {
+    size--;
   }
-  cur_message.FIN = (input_.reader().is_finished() && input_.reader().bytes_buffered() == 0);
+  
+  // seqno -> bytes popped from stream
+  cur_message.seqno = Wrap32::wrap(last_segment_sent_, isn_);
+  if (can_add_fin_bit) {
+    cur_message.FIN = true;
+    sent_fin_bit = true;
+    size = min(size, size - 1);
+  }
+  cur_message.payload = bytestream_state.substr(0, size);
+  input_.reader().pop(size);
+  
+  cur_message.RST = rst;
   transmit(cur_message);
+
+  // if (!false_window) {
+    // add to dictionary - assuming passing by value here
+    outstanding_segments[last_segment_sent_] = cur_message;
+    last_segment_sent_ += cur_message.sequence_length();
+    bytes_outstanding += cur_message.sequence_length();
+    if (!rto_timer_is_on_) {
+      set_rto_alarm();
+    }
+  // }
 }
 
 void TCPSender::push( const TransmitFunction& transmit )
 {
-  uint64_t bytes_buffered_init = input_.reader().bytes_buffered();
-  // return if input is empty or bytestream is closed
-  if ( bytes_buffered_init == 0 ) {
+  TCPSenderMessage cur_message;
+
+  // check for RST Flag -> push RST packet
+  if (RST || input_.has_error()) {
+    push_packet(0, cur_message, transmit, RST || input_.has_error(), false);
     return;
   }
 
-  TCPSenderMessage cur_message;
-  size_t empty_message_size = cur_message.sequence_length();
+  // send just SYN Flag if sender is reaching out first
+  if ( input_.reader().bytes_buffered() == 0 && !connection_started ) {
+    push_packet(0, cur_message, transmit, false, input_.writer().is_closed());
+    return;
+  }
+
+  //size_t empty_message_size = cur_message.sequence_length();
   // if window_size is 0 and this is not the first message, always send a packet of size one to recieve new window size information
   if (window_size == 0 && connection_started) {
-    push_packet(1, cur_message, transmit, true);
+     if (!bytes_outstanding) {
+      push_packet(1, cur_message, transmit, false, input_.reader().is_finished());
+     }
+    return;
   }
 
   // otherwise, transmit as big of a message as you can
-  size_t curr_space_in_connection = window_size - bytes_outstanding - empty_message_size; // 7 bytes of non-payload info
-  size_t payload_size = min(TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection);
+  size_t curr_space_in_connection = window_size - bytes_outstanding; // 7 bytes of non-payload info
+  size_t payload_size = min(min(TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection), input_.reader().bytes_buffered());
+  bool can_add_syn_bit = last_segment_sent_ == 0 && curr_space_in_connection - payload_size;
+  //payload_size += can_add_syn_bit;
+  bool can_add_fin_bit = (input_.writer().is_closed() && payload_size >= input_.reader().bytes_buffered() && !sent_fin_bit); // can add if BS is closed + all bytes will fit
+  can_add_fin_bit = (can_add_fin_bit && curr_space_in_connection - payload_size); // Check for space in window
+  //payload_size += can_add_fin_bit;
+  
 
   // assuming window_size is bytes free in the bytestream; if less then 7 bytes if available cannot create a TCPMessage
-  while (window_size - bytes_outstanding > empty_message_size) {
-    curr_space_in_connection = window_size - bytes_outstanding - empty_message_size; // 7 bytes of non-payload info
-    payload_size = min(TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection);
-    push_packet(payload_size, cur_message, transmit, false);
-    // add to dictionary - assuming passing by value here
-    outstanding_segments[last_segment_sent_] = cur_message;
-    bytes_outstanding += cur_message.sequence_length();
-    last_segment_sent_ += cur_message.sequence_length();
+  // TODO: figure out how to add FIN/SYN flag status to input.reader().size
+  while (curr_space_in_connection > 0 && payload_size + (can_add_fin_bit && !sent_fin_bit) > 0) {
+    // Re-evaluate the vars that could change after a packet is pushed
+    can_add_fin_bit = (input_.writer().is_closed() && payload_size >= input_.reader().bytes_buffered() && !sent_fin_bit); // can add if BS is closed + all bytes will fit
+    can_add_fin_bit = (can_add_fin_bit && curr_space_in_connection - payload_size);
+    size_t overall_size = payload_size + can_add_fin_bit + can_add_syn_bit;
+    push_packet(overall_size, cur_message, transmit, false, can_add_fin_bit);
+    // Re-evaluate the vars that could change after a packet is pushed
+    curr_space_in_connection = window_size - bytes_outstanding;
+    payload_size = min(min(TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection), input_.reader().bytes_buffered());
+    can_add_fin_bit = (input_.writer().is_closed() && input_.reader().bytes_buffered() < curr_space_in_connection && !sent_fin_bit);
   }
 }
 
 TCPSenderMessage TCPSender::make_empty_message() const
 {
   TCPSenderMessage cur_message;
-  cur_message.seqno = Wrap32::wrap(reader().bytes_popped(), isn_);
+  cur_message.seqno = Wrap32::wrap(last_segment_sent_, isn_);
+  cur_message.RST = RST || input_.has_error();
   return cur_message;
 }
 
@@ -72,21 +111,36 @@ TCPSenderMessage TCPSender::make_empty_message() const
 Goal of this function is to find the ackno of the first byte of the first, unacknowledged segment.
 The first unackno. segment is always the key before, a key k s.t. k > msg_ackno.
 */
-void TCPSender::update_expected_ackno_and_clean(uint64_t msg_ackno) {
-  for (auto& pair : outstanding_segments) {
-    uint64_t key = pair.first;
-    if (key >= msg_ackno) {
-      break;
+void TCPSender::update_last_segment_recieved_and_clean(uint64_t msg_ackno) {
+  auto it = outstanding_segments.begin();
+  while (it != outstanding_segments.end()) {
+    if (it->first >= msg_ackno) {
+        break;
     }
-    // decrement bytes_outstanding can clean map
-    bytes_outstanding -= outstanding_segments[expected_ackno_].sequence_length();
-    outstanding_segments.erase(expected_ackno_);
-    expected_ackno_ = key;
+    // decrement bytes_outstanding and clean map if we have ackno'd all the bytes
+    if (it->first + it->second.sequence_length() <= msg_ackno) {
+      bytes_outstanding = last_segment_sent_ - msg_ackno;
+      last_segment_recieved_ += it->second.sequence_length();
+      it = outstanding_segments.erase(it);  // erase returns next valid iterator
+    } else {
+      // Update Outstanding Bytes for a partial segment recognition
+      bytes_outstanding = last_segment_sent_ - msg_ackno;
+      ++it;
+    }
   }
+  // decrement bytes_outstanding
+  bytes_outstanding = last_segment_sent_ - msg_ackno;
+
 }
 
 void TCPSender::receive( const TCPReceiverMessage& msg )
 {
+  RST = msg.RST || input_.has_error();
+  window_size = msg.window_size;
+  if (RST) {
+    input_.set_error();
+  }
+  
   // if the msg has no value, skip it
   if (!msg.ackno.has_value()) {
     return;
@@ -94,29 +148,34 @@ void TCPSender::receive( const TCPReceiverMessage& msg )
 
   // TODO: Clean collection of outstanding segments; add below to a helper function under RTO + decrement bytes_outstanding
   connection_started = true;
-  window_size = msg.window_size;
+  
+  
 
-  uint64_t msg_ackno = msg.ackno.value().unwrap(isn_, expected_ackno_);
+  uint64_t msg_ackno = msg.ackno.value().unwrap(isn_, last_segment_recieved_);
+  // check for impossible msg_ackno
+  if (msg_ackno > last_segment_sent_) {
+    return;
+  }
   // RTO Timer: If all outstanding data has been acknowledged stop the retransmission timer
-  if (expected_ackno_ <= msg_ackno && msg_ackno == last_segment_sent_) {
+  if (last_segment_recieved_ <= msg_ackno && msg_ackno == last_segment_sent_) {
+    last_ackno_received = msg_ackno;
     stop_rto_alarm();
-    update_expected_ackno_and_clean(msg_ackno);
+    update_last_segment_recieved_and_clean(msg_ackno);
     return;
   }
 
   // RTO Timer: If we confirm receipt of new data
-  if (expected_ackno_ <= msg_ackno) {
-    update_expected_ackno_and_clean(msg_ackno);
+  if (last_segment_recieved_ < msg_ackno) {
+    last_ackno_received = msg_ackno;
+    update_last_segment_recieved_and_clean(msg_ackno);
     stop_rto_alarm();
 
     // If there is outstanding data leftover -> set_RTO_alarm + reset consec retransmissions
-    if (expected_ackno_ <= last_segment_sent_) {
+    if (last_segment_recieved_ <= last_segment_sent_) {
       set_rto_alarm();
     }
     // Else: all outstanding data has been acknowledged
   }
-
-  
 }
 
 void TCPSender::tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit )
@@ -130,19 +189,14 @@ void TCPSender::tick( uint64_t ms_since_last_tick, const TransmitFunction& trans
       Reset RTO Timer
   */  
   if (check_rto_alarm(ms_since_last_tick)) {
-      TCPSenderMessage retransmit_msg = outstanding_segments[expected_ackno_];
+      TCPSenderMessage retransmit_msg = outstanding_segments[last_segment_recieved_];
       transmit(retransmit_msg);
       // update RTO and start new aalarm
-      curr_RTO_ms_ *= 2;
+      if (window_size != 0) {
+        curr_RTO_ms_ *= 2;
+      }
       set_rto_alarm();
   }
-  
-  
- 
-  
-
-  debug( "unimplemented tick({}, ...) called", ms_since_last_tick );
-  (void)transmit;
 }
 
 void TCPSender::set_rto_alarm() {

--- a/src/tcp_sender.cc
+++ b/src/tcp_sender.cc
@@ -1,6 +1,7 @@
 #include "tcp_sender.hh"
 #include "debug.hh"
 #include "tcp_config.hh"
+#include "cmath"
 
 using namespace std;
 
@@ -14,8 +15,7 @@ uint64_t TCPSender::sequence_numbers_in_flight() const
 // This function is for testing only; don't add extra state to support it.
 uint64_t TCPSender::consecutive_retransmissions() const
 {
-  debug( "unimplemented consecutive_retransmissions() called" );
-  return {};
+  return log2( curr_RTO_ms_ / initial_RTO_ms_);
 }
 
 void TCPSender::push( const TransmitFunction& transmit )
@@ -32,12 +32,80 @@ TCPSenderMessage TCPSender::make_empty_message() const
 
 void TCPSender::receive( const TCPReceiverMessage& msg )
 {
-  debug( "unimplemented receive() called" );
-  (void)msg;
+  // if the msg has no value, skip it
+  if (!msg.ackno.has_value()) {
+    return;
+  }
+  uint64_t msg_ackno = msg.ackno.value().unwrap(isn_, expected_ackno_);
+  // RTO Timer: If all outstanding data has been acknowledged stop the retransmission timer
+  if (expected_ackno_ <= msg_ackno && msg_ackno == last_segment_sent_) {
+    stop_rto_alarm();
+    expected_ackno_++;
+    return;
+  }
+
+  // RTO Timer: If we confirm receipt of new data
+  if (expected_ackno_ <= msg_ackno) {
+    expected_ackno_ = msg_ackno + 1;
+    stop_rto_alarm();
+
+    // If there is outstanding data leftover -> set_RTO_alarm + reset consec retransmissions
+    if (expected_ackno_ <= last_segment_sent_) {
+      set_rto_alarm();
+    }
+
+    // Else: all outstanding data has been acknowledged
+  }
 }
 
 void TCPSender::tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit )
 {
+  /*
+  If RTO Timer is expired:
+      Retransmit the earlist segement not acknowledged
+      If window_size is nonzero
+        keep track of consec retransmissions and increment
+        double value of curr_rto_
+      Reset RTO Timer
+  */  
+  if (check_rto_alarm(ms_since_last_tick)) {
+      TCPSenderMessage retransmit_msg = outstanding_segments[expected_ackno_];
+      transmit(retransmit_msg);
+      // update RTO and start new aalarm
+      curr_RTO_ms_ *= 2;
+      set_rto_alarm();
+  }
+  
+  
+ 
+  
+
   debug( "unimplemented tick({}, ...) called", ms_since_last_tick );
   (void)transmit;
+}
+
+void TCPSender::set_rto_alarm() {
+  rto_timer_is_on_ = true;
+  rto_timer_ttl_ = curr_RTO_ms_;
+}
+
+bool TCPSender::check_rto_alarm( uint64_t ms_since_last_tick ) {
+  // return false if timer is off
+  if (!rto_timer_is_on_) {
+    return false;
+  }
+  // check for expired timer
+  if (ms_since_last_tick >= rto_timer_ttl_) {
+    rto_timer_ttl_ = 0;
+    rto_timer_is_on_ = false;
+    return true;
+  }
+  // update tick + return false
+  rto_timer_ttl_ -= ms_since_last_tick;
+  return false;
+}
+
+void TCPSender::stop_rto_alarm() {
+  rto_timer_is_on_ = false;
+  curr_RTO_ms_ = initial_RTO_ms_;
 }

--- a/src/tcp_sender.cc
+++ b/src/tcp_sender.cc
@@ -18,81 +18,85 @@ uint64_t TCPSender::consecutive_retransmissions() const
 }
 
 void TCPSender::push_packet(uint64_t size, TCPSenderMessage &cur_message, const TransmitFunction& transmit, bool rst, bool can_add_fin_bit) {
-  string_view bytestream_state = input_.reader().peek();
-  
+  // Adding SYN Flag is first priority; update size after
   cur_message.SYN = last_segment_sent_ == 0;
   if (cur_message.SYN && size != 0) {
     size--;
   }
   
-  // seqno -> bytes popped from stream
+  // Compute Seqno
   cur_message.seqno = Wrap32::wrap(last_segment_sent_, isn_);
+
+  // Add Fin Flag
   if (can_add_fin_bit) {
     cur_message.FIN = true;
     sent_fin_bit = true;
     size = min(size, size - 1);
   }
-  cur_message.payload = bytestream_state.substr(0, size);
+  // Add Payload; Update input_ Byte Stream
+  cur_message.payload = input_.reader().peek().substr(0, size);
   input_.reader().pop(size);
   
+  // Add RST Flag + Transmit
   cur_message.RST = rst;
   transmit(cur_message);
 
-  // if (!false_window) {
-    // add to dictionary - assuming passing by value here
-    outstanding_segments[last_segment_sent_] = cur_message;
-    last_segment_sent_ += cur_message.sequence_length();
-    bytes_outstanding += cur_message.sequence_length();
-    if (!rto_timer_is_on_) {
-      set_rto_alarm();
-    }
-  // }
+  // Update State + Timer
+  outstanding_segments[last_segment_sent_] = cur_message;
+  last_segment_sent_ += cur_message.sequence_length();
+  bytes_outstanding += cur_message.sequence_length();
+  if (!rto_timer_is_on_) {
+    set_rto_alarm();
+  }
 }
 
 void TCPSender::push( const TransmitFunction& transmit )
 {
   TCPSenderMessage cur_message;
 
-  // check for RST Flag -> push RST packet
+  // Edge Case: If RST Flag has been raised transmit RST Packet
   if (RST || input_.has_error()) {
     push_packet(0, cur_message, transmit, RST || input_.has_error(), false);
     return;
   }
 
-  // send just SYN Flag if sender is reaching out first
+  // Edge Case: Send just the SYN Flag only when Sender reaches out to Peer first
   if ( input_.reader().bytes_buffered() == 0 && !connection_started ) {
     push_packet(0, cur_message, transmit, false, input_.writer().is_closed());
     return;
   }
 
-  //size_t empty_message_size = cur_message.sequence_length();
-  // if window_size is 0 and this is not the first message, always send a packet of size one to recieve new window size information
+  // Edge Case: If Window Size is 0 send 1 byte packet to recieve new window
   if (window_size == 0 && connection_started) {
-     if (!bytes_outstanding) {
+     if (!bytes_outstanding) { // Check for outstanding packets (ie. if Sender sent a 1 Byte Packet previously already)
       push_packet(1, cur_message, transmit, false, input_.reader().is_finished());
      }
     return;
   }
 
-  // otherwise, transmit as big of a message as you can
-  size_t curr_space_in_connection = window_size - bytes_outstanding; // 7 bytes of non-payload info
+  // Compute Constant to construct largest TCP Message Possible
+  size_t curr_space_in_connection = window_size - bytes_outstanding; 
+  // Payload Size is the min between the MAX_PAYLOAD_SIZE, Current Space in the Connection, and the Number of Bytes Buffered in input_
   size_t payload_size = min(min(TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection), input_.reader().bytes_buffered());
-  bool can_add_syn_bit = last_segment_sent_ == 0 && curr_space_in_connection - payload_size;
-  //payload_size += can_add_syn_bit;
-  bool can_add_fin_bit = (input_.writer().is_closed() && payload_size >= input_.reader().bytes_buffered() && !sent_fin_bit); // can add if BS is closed + all bytes will fit
-  can_add_fin_bit = (can_add_fin_bit && curr_space_in_connection - payload_size); // Check for space in window
-  //payload_size += can_add_fin_bit;
+
+  // Determine if SYN/FIN flags should be raised
+  bool can_add_syn_bit = last_segment_sent_ == 0;
+  bool can_add_fin_bit = (input_.writer().is_closed() && payload_size >= input_.reader().bytes_buffered() && !sent_fin_bit); 
+  
+  // Check if there is space in connection for SYN/FIN
+  can_add_syn_bit = can_add_syn_bit && curr_space_in_connection - payload_size;
+  can_add_fin_bit = can_add_fin_bit && curr_space_in_connection - payload_size;
   
 
-  // assuming window_size is bytes free in the bytestream; if less then 7 bytes if available cannot create a TCPMessage
-  // TODO: figure out how to add FIN/SYN flag status to input.reader().size
+  // While there is space in the connection && we have bytes we need to send
   while (curr_space_in_connection > 0 && payload_size + (can_add_fin_bit && !sent_fin_bit) > 0) {
-    // Re-evaluate the vars that could change after a packet is pushed
-    can_add_fin_bit = (input_.writer().is_closed() && payload_size >= input_.reader().bytes_buffered() && !sent_fin_bit); // can add if BS is closed + all bytes will fit
+    // Re-evaluate the variables that could change after a packet is pushed (an iteration of the while loop passes)
+    can_add_fin_bit = (input_.writer().is_closed() && payload_size >= input_.reader().bytes_buffered() && !sent_fin_bit); 
     can_add_fin_bit = (can_add_fin_bit && curr_space_in_connection - payload_size);
+    // Final Payload Size = Payload Size + Additional Flag Bits
     size_t overall_size = payload_size + can_add_fin_bit + can_add_syn_bit;
     push_packet(overall_size, cur_message, transmit, false, can_add_fin_bit);
-    // Re-evaluate the vars that could change after a packet is pushed
+    // Re-evaluate the variables that could change after a packet is pushed (an iteration of the while loop passes)
     curr_space_in_connection = window_size - bytes_outstanding;
     payload_size = min(min(TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection), input_.reader().bytes_buffered());
     can_add_fin_bit = (input_.writer().is_closed() && input_.reader().bytes_buffered() < curr_space_in_connection && !sent_fin_bit);
@@ -112,47 +116,43 @@ Goal of this function is to find the ackno of the first byte of the first, unack
 The first unackno. segment is always the key before, a key k s.t. k > msg_ackno.
 */
 void TCPSender::update_last_segment_recieved_and_clean(uint64_t msg_ackno) {
+  // Loop through outstanding_segments and remove stored segments that have been acknowledged
   auto it = outstanding_segments.begin();
   while (it != outstanding_segments.end()) {
+    // If this key is not acknowledged by msg_ackno, break
     if (it->first >= msg_ackno) {
         break;
     }
-    // decrement bytes_outstanding and clean map if we have ackno'd all the bytes
+    // If: Segment has been completely acknowledged by the peer
     if (it->first + it->second.sequence_length() <= msg_ackno) {
       bytes_outstanding = last_segment_sent_ - msg_ackno;
       last_segment_recieved_ += it->second.sequence_length();
       it = outstanding_segments.erase(it);  // erase returns next valid iterator
     } else {
-      // Update Outstanding Bytes for a partial segment recognition
+      // Else: Update Outstanding Bytes for a partial segment recognition
       bytes_outstanding = last_segment_sent_ - msg_ackno;
       ++it;
     }
   }
-  // decrement bytes_outstanding
-  bytes_outstanding = last_segment_sent_ - msg_ackno;
-
 }
 
 void TCPSender::receive( const TCPReceiverMessage& msg )
 {
+  // Check RST Flag + Update Window
   RST = msg.RST || input_.has_error();
   window_size = msg.window_size;
   if (RST) {
     input_.set_error();
   }
-  
-  // if the msg has no value, skip it
+  // If the message has no other value, skip it
   if (!msg.ackno.has_value()) {
     return;
   }
-
-  // TODO: Clean collection of outstanding segments; add below to a helper function under RTO + decrement bytes_outstanding
+  // Update State
   connection_started = true;
   
-  
-
   uint64_t msg_ackno = msg.ackno.value().unwrap(isn_, last_segment_recieved_);
-  // check for impossible msg_ackno
+  // Check for an impossible ackno (greater then what we have sent)
   if (msg_ackno > last_segment_sent_) {
     return;
   }
@@ -163,35 +163,26 @@ void TCPSender::receive( const TCPReceiverMessage& msg )
     update_last_segment_recieved_and_clean(msg_ackno);
     return;
   }
-
-  // RTO Timer: If we confirm receipt of new data
+  // RTO Timer: If we confirm receipt of new data, update state + alarm
   if (last_segment_recieved_ < msg_ackno) {
     last_ackno_received = msg_ackno;
     update_last_segment_recieved_and_clean(msg_ackno);
     stop_rto_alarm();
-
-    // If there is outstanding data leftover -> set_RTO_alarm + reset consec retransmissions
+    // If there is outstanding data leftover -> set_RTO_alarm() + reset consecutive retransmission count
     if (last_segment_recieved_ <= last_segment_sent_) {
       set_rto_alarm();
     }
-    // Else: all outstanding data has been acknowledged
   }
 }
 
 void TCPSender::tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit )
 {
-  /*
-  If RTO Timer is expired:
-      Retransmit the earlist segement not acknowledged
-      If window_size is nonzero
-        keep track of consec retransmissions and increment
-        double value of curr_rto_
-      Reset RTO Timer
-  */  
+  // Check RTO Timer
   if (check_rto_alarm(ms_since_last_tick)) {
+      // Retransmit Segment
       TCPSenderMessage retransmit_msg = outstanding_segments[last_segment_recieved_];
       transmit(retransmit_msg);
-      // update RTO and start new aalarm
+      // Update Consecutive RTO Count
       if (window_size != 0) {
         curr_RTO_ms_ *= 2;
       }
@@ -205,17 +196,17 @@ void TCPSender::set_rto_alarm() {
 }
 
 bool TCPSender::check_rto_alarm( uint64_t ms_since_last_tick ) {
-  // return false if timer is off
+  // Return False if timer is off
   if (!rto_timer_is_on_) {
     return false;
   }
-  // check for expired timer
+  // Check for expired timer
   if (ms_since_last_tick >= rto_timer_ttl_) {
     rto_timer_ttl_ = 0;
     rto_timer_is_on_ = false;
     return true;
   }
-  // update tick + return false
+  // Update tick + return false
   rto_timer_ttl_ -= ms_since_last_tick;
   return false;
 }

--- a/src/tcp_sender.cc
+++ b/src/tcp_sender.cc
@@ -1,7 +1,7 @@
 #include "tcp_sender.hh"
+#include "cmath"
 #include "debug.hh"
 #include "tcp_config.hh"
-#include "cmath"
 
 using namespace std;
 
@@ -14,38 +14,43 @@ uint64_t TCPSender::sequence_numbers_in_flight() const
 // This function is for testing only; don't add extra state to support it.
 uint64_t TCPSender::consecutive_retransmissions() const
 {
-  return log2( curr_RTO_ms_ / initial_RTO_ms_);
+  return log2( curr_RTO_ms_ / initial_RTO_ms_ );
 }
 
-void TCPSender::push_packet(uint64_t size, TCPSenderMessage &cur_message, const TransmitFunction& transmit, bool rst, bool can_add_fin_bit) {
+void TCPSender::push_packet( uint64_t size,
+                             TCPSenderMessage& cur_message,
+                             const TransmitFunction& transmit,
+                             bool rst,
+                             bool can_add_fin_bit )
+{
   // Adding SYN Flag is first priority; update size after
   cur_message.SYN = last_segment_sent_ == 0;
-  if (cur_message.SYN && size != 0) {
+  if ( cur_message.SYN && size != 0 ) {
     size--;
   }
-  
+
   // Compute Seqno
-  cur_message.seqno = Wrap32::wrap(last_segment_sent_, isn_);
+  cur_message.seqno = Wrap32::wrap( last_segment_sent_, isn_ );
 
   // Add Fin Flag
-  if (can_add_fin_bit) {
+  if ( can_add_fin_bit ) {
     cur_message.FIN = true;
     sent_fin_bit = true;
-    size = min(size, size - 1);
+    size = min( size, size - 1 );
   }
   // Add Payload; Update input_ Byte Stream
-  cur_message.payload = input_.reader().peek().substr(0, size);
-  input_.reader().pop(size);
-  
+  cur_message.payload = input_.reader().peek().substr( 0, size );
+  input_.reader().pop( size );
+
   // Add RST Flag + Transmit
   cur_message.RST = rst;
-  transmit(cur_message);
+  transmit( cur_message );
 
   // Update State + Timer
   outstanding_segments[last_segment_sent_] = cur_message;
   last_segment_sent_ += cur_message.sequence_length();
   bytes_outstanding += cur_message.sequence_length();
-  if (!rto_timer_is_on_) {
+  if ( !rto_timer_is_on_ ) {
     set_rto_alarm();
   }
 }
@@ -55,58 +60,64 @@ void TCPSender::push( const TransmitFunction& transmit )
   TCPSenderMessage cur_message;
 
   // Edge Case: If RST Flag has been raised transmit RST Packet
-  if (RST || input_.has_error()) {
-    push_packet(0, cur_message, transmit, RST || input_.has_error(), false);
+  if ( RST || input_.has_error() ) {
+    push_packet( 0, cur_message, transmit, RST || input_.has_error(), false );
     return;
   }
 
   // Edge Case: Send just the SYN Flag only when Sender reaches out to Peer first
   if ( input_.reader().bytes_buffered() == 0 && !connection_started ) {
-    push_packet(0, cur_message, transmit, false, input_.writer().is_closed());
+    push_packet( 0, cur_message, transmit, false, input_.writer().is_closed() );
     return;
   }
 
   // Edge Case: If Window Size is 0 send 1 byte packet to recieve new window
-  if (window_size == 0 && connection_started) {
-     if (!bytes_outstanding) { // Check for outstanding packets (ie. if Sender sent a 1 Byte Packet previously already)
-      push_packet(1, cur_message, transmit, false, input_.reader().is_finished());
-     }
+  if ( window_size == 0 && connection_started ) {
+    if ( !bytes_outstanding ) { // Check for outstanding packets (ie. if Sender sent a 1 Byte Packet previously
+                                // already)
+      push_packet( 1, cur_message, transmit, false, input_.reader().is_finished() );
+    }
     return;
   }
 
   // Compute Constant to construct largest TCP Message Possible
-  size_t curr_space_in_connection = window_size - bytes_outstanding; 
-  // Payload Size is the min between the MAX_PAYLOAD_SIZE, Current Space in the Connection, and the Number of Bytes Buffered in input_
-  size_t payload_size = min(min(TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection), input_.reader().bytes_buffered());
+  size_t curr_space_in_connection = window_size - bytes_outstanding;
+  // Payload Size is the min between the MAX_PAYLOAD_SIZE, Current Space in the Connection, and the Number of Bytes
+  // Buffered in input_
+  size_t payload_size
+    = min( min( TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection ), input_.reader().bytes_buffered() );
 
   // Determine if SYN/FIN flags should be raised
   bool can_add_syn_bit = last_segment_sent_ == 0;
-  bool can_add_fin_bit = (input_.writer().is_closed() && payload_size >= input_.reader().bytes_buffered() && !sent_fin_bit); 
-  
+  bool can_add_fin_bit
+    = ( input_.writer().is_closed() && payload_size >= input_.reader().bytes_buffered() && !sent_fin_bit );
+
   // Check if there is space in connection for SYN/FIN
   can_add_syn_bit = can_add_syn_bit && curr_space_in_connection - payload_size;
   can_add_fin_bit = can_add_fin_bit && curr_space_in_connection - payload_size;
-  
 
   // While there is space in the connection && we have bytes we need to send
-  while (curr_space_in_connection > 0 && payload_size + (can_add_fin_bit && !sent_fin_bit) > 0) {
+  while ( curr_space_in_connection > 0 && payload_size + ( can_add_fin_bit && !sent_fin_bit ) > 0 ) {
     // Re-evaluate the variables that could change after a packet is pushed (an iteration of the while loop passes)
-    can_add_fin_bit = (input_.writer().is_closed() && payload_size >= input_.reader().bytes_buffered() && !sent_fin_bit); 
-    can_add_fin_bit = (can_add_fin_bit && curr_space_in_connection - payload_size);
+    can_add_fin_bit
+      = ( input_.writer().is_closed() && payload_size >= input_.reader().bytes_buffered() && !sent_fin_bit );
+    can_add_fin_bit = ( can_add_fin_bit && curr_space_in_connection - payload_size );
     // Final Payload Size = Payload Size + Additional Flag Bits
     size_t overall_size = payload_size + can_add_fin_bit + can_add_syn_bit;
-    push_packet(overall_size, cur_message, transmit, false, can_add_fin_bit);
+    push_packet( overall_size, cur_message, transmit, false, can_add_fin_bit );
     // Re-evaluate the variables that could change after a packet is pushed (an iteration of the while loop passes)
     curr_space_in_connection = window_size - bytes_outstanding;
-    payload_size = min(min(TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection), input_.reader().bytes_buffered());
-    can_add_fin_bit = (input_.writer().is_closed() && input_.reader().bytes_buffered() < curr_space_in_connection && !sent_fin_bit);
+    payload_size
+      = min( min( TCPConfig::MAX_PAYLOAD_SIZE, curr_space_in_connection ), input_.reader().bytes_buffered() );
+    can_add_fin_bit = ( input_.writer().is_closed() && input_.reader().bytes_buffered() < curr_space_in_connection
+                        && !sent_fin_bit );
   }
 }
 
 TCPSenderMessage TCPSender::make_empty_message() const
 {
   TCPSenderMessage cur_message;
-  cur_message.seqno = Wrap32::wrap(last_segment_sent_, isn_);
+  cur_message.seqno = Wrap32::wrap( last_segment_sent_, isn_ );
   cur_message.RST = RST || input_.has_error();
   return cur_message;
 }
@@ -115,19 +126,20 @@ TCPSenderMessage TCPSender::make_empty_message() const
 Goal of this function is to find the ackno of the first byte of the first, unacknowledged segment.
 The first unackno. segment is always the key before, a key k s.t. k > msg_ackno.
 */
-void TCPSender::update_last_segment_recieved_and_clean(uint64_t msg_ackno) {
+void TCPSender::update_last_segment_recieved_and_clean( uint64_t msg_ackno )
+{
   // Loop through outstanding_segments and remove stored segments that have been acknowledged
   auto it = outstanding_segments.begin();
-  while (it != outstanding_segments.end()) {
+  while ( it != outstanding_segments.end() ) {
     // If this key is not acknowledged by msg_ackno, break
-    if (it->first >= msg_ackno) {
-        break;
+    if ( it->first >= msg_ackno ) {
+      break;
     }
     // If: Segment has been completely acknowledged by the peer
-    if (it->first + it->second.sequence_length() <= msg_ackno) {
+    if ( it->first + it->second.sequence_length() <= msg_ackno ) {
       bytes_outstanding = last_segment_sent_ - msg_ackno;
       last_segment_recieved_ += it->second.sequence_length();
-      it = outstanding_segments.erase(it);  // erase returns next valid iterator
+      it = outstanding_segments.erase( it ); // erase returns next valid iterator
     } else {
       // Else: Update Outstanding Bytes for a partial segment recognition
       bytes_outstanding = last_segment_sent_ - msg_ackno;
@@ -141,35 +153,35 @@ void TCPSender::receive( const TCPReceiverMessage& msg )
   // Check RST Flag + Update Window
   RST = msg.RST || input_.has_error();
   window_size = msg.window_size;
-  if (RST) {
+  if ( RST ) {
     input_.set_error();
   }
   // If the message has no other value, skip it
-  if (!msg.ackno.has_value()) {
+  if ( !msg.ackno.has_value() ) {
     return;
   }
   // Update State
   connection_started = true;
-  
-  uint64_t msg_ackno = msg.ackno.value().unwrap(isn_, last_segment_recieved_);
+
+  uint64_t msg_ackno = msg.ackno.value().unwrap( isn_, last_segment_recieved_ );
   // Check for an impossible ackno (greater then what we have sent)
-  if (msg_ackno > last_segment_sent_) {
+  if ( msg_ackno > last_segment_sent_ ) {
     return;
   }
   // RTO Timer: If all outstanding data has been acknowledged stop the retransmission timer
-  if (last_segment_recieved_ <= msg_ackno && msg_ackno == last_segment_sent_) {
+  if ( last_segment_recieved_ <= msg_ackno && msg_ackno == last_segment_sent_ ) {
     last_ackno_received = msg_ackno;
     stop_rto_alarm();
-    update_last_segment_recieved_and_clean(msg_ackno);
+    update_last_segment_recieved_and_clean( msg_ackno );
     return;
   }
   // RTO Timer: If we confirm receipt of new data, update state + alarm
-  if (last_segment_recieved_ < msg_ackno) {
+  if ( last_segment_recieved_ < msg_ackno ) {
     last_ackno_received = msg_ackno;
-    update_last_segment_recieved_and_clean(msg_ackno);
+    update_last_segment_recieved_and_clean( msg_ackno );
     stop_rto_alarm();
     // If there is outstanding data leftover -> set_RTO_alarm() + reset consecutive retransmission count
-    if (last_segment_recieved_ <= last_segment_sent_) {
+    if ( last_segment_recieved_ <= last_segment_sent_ ) {
       set_rto_alarm();
     }
   }
@@ -178,30 +190,32 @@ void TCPSender::receive( const TCPReceiverMessage& msg )
 void TCPSender::tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit )
 {
   // Check RTO Timer
-  if (check_rto_alarm(ms_since_last_tick)) {
-      // Retransmit Segment
-      TCPSenderMessage retransmit_msg = outstanding_segments[last_segment_recieved_];
-      transmit(retransmit_msg);
-      // Update Consecutive RTO Count
-      if (window_size != 0) {
-        curr_RTO_ms_ *= 2;
-      }
-      set_rto_alarm();
+  if ( check_rto_alarm( ms_since_last_tick ) ) {
+    // Retransmit Segment
+    TCPSenderMessage retransmit_msg = outstanding_segments[last_segment_recieved_];
+    transmit( retransmit_msg );
+    // Update Consecutive RTO Count
+    if ( window_size != 0 ) {
+      curr_RTO_ms_ *= 2;
+    }
+    set_rto_alarm();
   }
 }
 
-void TCPSender::set_rto_alarm() {
+void TCPSender::set_rto_alarm()
+{
   rto_timer_is_on_ = true;
   rto_timer_ttl_ = curr_RTO_ms_;
 }
 
-bool TCPSender::check_rto_alarm( uint64_t ms_since_last_tick ) {
+bool TCPSender::check_rto_alarm( uint64_t ms_since_last_tick )
+{
   // Return False if timer is off
-  if (!rto_timer_is_on_) {
+  if ( !rto_timer_is_on_ ) {
     return false;
   }
   // Check for expired timer
-  if (ms_since_last_tick >= rto_timer_ttl_) {
+  if ( ms_since_last_tick >= rto_timer_ttl_ ) {
     rto_timer_ttl_ = 0;
     rto_timer_is_on_ = false;
     return true;
@@ -211,7 +225,8 @@ bool TCPSender::check_rto_alarm( uint64_t ms_since_last_tick ) {
   return false;
 }
 
-void TCPSender::stop_rto_alarm() {
+void TCPSender::stop_rto_alarm()
+{
   rto_timer_is_on_ = false;
   curr_RTO_ms_ = initial_RTO_ms_;
 }

--- a/src/tcp_sender.hh
+++ b/src/tcp_sender.hh
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "byte_stream.hh"
+#include "tcp_receiver_message.hh"
+#include "tcp_sender_message.hh"
+
+#include <functional>
+
+class TCPSender
+{
+public:
+  /* Construct TCP sender with given default Retransmission Timeout and possible ISN */
+  TCPSender( ByteStream&& input, Wrap32 isn, uint64_t initial_RTO_ms )
+    : input_( std::move( input ) ), isn_( isn ), initial_RTO_ms_( initial_RTO_ms )
+  {}
+
+  /* Generate an empty TCPSenderMessage */
+  TCPSenderMessage make_empty_message() const;
+
+  /* Receive and process a TCPReceiverMessage from the peer's receiver */
+  void receive( const TCPReceiverMessage& msg );
+
+  /* Type of the `transmit` function that the push and tick methods can use to send messages */
+  using TransmitFunction = std::function<void( const TCPSenderMessage& )>;
+
+  /* Push bytes from the outbound stream */
+  void push( const TransmitFunction& transmit );
+
+  /* Time has passed by the given # of milliseconds since the last time the tick() method was called */
+  void tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit );
+
+  // Accessors
+  uint64_t sequence_numbers_in_flight() const;  // For testing: how many sequence numbers are outstanding?
+  uint64_t consecutive_retransmissions() const; // For testing: how many consecutive retransmissions have happened?
+  const Writer& writer() const { return input_.writer(); }
+  const Reader& reader() const { return input_.reader(); }
+  Writer& writer() { return input_.writer(); }
+
+private:
+  Reader& reader() { return input_.reader(); }
+
+  ByteStream input_;
+  Wrap32 isn_;
+  uint64_t initial_RTO_ms_;
+};

--- a/src/tcp_sender.hh
+++ b/src/tcp_sender.hh
@@ -11,7 +11,7 @@ class TCPSender
 public:
   /* Construct TCP sender with given default Retransmission Timeout and possible ISN */
   TCPSender( ByteStream&& input, Wrap32 isn, uint64_t initial_RTO_ms )
-    : input_( std::move( input ) ), isn_( isn ), initial_RTO_ms_( initial_RTO_ms )
+    : input_( std::move( input ) ), isn_( isn ), initial_RTO_ms_( initial_RTO_ms ), curr_RTO_ms_( initial_RTO_ms )
   {}
 
   /* Generate an empty TCPSenderMessage */
@@ -29,6 +29,15 @@ public:
   /* Time has passed by the given # of milliseconds since the last time the tick() method was called */
   void tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit );
 
+  /* Set the Retransmission timer alarm, generally references RTO value */
+  void set_rto_alarm();
+
+  /* Check the existing Retransmission timer alarm given time since last tick information, returns true if timer has expired, false otherwise */
+  bool check_rto_alarm( uint64_t ms_since_last_tick );
+
+  /* Stop the RTO alarm if all outstanding data has been acknowledged */
+  void stop_rto_alarm();
+
   // Accessors
   uint64_t sequence_numbers_in_flight() const;  // For testing: how many sequence numbers are outstanding?
   uint64_t consecutive_retransmissions() const; // For testing: how many consecutive retransmissions have happened?
@@ -42,4 +51,15 @@ private:
   ByteStream input_;
   Wrap32 isn_;
   uint64_t initial_RTO_ms_;
+  uint64_t curr_RTO_ms_;
+
+  // state for tcp_sender
+  uint64_t expected_ackno_ = 0;
+  uint64_t last_segment_sent_ = 0;
+  unordered_map<uint64_t, TCPSenderMessage> outstanding_segments = {};
+
+
+  // state(s) for retransimission timer; only used in rto_timer_functions
+  bool rto_timer_is_on_ = false;
+  uint64_t rto_timer_ttl_ = 0;
 };

--- a/src/tcp_sender.hh
+++ b/src/tcp_sender.hh
@@ -30,8 +30,6 @@ public:
   /* Time has passed by the given # of milliseconds since the last time the tick() method was called */
   void tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit );
 
-
-
   // Accessors
   uint64_t sequence_numbers_in_flight() const;  // For testing: how many sequence numbers are outstanding?
   uint64_t consecutive_retransmissions() const; // For testing: how many consecutive retransmissions have happened?
@@ -42,20 +40,25 @@ public:
 private:
   Reader& reader() { return input_.reader(); }
 
-    /* Set the Retransmission timer alarm, generally references RTO value */
+  /* Set the Retransmission timer alarm, generally references RTO value */
   void set_rto_alarm();
 
-  /* Check the existing Retransmission timer alarm given time since last tick information, returns true if timer has expired, false otherwise */
+  /* Check the existing Retransmission timer alarm given time since last tick information, returns true if timer has
+   * expired, false otherwise */
   bool check_rto_alarm( uint64_t ms_since_last_tick );
 
   /* Stop the RTO alarm if all outstanding data has been acknowledged */
   void stop_rto_alarm();
 
   /* Push Packet of given # of Bytes*/
-  void push_packet(uint64_t size, TCPSenderMessage &cur_message, const TransmitFunction& transmit, bool false_window, bool add_fin_bit);
+  void push_packet( uint64_t size,
+                    TCPSenderMessage& cur_message,
+                    const TransmitFunction& transmit,
+                    bool false_window,
+                    bool add_fin_bit );
 
   // update the expected ackno to the first, segment to which we have not recieved a reply; also cleans map
-  void update_last_segment_recieved_and_clean(uint64_t msg_ackno);
+  void update_last_segment_recieved_and_clean( uint64_t msg_ackno );
 
   ByteStream input_;
   Wrap32 isn_;
@@ -74,7 +77,6 @@ private:
   bool connection_started = false;
   bool sent_fin_bit = false;
   bool RST = false;
-  
 
   // state(s) for retransimission timer; only used in rto_timer_functions
   bool rto_timer_is_on_ = false;

--- a/src/tcp_sender.hh
+++ b/src/tcp_sender.hh
@@ -62,7 +62,7 @@ private:
   uint64_t initial_RTO_ms_;
   uint64_t curr_RTO_ms_;
 
-  // state for tcp_sender
+  // State for TCP_Sender
   uint64_t last_segment_recieved_ = 0;
   uint64_t last_ackno_received = 0;
   uint64_t last_segment_sent_ = 0;

--- a/src/tcp_sender.hh
+++ b/src/tcp_sender.hh
@@ -52,10 +52,10 @@ private:
   void stop_rto_alarm();
 
   /* Push Packet of given # of Bytes*/
-  void push_packet(uint64_t size, TCPSenderMessage &cur_message, const TransmitFunction& transmit, bool false_window);
+  void push_packet(uint64_t size, TCPSenderMessage &cur_message, const TransmitFunction& transmit, bool false_window, bool add_fin_bit);
 
   // update the expected ackno to the first, segment to which we have not recieved a reply; also cleans map
-  void update_expected_ackno_and_clean(uint64_t msg_ackno);
+  void update_last_segment_recieved_and_clean(uint64_t msg_ackno);
 
   ByteStream input_;
   Wrap32 isn_;
@@ -63,7 +63,8 @@ private:
   uint64_t curr_RTO_ms_;
 
   // state for tcp_sender
-  uint64_t expected_ackno_ = 0;
+  uint64_t last_segment_recieved_ = 0;
+  uint64_t last_ackno_received = 0;
   uint64_t last_segment_sent_ = 0;
   std::map<uint64_t, TCPSenderMessage> outstanding_segments = {};
   uint64_t bytes_outstanding = 0;
@@ -71,8 +72,9 @@ private:
   // window size defaults to 0 to start a simple packet process to receive true window_size
   uint64_t window_size = 1;
   bool connection_started = false;
+  bool sent_fin_bit = false;
+  bool RST = false;
   
-
 
   // state(s) for retransimission timer; only used in rto_timer_functions
   bool rto_timer_is_on_ = false;

--- a/src/wrapping_integers.cc
+++ b/src/wrapping_integers.cc
@@ -1,0 +1,18 @@
+#include "wrapping_integers.hh"
+#include "debug.hh"
+
+using namespace std;
+
+Wrap32 Wrap32::wrap( uint64_t n, Wrap32 zero_point )
+{
+  // Your code here.
+  debug( "unimplemented wrap( {}, {} ) called", n, zero_point.raw_value_ );
+  return Wrap32 { 0 };
+}
+
+uint64_t Wrap32::unwrap( Wrap32 zero_point, uint64_t checkpoint ) const
+{
+  // Your code here.
+  debug( "unimplemented unwrap( {}, {} ) called", zero_point.raw_value_, checkpoint );
+  return {};
+}

--- a/src/wrapping_integers.cc
+++ b/src/wrapping_integers.cc
@@ -9,16 +9,24 @@ Wrap32 Wrap32::wrap( uint64_t n, Wrap32 zero_point )
   return Wrap32{static_cast<uint32_t>(zero_point.raw_value_ + (n & ((1ULL << 32) - 1)))};;
 }
 
+/*
+Uses the provided helper function to convert checkpoint to a wrapp
+and then calculate the distance from our main object. Using this distance
+create two more wraps, plus/minus the distance from checkpoint, and check which one 
+is our original object
+*/
 uint64_t Wrap32::unwrap( Wrap32 zero_point, uint64_t checkpoint ) const
 {
   // wrap the checkpoint
   Wrap32 c_point = Wrap32::wrap(checkpoint, zero_point);
-  // abs value logic
+  // find the distance from checkpoint to this->object
   uint32_t diff = (c_point.raw_value_ - this->raw_value_ < this->raw_value_ - c_point.raw_value_)
                 ? (c_point.raw_value_ - this->raw_value_)
                 : (this->raw_value_ - c_point.raw_value_);
   
+  // check uint64_t values +/- diff away from checkpoint and return
   uint64_t tmp = checkpoint + diff;
+  // protect against rounding error
   uint64_t tmp_sub = (checkpoint < diff) ? ((uint32_t)checkpoint - diff) : checkpoint - diff;
 
   if (Wrap32::wrap(tmp, zero_point) == *this) 

--- a/src/wrapping_integers.cc
+++ b/src/wrapping_integers.cc
@@ -5,14 +5,25 @@ using namespace std;
 
 Wrap32 Wrap32::wrap( uint64_t n, Wrap32 zero_point )
 {
-  // Your code here.
-  debug( "unimplemented wrap( {}, {} ) called", n, zero_point.raw_value_ );
-  return Wrap32 { 0 };
+  // ISN + zero_point % 2^32
+  return Wrap32{static_cast<uint32_t>(zero_point.raw_value_ + (n & ((1ULL << 32) - 1)))};;
 }
 
 uint64_t Wrap32::unwrap( Wrap32 zero_point, uint64_t checkpoint ) const
 {
-  // Your code here.
-  debug( "unimplemented unwrap( {}, {} ) called", zero_point.raw_value_, checkpoint );
-  return {};
+  // wrap the checkpoint
+  Wrap32 c_point = Wrap32::wrap(checkpoint, zero_point);
+  // abs value logic
+  uint32_t diff = (c_point.raw_value_ - this->raw_value_ < this->raw_value_ - c_point.raw_value_)
+                ? (c_point.raw_value_ - this->raw_value_)
+                : (this->raw_value_ - c_point.raw_value_);
+  
+  uint64_t tmp = checkpoint + diff;
+  uint64_t tmp_sub = (checkpoint < diff) ? ((uint32_t)checkpoint - diff) : checkpoint - diff;
+
+  if (Wrap32::wrap(tmp, zero_point) == *this) 
+    return tmp;
+  if (Wrap32::wrap(tmp_sub, zero_point) == *this) 
+    return tmp_sub;
+  return 0;
 }

--- a/src/wrapping_integers.cc
+++ b/src/wrapping_integers.cc
@@ -6,32 +6,33 @@ using namespace std;
 Wrap32 Wrap32::wrap( uint64_t n, Wrap32 zero_point )
 {
   // ISN + zero_point % 2^32
-  return Wrap32{static_cast<uint32_t>(zero_point.raw_value_ + (n & ((1ULL << 32) - 1)))};;
+  return Wrap32 { static_cast<uint32_t>( zero_point.raw_value_ + ( n & ( ( 1ULL << 32 ) - 1 ) ) ) };
+  ;
 }
 
 /*
 Uses the provided helper function to convert checkpoint to a wrapp
 and then calculate the distance from our main object. Using this distance
-create two more wraps, plus/minus the distance from checkpoint, and check which one 
+create two more wraps, plus/minus the distance from checkpoint, and check which one
 is our original object
 */
 uint64_t Wrap32::unwrap( Wrap32 zero_point, uint64_t checkpoint ) const
 {
   // wrap the checkpoint
-  Wrap32 c_point = Wrap32::wrap(checkpoint, zero_point);
+  Wrap32 c_point = Wrap32::wrap( checkpoint, zero_point );
   // find the distance from checkpoint to this->object
-  uint32_t diff = (c_point.raw_value_ - this->raw_value_ < this->raw_value_ - c_point.raw_value_)
-                ? (c_point.raw_value_ - this->raw_value_)
-                : (this->raw_value_ - c_point.raw_value_);
-  
+  uint32_t diff = ( c_point.raw_value_ - this->raw_value_ < this->raw_value_ - c_point.raw_value_ )
+                    ? ( c_point.raw_value_ - this->raw_value_ )
+                    : ( this->raw_value_ - c_point.raw_value_ );
+
   // check uint64_t values +/- diff away from checkpoint and return
   uint64_t tmp = checkpoint + diff;
   // protect against rounding error
-  uint64_t tmp_sub = (checkpoint < diff) ? ((uint32_t)checkpoint - diff) : checkpoint - diff;
+  uint64_t tmp_sub = ( checkpoint < diff ) ? ( (uint32_t)checkpoint - diff ) : checkpoint - diff;
 
-  if (Wrap32::wrap(tmp, zero_point) == *this) 
+  if ( Wrap32::wrap( tmp, zero_point ) == *this )
     return tmp;
-  if (Wrap32::wrap(tmp_sub, zero_point) == *this) 
+  if ( Wrap32::wrap( tmp_sub, zero_point ) == *this )
     return tmp_sub;
   return 0;
 }

--- a/src/wrapping_integers.hh
+++ b/src/wrapping_integers.hh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+
+/*
+ * The Wrap32 type represents a 32-bit unsigned integer that:
+ *    - starts at an arbitrary "zero point" (initial value), and
+ *    - wraps back to zero when it reaches 2^32 - 1.
+ */
+
+class Wrap32
+{
+public:
+  explicit Wrap32( uint32_t raw_value ) : raw_value_( raw_value ) {}
+
+  /* Construct a Wrap32 given an absolute sequence number n and the zero point. */
+  static Wrap32 wrap( uint64_t n, Wrap32 zero_point );
+
+  /*
+   * The unwrap method returns an absolute sequence number that wraps to this Wrap32, given the zero point
+   * and a "checkpoint": another absolute sequence number near the desired answer.
+   *
+   * There are many possible absolute sequence numbers that all wrap to the same Wrap32.
+   * The unwrap method should return the one that is closest to the checkpoint.
+   */
+  uint64_t unwrap( Wrap32 zero_point, uint64_t checkpoint ) const;
+
+  Wrap32 operator+( uint32_t n ) const { return Wrap32 { raw_value_ + n }; }
+  bool operator==( const Wrap32& other ) const { return raw_value_ == other.raw_value_; }
+
+protected:
+  uint32_t raw_value_ {};
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,14 @@ add_test_exec(recv_reorder_more)
 add_test_exec(recv_close)
 add_test_exec(recv_special)
 
+add_test_exec(send_connect)
+add_test_exec(send_transmit)
+add_test_exec(send_window)
+add_test_exec(send_ack)
+add_test_exec(send_close)
+add_test_exec(send_retx)
+add_test_exec(send_extra)
+
 add_test_exec(no_skip)
 
 add_speed_test(byte_stream_speed_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,20 @@ add_test_exec(reassembler_holes)
 add_test_exec(reassembler_overlapping)
 add_test_exec(reassembler_win)
 
+add_test_exec(wrapping_integers_cmp)
+add_test_exec(wrapping_integers_wrap)
+add_test_exec(wrapping_integers_unwrap)
+add_test_exec(wrapping_integers_roundtrip)
+add_test_exec(wrapping_integers_extra)
+
+add_test_exec(recv_connect)
+add_test_exec(recv_transmit)
+add_test_exec(recv_window)
+add_test_exec(recv_reorder)
+add_test_exec(recv_reorder_more)
+add_test_exec(recv_close)
+add_test_exec(recv_special)
+
 add_test_exec(no_skip)
 
 add_speed_test(byte_stream_speed_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,15 @@ add_test_exec(byte_stream_two_writes)
 add_test_exec(byte_stream_many_writes)
 add_test_exec(byte_stream_stress_test)
 
+add_test_exec(reassembler_single)
+add_test_exec(reassembler_cap)
+add_test_exec(reassembler_seq)
+add_test_exec(reassembler_dup)
+add_test_exec(reassembler_holes)
+add_test_exec(reassembler_overlapping)
+add_test_exec(reassembler_win)
+
 add_test_exec(no_skip)
 
 add_speed_test(byte_stream_speed_test)
+add_speed_test(reassembler_speed_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,8 @@ add_test_exec(send_extra)
 
 add_test_exec(net_interface)
 
+add_test_exec(router)
+
 add_test_exec(no_skip)
 
 add_speed_test(byte_stream_speed_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,8 @@ add_test_exec(send_close)
 add_test_exec(send_retx)
 add_test_exec(send_extra)
 
+add_test_exec(net_interface)
+
 add_test_exec(no_skip)
 
 add_speed_test(byte_stream_speed_test)

--- a/tests/byte_stream_speed_test.cc
+++ b/tests/byte_stream_speed_test.cc
@@ -77,7 +77,7 @@ double speed_test( fstream& debug_output,
        << " reached " << fixed << setprecision( 2 ) << gigabits_per_second << " Gbit/s.\n";
 
   auto read_s = to_string( read_size );
-  string fill( 5 - read_s.size(), ' ' );
+  const string fill( 5 - read_s.size(), ' ' );
   debug_output << "        ByteStream throughput (pop length " << read_s << "):" << fill << fixed
                << setprecision( 2 ) << setw( 5 ) << gigabits_per_second << " Gbit/s\n";
 

--- a/tests/common.hh
+++ b/tests/common.hh
@@ -3,6 +3,7 @@
 #include "conversions.hh"
 #include "debug.hh"
 #include "exception.hh"
+#include "tcp_sender_message.hh"
 
 #include <iostream>
 #include <optional>
@@ -18,7 +19,7 @@ public:
   explicit ExpectationViolation( const std::string& msg ) : std::runtime_error( msg ) {}
 
   template<typename T>
-  inline ExpectationViolation( const std::string& property_name, const T& expected, const T& actual )
+  ExpectationViolation( const std::string& property_name, const T& expected, const T& actual )
     : ExpectationViolation { "should have had " + property_name + " = " + to_string( expected )
                              + ", but instead it was " + to_string( actual ) }
   {}
@@ -74,11 +75,21 @@ class Timeout
   public:
     Timer();
     ~Timer();
+
+    Timer( const Timer& other ) = delete;
+    Timer( Timer&& other ) = delete;
+    Timer& operator=( const Timer& other ) = delete;
+    Timer& operator=( Timer&& other ) = delete;
   };
 
 public:
   Timeout();
   ~Timeout();
+
+  Timeout( const Timeout& other ) = delete;
+  Timeout( Timeout&& other ) = delete;
+  Timeout& operator=( const Timeout& other ) = delete;
+  Timeout& operator=( Timeout&& other ) = delete;
 
   Timer make_timer();
 };
@@ -123,6 +134,9 @@ class TestHarness
 
   void finish_step( const std::string& str, int color )
   {
+    if ( not steps_executed_ ) {
+      throw std::runtime_error( "TestHarness in invalid state" );
+    }
     steps_executed_.value().emplace_back( str, color, std::move( debug_output_ ) );
     debug_output_.clear();
   }
@@ -235,3 +249,5 @@ struct ExpectBool : public ExpectNumber<T, bool>
 {
   using ExpectNumber<T, bool>::ExpectNumber;
 };
+
+std::string to_string( const TCPSenderMessage& msg );

--- a/tests/conversions.hh
+++ b/tests/conversions.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "helpers.hh"
+#include "wrapping_integers.hh"
 
 #include <optional>
 #include <string>
@@ -10,6 +11,17 @@
 
 namespace minnow_conversions {
 using std::to_string;
+
+class DebugWrap32 : public Wrap32
+{
+public:
+  uint32_t debug_get_raw_value() const { return raw_value_; }
+};
+
+inline std::string to_string( Wrap32 i )
+{
+  return "Wrap32<" + std::to_string( DebugWrap32 { i }.debug_get_raw_value() ) + ">";
+}
 
 template<typename T>
 std::string to_string( const std::optional<T>& v )
@@ -39,4 +51,14 @@ template<MinnowStringable T>
 std::string to_string( T&& t )
 {
   return minnow_conversions::to_string( std::forward<T>( t ) );
+}
+
+inline std::ostream& operator<<( std::ostream& os, Wrap32 a )
+{
+  return os << to_string( a );
+}
+
+inline bool operator!=( Wrap32 a, Wrap32 b )
+{
+  return not( a == b );
 }

--- a/tests/net_interface.cc
+++ b/tests/net_interface.cc
@@ -1,0 +1,625 @@
+#include "arp_message.hh"
+#include "ethernet_header.hh"
+#include "ipv4_datagram.hh"
+#include "network_interface_test_harness.hh"
+
+#include <cstdlib>
+#include <iostream>
+#include <random>
+
+using namespace std;
+
+EthernetAddress random_private_ethernet_address()
+{
+  EthernetAddress addr;
+  for ( auto& byte : addr ) {
+    byte = random_device()(); // use a random local Ethernet address
+  }
+  addr.at( 0 ) |= 0x02; // "10" in last two binary digits marks a private Ethernet address
+  addr.at( 0 ) &= 0xfe;
+
+  return addr;
+}
+
+InternetDatagram make_datagram( const string& src_ip, const string& dst_ip ) // NOLINT(*-swappable-*)
+{
+  InternetDatagram dgram;
+  dgram.header.src = Address( src_ip, 0 ).ipv4_numeric();
+  dgram.header.dst = Address( dst_ip, 0 ).ipv4_numeric();
+  dgram.payload.emplace_back( "hello" );
+  dgram.header.len = static_cast<uint64_t>( dgram.header.hlen ) * 4 + dgram.payload.front()->size();
+  dgram.header.compute_checksum();
+  return dgram;
+}
+
+ARPMessage make_arp( const uint16_t opcode,
+                     const EthernetAddress sender_ethernet_address,
+                     const string& sender_ip_address,
+                     const EthernetAddress target_ethernet_address,
+                     const string& target_ip_address )
+{
+  ARPMessage arp;
+  arp.opcode = opcode;
+  arp.sender_ethernet_address = sender_ethernet_address;
+  arp.sender_ip_address = Address( sender_ip_address, 0 ).ipv4_numeric();
+  arp.target_ethernet_address = target_ethernet_address;
+  arp.target_ip_address = Address( target_ip_address, 0 ).ipv4_numeric();
+  return arp;
+}
+
+EthernetFrame make_frame( const EthernetAddress& src,
+                          const EthernetAddress& dst,
+                          const uint16_t type,
+                          vector<Ref<string>> payload )
+{
+  EthernetFrame frame;
+  frame.header.src = src;
+  frame.header.dst = dst;
+  frame.header.type = type;
+  frame.payload = move( payload );
+  return frame;
+}
+
+int main()
+{
+  try {
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "typical ARP workflow", local_eth, Address( "4.3.2.1", 0 ) };
+
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+
+      // outgoing datagram should result in an ARP request
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      const EthernetAddress target_eth = random_private_ethernet_address();
+
+      test.execute( Tick { 800 } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP reply should result in the queued datagram getting sent
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // any IP reply directed for our Ethernet address should be passed up the stack
+      const auto reply_datagram = make_datagram( "13.12.11.10", "5.6.7.8" );
+      test.execute(
+        ReceiveFrame( make_frame( target_eth, local_eth, EthernetHeader::TYPE_IPv4, serialize( reply_datagram ) ),
+                      reply_datagram ) );
+      test.execute( ExpectNoFrame {} );
+
+      // incoming frames to another Ethernet address (not ours) should be ignored
+      const EthernetAddress another_eth = { 1, 1, 1, 1, 1, 1 };
+      test.execute( ReceiveFrame(
+        make_frame( target_eth, another_eth, EthernetHeader::TYPE_IPv4, serialize( reply_datagram ) ) ) );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress remote_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "reply to ARP request", local_eth, Address( "5.5.5.5", 0 ) };
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "10.0.1.1", {}, "7.7.7.7" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "10.0.1.1", {}, "5.5.5.5" ) ) ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        remote_eth,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, local_eth, "5.5.5.5", remote_eth, "10.0.1.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress remote_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "learn from ARP request", local_eth, Address( "5.5.5.5", 0 ) };
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "10.0.1.1", {}, "5.5.5.5" ) ) ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        remote_eth,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, local_eth, "5.5.5.5", remote_eth, "10.0.1.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "10.0.1.1", 0 ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "pending mappings last five seconds", local_eth, Address( "1.2.3.4", 0 ) };
+
+      test.execute( SendDatagram { make_datagram( "5.6.7.8", "13.12.11.10" ), Address( "10.0.0.1", 0 ) } );
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    ETHERNET_BROADCAST,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "1.2.3.4", {}, "10.0.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      test.execute( Tick { 4990 } );
+      test.execute( SendDatagram { make_datagram( "17.17.17.17", "18.18.18.18" ), Address( "10.0.0.1", 0 ) } );
+      test.execute( ExpectNoFrame {} );
+      test.execute( Tick { 20 } );
+      // pending mapping should now expire
+      test.execute( SendDatagram { make_datagram( "42.41.40.39", "13.12.11.10" ), Address( "10.0.0.1", 0 ) } );
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    ETHERNET_BROADCAST,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "1.2.3.4", {}, "10.0.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "active mappings last 30 seconds", local_eth, Address( "4.3.2.1", 0 ) };
+
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      const auto datagram2 = make_datagram( "5.6.7.8", "13.12.11.11" );
+      const auto datagram3 = make_datagram( "5.6.7.8", "13.12.11.12" );
+      const auto datagram4 = make_datagram( "5.6.7.8", "13.12.11.13" );
+      const auto datagram5 = make_datagram( "5.6.7.8", "13.12.11.14" );
+
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      const EthernetAddress target_eth = random_private_ethernet_address();
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // try after 10 seconds -- no ARP should be generated
+      test.execute( Tick { 10000 } );
+      test.execute( SendDatagram { datagram2, Address( "192.168.0.1", 0 ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram2 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // another 10 seconds -- no ARP should be generated
+      test.execute( Tick { 10000 } );
+      test.execute( SendDatagram { datagram3, Address( "192.168.0.1", 0 ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram3 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // after another 11 seconds, need to ARP again
+      test.execute( Tick { 11000 } );
+      test.execute( SendDatagram { datagram4, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // should not generate ARP message because original request still pending
+      // test credit: Matt Reed
+      test.execute( Tick { 4900 } );
+      test.execute( SendDatagram { datagram5, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP reply again
+      const EthernetAddress new_target_eth = random_private_ethernet_address();
+      test.execute( ReceiveFrame {
+        make_frame( new_target_eth,
+                    local_eth,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp(
+                      ARPMessage::OPCODE_REPLY, new_target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+      test.execute( ExpectFrame {
+        make_frame( local_eth, new_target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram4 ) ) } );
+      test.execute( ExpectFrame {
+        make_frame( local_eth, new_target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram5 ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress remote_eth1 = random_private_ethernet_address();
+      const EthernetAddress remote_eth2 = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "different ARP mappings are independent", local_eth, Address( "10.0.0.1", 0 ) };
+
+      // first ARP mapping
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth1,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth1, "10.0.0.5", {}, "10.0.0.1" ) ) ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        remote_eth1,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, local_eth, "10.0.0.1", remote_eth1, "10.0.0.5" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      test.execute( Tick { 15000 } );
+
+      // second ARP mapping
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth2,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth2, "10.0.0.19", {}, "10.0.0.1" ) ) ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        remote_eth2,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, local_eth, "10.0.0.1", remote_eth2, "10.0.0.19" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      test.execute( Tick { 10000 } );
+
+      // outgoing datagram to first destination
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "10.0.0.5", 0 ) } );
+
+      // outgoing datagram to second destination
+      const auto datagram2 = make_datagram( "100.99.98.97", "4.10.4.10" );
+      test.execute( SendDatagram { datagram2, Address( "10.0.0.19", 0 ) } );
+
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth1, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth2, EthernetHeader::TYPE_IPv4, serialize( datagram2 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      test.execute( Tick { 5010 } );
+
+      // outgoing datagram to second destination (mapping still alive)
+      const auto datagram3 = make_datagram( "150.140.130.120", "144.144.144.144" );
+      test.execute( SendDatagram { datagram3, Address( "10.0.0.19", 0 ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth2, EthernetHeader::TYPE_IPv4, serialize( datagram3 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // outgoing datagram to second destination (mapping has expired)
+      const auto datagram4 = make_datagram( "244.244.244.244", "3.3.3.3" );
+      test.execute( SendDatagram { datagram4, Address( "10.0.0.5", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "10.0.0.1", {}, "10.0.0.5" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // test credit: Matthew Harvill
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress target_eth1 = random_private_ethernet_address();
+      const EthernetAddress target_eth2 = random_private_ethernet_address();
+
+      NetworkInterfaceTestHarness test {
+        "pending datagrams sent to correct dst when ARP replies received out-of-order",
+        local_eth,
+        Address( "4.3.2.1", 0 ) };
+
+      const auto datagram1 = make_datagram( "5.6.7.8", "13.12.11.10" );
+      const auto datagram2 = make_datagram( "5.6.7.8", "13.12.11.11" );
+
+      // Try to send datagram1, but we don't know target_eth1 yet, so send ARP request to get it
+      test.execute( SendDatagram { datagram1, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+
+      // Try to send datagram2, but we don't know target_eth2 yet, so send ARP request to get it
+      test.execute( SendDatagram { datagram2, Address( "192.168.0.2", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.2" ) ) ) } );
+
+      // Receive ARP reply from target_eth2 first; make sure to send datagram2, not datagram1
+      test.execute( ReceiveFrame { make_frame(
+        target_eth2,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth2, "192.168.0.2", local_eth, "4.3.2.1" ) ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth2, EthernetHeader::TYPE_IPv4, serialize( datagram2 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // Receive ARP reply from target_eth1 next, make sure we send datagram1
+      test.execute( ReceiveFrame { make_frame(
+        target_eth1,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth1, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth1, EthernetHeader::TYPE_IPv4, serialize( datagram1 ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // test credit: Matthew Harvill
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress target_eth = random_private_ethernet_address();
+
+      NetworkInterfaceTestHarness test {
+        "multiple pending datagrams sent when ARP reply received", local_eth, Address( "4.3.2.1", 0 ) };
+
+      const auto datagram1 = make_datagram( "5.6.7.8", "13.12.11.10" );
+      const auto datagram2 = make_datagram( "5.6.7.8", "13.12.11.11" );
+      const auto datagram3 = make_datagram( "5.6.7.8", "13.12.11.12" );
+
+      // Try to send all datagrams, but we don't know target_eth yet, so should send ARP request to get it
+      test.execute( SendDatagram { datagram1, Address( "192.168.0.1", 0 ) } );
+      test.execute( SendDatagram { datagram2, Address( "192.168.0.1", 0 ) } );
+      test.execute( SendDatagram { datagram3, Address( "192.168.0.1", 0 ) } );
+
+      // Should have sent an ARP request to get target_eth
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // Receive ARP reply from target_eth next, and make sure we respond by sending all datagrams
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram1 ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram2 ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram3 ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // test credit: Tanmay Garg
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress remote_eth = random_private_ethernet_address();
+      const auto datagram1 = make_datagram( "5.6.7.8", "13.12.11.10" );
+      const auto datagram2 = make_datagram( "5.6.7.8", "13.12.11.11" );
+
+      NetworkInterfaceTestHarness test {
+        "update timestamp for ARP mapping if in map already", local_eth, Address( "100.5.100.5", 0 ) };
+
+      // receive ARP request
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "144.144.144.144", {}, "100.5.100.5" ) ) ) } );
+
+      // send ARP reply which does not reach destination
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    remote_eth,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp(
+                      ARPMessage::OPCODE_REPLY, local_eth, "100.5.100.5", remote_eth, "144.144.144.144" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // just more than 5 seconds pass
+      test.execute( Tick { 5001 } );
+
+      // receive same ARP request and update mapping timestamp
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "144.144.144.144", {}, "100.5.100.5" ) ) ) } );
+
+      // send same arp reply again
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    remote_eth,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp(
+                      ARPMessage::OPCODE_REPLY, local_eth, "100.5.100.5", remote_eth, "144.144.144.144" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // 25 seconds pass
+      test.execute( Tick { 25000 } );
+
+      // expect mapping to not be expired (25 sec since updated timestamp)
+      test.execute( SendDatagram { datagram1, Address( "144.144.144.144", 0 ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth, EthernetHeader::TYPE_IPv4, serialize( datagram1 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // just more than 5 seconds pass
+      test.execute( Tick { 5001 } );
+
+      // expect mapping to be expired now (30.001 sec since updated timestamp)
+      test.execute( SendDatagram { datagram2, Address( "144.144.144.144", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "100.5.100.5", {}, "144.144.144.144" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // test credit: Josselin Somerville Roberts
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "Two datagrams sent before ARP response", local_eth, Address( "4.3.2.1", 0 ) };
+
+      // Send first datagram
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+
+      // outgoing datagram should result in an ARP request
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      const EthernetAddress target_eth = random_private_ethernet_address();
+
+      // Resend a second time a datagram
+      // This should not result in an ARP request
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP reply should result in the queued datagram getting sent
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+
+      // Should receive the two queued datagrams
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // test credit: Josselin Somerville Roberts
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "Pending datagrams dropped when pending request expires", local_eth, Address( "4.3.2.1", 0 ) };
+
+      // Send first datagram
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+
+      // outgoing datagram should result in an ARP request
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      const EthernetAddress target_eth = random_private_ethernet_address();
+
+      // Send another datagram after some delay
+      test.execute( Tick { 5100 } );
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+
+      // outgoing datagram should result in a new ARP request
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP reply should result in the queued datagram getting sent
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+
+      // We should receive only the second queued datagram
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // Test credit: Shiva Khanna Yamamoto
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "ARP replies trigger correct Ethernet frame", local_eth, Address( "5.5.5.5", 0 ) };
+
+      int dst_suffix = 1;
+      int dst_suffix_2 = 1;
+      int dst_suffix_3 = 1;
+
+      for ( int i = 0; i < 50; i++ ) {
+        // call send_datagram expecting two ARP requests
+        const auto datagram_1 = make_datagram( "5.6.7.8", "14.12.11." + to_string( dst_suffix_2 ) );
+        const auto datagram_2 = make_datagram( "5.6.7.8", "14.12.11." + to_string( dst_suffix_2 + 1 ) );
+        test.execute( SendDatagram { datagram_1, Address( "192.168.0." + to_string( dst_suffix_3 ), 0 ) } );
+        test.execute( SendDatagram { datagram_2, Address( "192.168.0." + to_string( dst_suffix_3 + 1 ), 0 ) } );
+        test.execute(
+          ExpectFrame { make_frame( local_eth,
+                                    ETHERNET_BROADCAST,
+                                    EthernetHeader::TYPE_ARP,
+                                    serialize( make_arp( ARPMessage::OPCODE_REQUEST,
+                                                         local_eth,
+                                                         "5.5.5.5",
+                                                         {},
+                                                         "192.168.0." + to_string( dst_suffix_3 ) ) ) ) } );
+        test.execute(
+          ExpectFrame { make_frame( local_eth,
+                                    ETHERNET_BROADCAST,
+                                    EthernetHeader::TYPE_ARP,
+                                    serialize( make_arp( ARPMessage::OPCODE_REQUEST,
+                                                         local_eth,
+                                                         "5.5.5.5",
+                                                         {},
+                                                         "192.168.0." + to_string( dst_suffix_3 + 1 ) ) ) ) } );
+
+        // call recv_frame once, expecting only one ARP Reply followed by transmission of the correct Ethernet Frame
+        const EthernetAddress target_eth = random_private_ethernet_address();
+        test.execute( ReceiveFrame { make_frame( target_eth,
+                                                 local_eth,
+                                                 EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+                                                 serialize( make_arp( ARPMessage::OPCODE_REPLY,
+                                                                      target_eth,
+                                                                      "192.168.0." + to_string( dst_suffix_3 + 1 ),
+                                                                      local_eth,
+                                                                      "5.5.5.5" ) ) ) } );
+        test.execute(
+          ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram_2 ) ) } );
+        test.execute( ExpectNoFrame {} );
+
+        // change destination addrs
+        dst_suffix = dst_suffix + 2;
+        dst_suffix_2 = dst_suffix_2 + 2;
+        dst_suffix_3 = dst_suffix_3 + 2;
+      }
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/net_interface.cc
+++ b/tests/net_interface.cc
@@ -618,9 +618,11 @@ int main()
     }
 
     // CUSTOM TEST
-    // If the Network Interface is waiting on an ARP Reply from a given IP, but then they recieve a ARP Request from said IP, they should still
-    // send the queued messages, since they now know the IP/Eth Addresses. Right now, this case is not tested. Inuitively, I believe this case should either
-    // an ARP reply and end or (more likely) send an ARP reply and the queued messages after. In my code (Line ~147) I have incorrect / correct code for this test case.
+    // If the Network Interface is waiting on an ARP Reply from a given IP, but then they recieve a ARP Request from
+    // said IP, they should still send the queued messages, since they now know the IP/Eth Addresses. Right now,
+    // this case is not tested. Inuitively, I believe this case should either an ARP reply and end or (more likely)
+    // send an ARP reply and the queued messages after. In my code (Line ~147) I have incorrect / correct code for
+    // this test case.
     {
       const EthernetAddress local_eth = random_private_ethernet_address();
       NetworkInterfaceTestHarness test {
@@ -652,12 +654,11 @@ int main()
         serialize( make_arp( ARPMessage::OPCODE_REQUEST, target_eth, "192.168.0.1", {}, "4.3.2.1" ) ) ) } );
 
       // Should receive arp reply
-      test.execute( ExpectFrame {
-        make_frame( local_eth,
-                    target_eth,
-                    EthernetHeader::TYPE_ARP,
-                    serialize( make_arp(
-                        ARPMessage::OPCODE_REPLY, local_eth, "4.3.2.1", target_eth, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        target_eth,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, local_eth, "4.3.2.1", target_eth, "192.168.0.1" ) ) ) } );
 
       // Should receive the two queued datagrams
       test.execute(

--- a/tests/net_interface.cc
+++ b/tests/net_interface.cc
@@ -616,6 +616,57 @@ int main()
         dst_suffix_3 = dst_suffix_3 + 2;
       }
     }
+
+    // CUSTOM TEST
+    // If the Network Interface is waiting on an ARP Reply from a given IP, but then they recieve a ARP Request from said IP, they should still
+    // send the queued messages, since they now know the IP/Eth Addresses. Right now, this case is not tested. Inuitively, I believe this case should either
+    // an ARP reply and end or (more likely) send an ARP reply and the queued messages after. In my code (Line ~147) I have incorrect / correct code for this test case.
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "Two datagrams sent before ARP request of same addr", local_eth, Address( "4.3.2.1", 0 ) };
+
+      // Send first datagram
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+
+      // outgoing datagram should result in an ARP request
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      const EthernetAddress target_eth = random_private_ethernet_address();
+
+      // Resend a second time a datagram
+      // This should not result in an ARP request
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP request should result in the queued datagram getting sent
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, target_eth, "192.168.0.1", {}, "4.3.2.1" ) ) ) } );
+
+      // Should receive arp reply
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    target_eth,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp(
+                        ARPMessage::OPCODE_REPLY, local_eth, "4.3.2.1", target_eth, "192.168.0.1" ) ) ) } );
+
+      // Should receive the two queued datagrams
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return EXIT_FAILURE;

--- a/tests/network_interface_test_harness.hh
+++ b/tests/network_interface_test_harness.hh
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include "common.hh"
+#include "helpers.hh"
+#include "network_interface.hh"
+
+class FramesOut : public NetworkInterface::OutputPort
+{
+public:
+  std::queue<EthernetFrame> frames {};
+  void transmit( const NetworkInterface& n [[maybe_unused]], const EthernetFrame& x ) override
+  {
+    frames.push( clone( x ) );
+  }
+
+  EthernetFrame expect_frame() const
+  {
+    if ( frames.empty() ) {
+      throw ExpectationViolation( "should have sent an Ethernet frame" );
+    }
+    auto& mutable_output = const_cast<decltype( frames )&>( frames ); // NOLINT(*-const-cast)
+    EthernetFrame ret { std::move( mutable_output.front() ) };
+    mutable_output.pop();
+    return ret;
+  }
+};
+
+using Output = std::shared_ptr<FramesOut>;
+using InterfaceAndOutput = std::pair<NetworkInterface, Output>;
+
+class NetworkInterfaceTestHarness : public TestHarness<InterfaceAndOutput>
+{
+public:
+  NetworkInterfaceTestHarness( std::string test_name,
+                               const EthernetAddress& ethernet_address,
+                               const Address& ip_address )
+    : TestHarness( move( test_name ), "eth=" + to_string( ethernet_address ) + ", ip=" + ip_address.ip(), [&] {
+      Output output { std::make_shared<FramesOut>() };
+      NetworkInterface iface { "test", output, ethernet_address, ip_address };
+      return InterfaceAndOutput { std::move( iface ), std::move( output ) };
+    }() )
+  {}
+};
+
+struct SendDatagram : public Action<InterfaceAndOutput>
+{
+  InternetDatagram dgram;
+  Address next_hop;
+
+  std::string description() const override
+  {
+    return "request to send datagram (to next hop " + next_hop.ip() + "): " + dgram.header.to_string()
+           + " payload=\"" + pretty_print( concat( dgram.payload ) ) + "\"";
+  }
+
+  void execute( InterfaceAndOutput& interface ) const override { interface.first.send_datagram( dgram, next_hop ); }
+
+  SendDatagram( const InternetDatagram& d, Address n ) : dgram( clone( d ) ), next_hop( n ) {}
+};
+
+template<class T>
+bool equal( const T& t1, const T& t2 )
+{
+  const auto t1s = serialize( t1 );
+  const auto t2s = serialize( t2 );
+
+  return concat( t1s ) == concat( t2s );
+}
+
+struct ReceiveFrame : public Action<InterfaceAndOutput>
+{
+  EthernetFrame frame;
+  std::optional<InternetDatagram> expected {};
+
+  std::string description() const override { return "receive frame (" + summary( frame ) + ")"; }
+  void execute( InterfaceAndOutput& interface ) const override
+  {
+    interface.first.recv_frame( clone( frame ) );
+
+    auto& inbound = interface.first.datagrams_received();
+
+    if ( not expected.has_value() ) {
+      if ( inbound.empty() ) {
+        return;
+      }
+      throw ExpectationViolation(
+        "an arriving Ethernet frame was passed up the stack as an Internet datagram, but was not expected to be "
+        "(did destination address match our interface?)" );
+    }
+
+    if ( inbound.empty() ) {
+      throw ExpectationViolation(
+        "an arriving Ethernet frame was expected to be passed up the stack as an Internet datagram, but wasn't" );
+    }
+
+    if ( not equal( inbound.front(), expected.value() ) ) {
+      throw ExpectationViolation(
+        std::string( "NetworkInterface::recv_frame() produced a different Internet datagram than was expected: " )
+        + "actual={" + inbound.front().header.to_string() + "}" );
+    }
+
+    inbound.pop();
+  }
+
+  ReceiveFrame( const EthernetFrame& f, const InternetDatagram& e ) : frame( clone( f ) ), expected( clone( e ) ) {}
+
+  explicit ReceiveFrame( const EthernetFrame& f ) : frame( clone( f ) ) {}
+};
+
+struct ExpectFrame : public Expectation<InterfaceAndOutput>
+{
+  EthernetFrame expected;
+
+  std::string description() const override { return "frame transmitted (" + summary( expected ) + ")"; }
+  void execute( const InterfaceAndOutput& interface ) const override
+  {
+    const EthernetFrame frame = interface.second->expect_frame();
+
+    if ( not equal( frame, expected ) ) {
+      throw ExpectationViolation( "NetworkInterface sent a different Ethernet frame than was expected: actual={"
+                                  + summary( frame ) + "}" );
+    }
+  }
+
+  explicit ExpectFrame( const EthernetFrame& e ) : expected( clone( e ) ) {}
+};
+
+struct ExpectNoFrame : public Expectation<InterfaceAndOutput>
+{
+  std::string description() const override { return "no frame transmitted"; }
+  void execute( const InterfaceAndOutput& interface ) const override
+  {
+    if ( not interface.second->frames.empty() ) {
+      throw ExpectationViolation( "NetworkInterface sent an Ethernet frame although none was expected" );
+    }
+  }
+};
+
+struct Tick : public Action<InterfaceAndOutput>
+{
+  size_t _ms;
+
+  std::string description() const override { return to_string( _ms ) + " ms pass"; }
+  void execute( InterfaceAndOutput& interface ) const override { interface.first.tick( _ms ); }
+
+  explicit Tick( const size_t ms ) : _ms( ms ) {}
+};

--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -1,0 +1,155 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      ReassemblerTestHarness test { "all within capacity", 2 };
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( Insert { "cd", 2 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "cd" ) );
+
+      test.execute( Insert { "ef", 4 } );
+      test.execute( BytesPushed( 6 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ef" ) );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert beyond capacity", 2 };
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "cd", 2 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "ab" ) );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "cd", 2 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "cd" ) );
+    }
+
+    {
+      ReassemblerTestHarness test { "overlapping inserts", 1 };
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "a" ) );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "abc", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "b" ) );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert beyond capacity repeated with different data", 2 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "bX", 2 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( Insert { "bc", 1 } );
+      test.execute( BytesPushed( 3 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "c" ) );
+    }
+
+    // test credit: Cooper de Nicola
+    {
+      ReassemblerTestHarness test { "insert last beyond capacity", 2 };
+
+      test.execute( Insert { "bc", 1 }.is_last() );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "bc", 1 }.is_last() );
+      test.execute( BytesPushed( 3 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "c" ) );
+
+      test.execute( IsFinished { true } );
+    }
+
+    // test credit: Tanmay Garg and Agam Mohan Singh Bhatia
+    {
+      ReassemblerTestHarness test { "insert last fully beyond capacity + empty string is last", 2 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "abc", 0 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "", 3 }.is_last() );
+      test.execute( IsFinished { false } );
+
+      test.execute( ReadAll( "ab" ) );
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( ReadAll( "c" ) );
+      test.execute( IsFinished { true } );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -146,6 +146,63 @@ int main()
       test.execute( ReadAll( "c" ) );
       test.execute( IsFinished { true } );
     }
+
+    // test credit: Parth Sarthi
+    {
+      ReassemblerTestHarness test { "last index exactly fills capacity", 2 };
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( ReadAll( "c" ) );
+
+      test.execute( Insert { "de", 3 }.is_last() );
+      test.execute( ReadAll( "de" ) );
+
+      test.execute( IsFinished { true } );
+    }
+
+    // test credit: Parth Sarthi
+    {
+      ReassemblerTestHarness test { "last index is unacceptable", 2 };
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( ReadAll( "c" ) );
+
+      test.execute( Insert { "def", 3 }.is_last() );
+      test.execute( ReadAll( "de" ) );
+
+      test.execute( IsFinished { false } );
+    }
+
+    // test credit: Andy Wang
+    {
+      ReassemblerTestHarness test { "insert beyond capacity at colossally gigantic index", 3 };
+
+      test.execute( Insert { "b", 1 }.is_last() );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "z", UINT64_MAX } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "xyz", UINT64_MAX - 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished( true ) );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << "\n";
     return EXIT_FAILURE;

--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -203,6 +203,51 @@ int main()
       test.execute( ReadAll( "ab" ) );
       test.execute( IsFinished( true ) );
     }
+
+#if 0
+    // test credit: Riya Ranjan
+    {
+      ReassemblerTestHarness test { "insert beyond capacity at colossally gigantic index II", 4 };
+      test.execute( Insert { "", 0 } );
+      test.execute( Insert { "a", UINT64_MAX - 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+#endif
+
+    // test credit: Andy Wang with Jasraj Yogesh Kripalani
+    {
+      ReassemblerTestHarness test { "Use full reassembler storage", 10 };
+
+      test.execute( Insert { "bcde", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 5 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "abcde" ) );
+
+      test.execute( Insert { "ghijklmno", 6 } );
+      test.execute( BytesPushed( 5 ) );
+      test.execute( BytesPending( 9 ) );
+
+      test.execute( Insert { "f", 5 } );
+      test.execute( BytesPushed( 15 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "fghijklmno" ) );
+
+      test.execute( Insert { "rstuvwxy", 17 }.is_last() );
+      test.execute( BytesPushed( 15 ) );
+      test.execute( BytesPending( 8 ) );
+
+      test.execute( Insert { "pq", 15 } );
+      test.execute( BytesPushed( 25 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "pqrstuvwxy" ) );
+
+      test.execute( IsFinished( true ) );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << "\n";
     return EXIT_FAILURE;

--- a/tests/reassembler_dup.cc
+++ b/tests/reassembler_dup.cc
@@ -1,0 +1,98 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      ReassemblerTestHarness test { "dup 1", 65000 };
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "dup 2", 65000 };
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abcd", 4 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abcd", 4 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "dup 3", 65000 };
+
+      test.execute( Insert { "abcdefgh", 0 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( ReadAll( "abcdefgh" ) );
+      test.execute( IsFinished { false } );
+      string data = "abcdefgh";
+
+      for ( size_t i = 0; i < 1000; ++i ) {
+        const size_t start_i = uniform_int_distribution<size_t> { 0, 8 }( rd );
+        auto start = data.begin();
+        advance( start, start_i );
+
+        const size_t end_i = uniform_int_distribution<size_t> { start_i, 8 }( rd );
+        auto end = data.begin();
+        advance( end, end_i );
+
+        test.execute( Insert { string { start, end }, start_i } );
+        test.execute( BytesPushed( 8 ) );
+        test.execute( ReadAll( "" ) );
+        test.execute( IsFinished { false } );
+      }
+    }
+
+    {
+      ReassemblerTestHarness test { "dup 4", 65000 };
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abcdef", 0 } );
+      test.execute( BytesPushed( 6 ) );
+      test.execute( ReadAll( "ef" ) );
+      test.execute( IsFinished { false } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_holes.cc
+++ b/tests/reassembler_holes.cc
@@ -1,0 +1,139 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      ReassemblerTestHarness test { "holes 1", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 2", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( Insert { "a", 0 } );
+
+      test.execute( BytesPushed( 2 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 3", 65000 };
+
+      test.execute( Insert { "b", 1 }.is_last() );
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "a", 0 } );
+
+      test.execute( BytesPushed( 2 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished { true } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 4", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( Insert { "ab", 0 } );
+
+      test.execute( BytesPushed( 2 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 5", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "d", 3 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "a", 0 } );
+
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 6", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "d", 3 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abc", 0 } );
+
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 7", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "d", 3 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "cd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "", 4 }.is_last() );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { true } );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_overlapping.cc
+++ b/tests/reassembler_overlapping.cc
@@ -1,0 +1,296 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      // Overlapping assembled (unread) section
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping assembled/unread section", cap };
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( Insert { "ab", 0 } );
+
+      test.execute( BytesPushed( 2 ) );
+      test.execute( ReadAll( "ab" ) );
+    }
+
+    {
+      // Overlapping assembled (read) section
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping assembled/read section", cap };
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "a" ) );
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( ReadAll( "b" ) );
+      test.execute( BytesPushed( 2 ) );
+    }
+
+    {
+      // Overlapping unassembled section, resulting in assembly
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping unassembled section to fill hole", cap };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "" ) );
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed( 2 ) );
+    }
+    {
+      // Overlapping unassembled section, not resulting in assembly
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping unassembled section", cap };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "" ) );
+
+      test.execute( Insert { "bc", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPending { 2 } );
+      test.execute( BytesPushed( 0 ) );
+    }
+    {
+      // Overlapping unassembled section, not resulting in assembly
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping unassembled section 2", cap };
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( ReadAll( "" ) );
+
+      test.execute( Insert { "bcd", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPending { 3 } );
+      test.execute( BytesPushed( 0 ) );
+    }
+
+    {
+      // Overlapping multiple unassembled sections
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping multiple unassembled sections", cap };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( Insert { "d", 3 } );
+      test.execute( ReadAll( "" ) );
+
+      test.execute( Insert { "bcde", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+    }
+
+    {
+      // Submission over existing
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "insert over existing section", cap };
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( Insert { "bcd", 1 } );
+
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 3 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Submission within existing
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "insert within existing section", cap };
+
+      test.execute( Insert { "bcd", 1 } );
+      test.execute( Insert { "c", 2 } );
+
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 3 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Hole filled progressively and with overlap. Credit: Sarah McCarthy
+
+      ReassemblerTestHarness test { "hole filled with overlap", 20 };
+
+      test.execute( Insert { "fgh", 5 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abc", 0 } );
+      test.execute( BytesPushed( 3 ) );
+
+      test.execute( Insert { "abcdef", 0 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "abcdefgh" ) );
+    }
+
+    {
+      // Multiple overlap. Credit: Sebastian Ingino
+      ReassemblerTestHarness test { "multiple overlaps", 1000 };
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( Insert { "e", 4 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 2 ) );
+
+      test.execute( Insert { "bcdef", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 5 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcdef" ) );
+      test.execute( BytesPushed( 6 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Overlap between two pending. Credit: Sebastian Ingino.
+      ReassemblerTestHarness test { "overlap between two pending", 1000 };
+
+      test.execute( Insert { "bc", 1 } );
+      test.execute( Insert { "ef", 4 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+
+      test.execute( Insert { "cde", 2 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 5 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcdef" ) );
+      test.execute( BytesPushed( 6 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Add exact copy. Credit: Sebastian Ingino.
+      ReassemblerTestHarness test { "exact copy", 1000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Credit: Anonymous (2023)
+      ReassemblerTestHarness test { "yet another overlap test", 150 };
+
+      test.execute( Insert { "efgh", 4 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+
+      test.execute( Insert { "op", 14 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 6 ) );
+
+      test.execute( Insert { "s", 18 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 7 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( BytesPending( 7 ) );
+
+      test.execute( Insert { "abcde", 0 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( BytesPending( 3 ) );
+
+      test.execute( Insert { "opqrst", 14 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( BytesPending( 6 ) );
+
+      test.execute( Insert { "op", 14 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( BytesPending( 6 ) );
+
+      test.execute( Insert { "ijklmn", 8 } );
+      test.execute( BytesPushed( 20 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Credit: Eli Wald
+      ReassemblerTestHarness test { "small capacity with overlapping insert", 2 };
+      test.execute( Insert { "bc", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Credit: Chenhao Li
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping multiple unassembled sections 2", cap };
+
+      test.execute( Insert { "bcd", 1 } );
+      test.execute( Insert { "cde", 2 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcde" ) );
+      test.execute( BytesPushed( 5 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Credit: Tanmay Garg
+      ReassemblerTestHarness test { "overlapping multiple unassembled sections 3", 30 };
+
+      test.execute( Insert { "hello", 15 } );
+      test.execute( Insert { "world!", 21 } );
+      test.execute( Insert { "I am sentient", 0 } );
+      test.execute( Insert { "sentient, hello world", 5 } );
+
+      test.execute( BytesPending( 0 ) );
+      test.execute( BytesPushed( 27 ) );
+      test.execute( ReadAll( "I am sentient, hello world!" ) );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_seq.cc
+++ b/tests/reassembler_seq.cc
@@ -1,0 +1,89 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      ReassemblerTestHarness test { "seq 1", 65000 };
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "efgh", 4 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( ReadAll( "efgh" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "seq 2", 65000 };
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "efgh", 4 } );
+      test.execute( BytesPushed( 8 ) );
+
+      test.execute( ReadAll( "abcdefgh" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "seq 3", 65000 };
+      ostringstream ss;
+
+      for ( size_t i = 0; i < 100; ++i ) {
+        test.execute( BytesPushed( 4 * i ) );
+        test.execute( Insert { "abcd", 4 * i } );
+        test.execute( IsFinished { false } );
+
+        ss << "abcd";
+      }
+
+      test.execute( ReadAll( ss.str() ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "seq 4", 65000 };
+      for ( size_t i = 0; i < 100; ++i ) {
+        test.execute( BytesPushed( 4 * i ) );
+        test.execute( Insert { "abcd", 4 * i } );
+        test.execute( IsFinished { false } );
+
+        test.execute( ReadAll( "abcd" ) );
+      }
+    }
+
+    {
+      ReassemblerTestHarness test { "zero-valued byte in substring", 16 };
+
+      test.execute( Insert { { 0x30, 0x0d, 0x62, 0x00, 0x61, 0x00, 0x00 }, 9 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { { 0x0d, 0x0a, 0x63, 0x61, 0x0a, 0x66 }, 0 } );
+      test.execute( BytesPushed( 6 ) );
+
+      test.execute( Insert { { 0x0d, 0x0a, 0x63, 0x61, 0x0a, 0x66, 0x65, 0x20, 0x62, 0x30 }, 0 } );
+      test.execute( BytesPushed( 16 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll(
+        { 0x0d, 0x0a, 0x63, 0x61, 0x0a, 0x66, 0x65, 0x20, 0x62, 0x30, 0x0d, 0x62, 0x00, 0x61, 0x00, 0x00 } ) );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_single.cc
+++ b/tests/reassembler_single.cc
@@ -1,0 +1,93 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      ReassemblerTestHarness test { "construction", 65000 };
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert a @ 0", 65000 };
+
+      test.execute( Insert { "a", 0 } );
+
+      test.execute( BytesPushed( 1 ) );
+      test.execute( ReadAll( "a" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert a @ 0 [last]", 65000 };
+
+      test.execute( Insert { "a", 0 }.is_last() );
+
+      test.execute( BytesPushed( 1 ) );
+      test.execute( ReadAll( "a" ) );
+      test.execute( IsFinished { true } );
+    }
+
+    {
+      ReassemblerTestHarness test { "empty stream", 65000 };
+
+      test.execute( Insert { "", 0 }.is_last() );
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( IsFinished { true } );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert b @ 0 [last]", 65000 };
+
+      test.execute( Insert { "b", 0 }.is_last() );
+
+      test.execute( BytesPushed( 1 ) );
+      test.execute( ReadAll( "b" ) );
+      test.execute( IsFinished { true } );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert empty string @ 0", 65000 };
+
+      test.execute( Insert { "", 0 } );
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( IsFinished { false } );
+    }
+
+    // credit: Joshua Dong
+    {
+      ReassemblerTestHarness test { "insert a after 'first unacceptable'", 1 };
+
+      test.execute( Insert { "g", 3 } );
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert b before 'first unassembled'", 1 };
+
+      test.execute( Insert { "b", 0 } );
+      test.execute( ReadAll( "b" ) );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( Insert { "b", 0 } );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( IsFinished { false } );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_single.cc
+++ b/tests/reassembler_single.cc
@@ -84,6 +84,29 @@ int main()
       test.execute( BytesPushed( 1 ) );
       test.execute( IsFinished { false } );
     }
+
+    // credit: iberny
+    {
+      ReassemblerTestHarness test { "stream ends first I", 1000 };
+
+      test.execute( Insert { "", 4 }.is_last() );
+      test.execute( Insert { "abc", 0 } );
+
+      test.execute( BytesPushed( 3 ) );
+      test.execute( ReadAll( "abc" ) );
+      test.execute( IsFinished( false ) );
+    }
+
+    {
+      ReassemblerTestHarness test { "stream ends first II", 1000 };
+
+      test.execute( Insert { "", 3 }.is_last() );
+      test.execute( Insert { "abc", 0 } );
+
+      test.execute( BytesPushed( 3 ) );
+      test.execute( ReadAll( "abc" ) );
+      test.execute( IsFinished( true ) );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << "\n";
     return EXIT_FAILURE;

--- a/tests/reassembler_speed_test.cc
+++ b/tests/reassembler_speed_test.cc
@@ -1,0 +1,111 @@
+#include "reassembler.hh"
+
+#include <chrono>
+#include <cstddef>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <queue>
+#include <random>
+#include <tuple>
+
+using namespace std;
+using namespace std::chrono;
+
+void speed_test( const size_t num_chunks,  // NOLINT(bugprone-easily-swappable-parameters)
+                 const size_t chunk_size,  // NOLINT(bugprone-easily-swappable-parameters)
+                 const size_t overlap,     // NOLINT(bugprone-easily-swappable-parameters)
+                 const size_t capacity,    // NOLINT(bugprone-easily-swappable-parameters)
+                 const size_t random_seed, // NOLINT(bugprone-easily-swappable-parameters)
+                 string_view scenario )
+{
+  // Generate the data to be written
+  const string data = [&] {
+    default_random_engine rd { random_seed };
+    uniform_int_distribution<char> ud;
+    string ret;
+    for ( size_t i = 0; i < num_chunks * chunk_size; ++i ) {
+      ret += ud( rd );
+    }
+    return ret;
+  }();
+
+  // Split the data into segments before writing
+  queue<tuple<uint64_t, string, bool>> split_data;
+  for ( size_t i = 0; i < data.size(); i += capacity ) {
+    size_t chunk_begin = min( i + capacity - 1, data.size() - 1 );
+    while ( true ) {
+      split_data.emplace(
+        chunk_begin, data.substr( chunk_begin, chunk_size ), chunk_begin + chunk_size >= data.size() );
+      if ( chunk_begin >= overlap ) {
+        chunk_begin -= overlap;
+      } else {
+        split_data.emplace( 0, data.substr( 0, chunk_size ), 0 + chunk_size >= data.size() );
+        break;
+      }
+    }
+  }
+
+  Reassembler reassembler { ByteStream { capacity } };
+
+  string output_data;
+  output_data.reserve( data.size() );
+
+  const auto start_time = steady_clock::now();
+  while ( not split_data.empty() ) {
+    auto& next = split_data.front();
+    reassembler.insert( get<uint64_t>( next ), move( get<string>( next ) ), get<bool>( next ) );
+    split_data.pop();
+
+    while ( reassembler.reader().bytes_buffered() ) {
+      output_data += reassembler.reader().peek();
+      reassembler.reader().pop( output_data.size() - reassembler.reader().bytes_popped() );
+    }
+  }
+
+  const auto stop_time = steady_clock::now();
+
+  if ( not reassembler.reader().is_finished() ) {
+    throw runtime_error( "Reassembler did not close ByteStream when finished" );
+  }
+
+  if ( data != output_data ) {
+    throw runtime_error( "Mismatch between data written and read" );
+  }
+
+  auto test_duration = duration_cast<duration<double>>( stop_time - start_time );
+  auto bytes_per_second = static_cast<double>( num_chunks * capacity ) / test_duration.count();
+  auto bits_per_second = 8 * bytes_per_second;
+  auto gigabits_per_second = bits_per_second / 1e9;
+
+  fstream debug_output;
+  debug_output.open( "/dev/tty" );
+
+  cout << "Reassembler to ByteStream with capacity=" << capacity << " reached " << fixed << setprecision( 2 )
+       << gigabits_per_second << " Gbit/s.\n";
+
+  debug_output << "        Reassembler throughput " << scenario << fixed << setprecision( 2 ) << setw( 5 )
+               << gigabits_per_second << " Gbit/s\n";
+
+  if ( gigabits_per_second < 0.1 ) {
+    throw runtime_error( "Reassembler did not meet minimum speed of 0.1 Gbit/s." );
+  }
+}
+
+void program_body()
+{
+  speed_test( 1000, 1500, 1500, 32768, 1370, "(no overlap):  " );
+  speed_test( 1000, 1500, 150, 32768, 6163, "(10x overlap): " );
+}
+
+int main()
+{
+  try {
+    program_body();
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_test_harness.hh
+++ b/tests/reassembler_test_harness.hh
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "common.hh"
+#include "helpers.hh"
+#include "reassembler.hh"
+
+#include <sstream>
+#include <utility>
+
+template<std::derived_from<TestStep<ByteStream>> T>
+struct ReassemblerTestStep : public TestStep<Reassembler>
+{
+  T step_;
+
+  explicit ReassemblerTestStep( T byte_stream_test_step )
+    : TestStep<Reassembler>(), step_( std::move( byte_stream_test_step ) )
+  {}
+
+  std::string str() const override { return step_.str(); }
+  uint8_t color() const override { return step_.color(); }
+  void execute( Reassembler& r ) const override { step_.execute( r.reader() ); }
+  constexpr std::string obj() const override { return step_.obj(); }
+};
+
+class ReassemblerTestHarness : public TestHarness<Reassembler>
+{
+public:
+  ReassemblerTestHarness( std::string test_name, uint64_t capacity )
+    : TestHarness( move( test_name ),
+                   "capacity=" + std::to_string( capacity ),
+                   { Reassembler { ByteStream { capacity } } } )
+  {}
+
+  template<std::derived_from<TestStep<ByteStream>> T>
+  void execute( const T& test )
+  {
+    TestHarness<Reassembler>::execute( ReassemblerTestStep { test } );
+  }
+
+  using TestHarness<Reassembler>::execute;
+};
+
+struct BytesPending : public ExpectNumber<Reassembler, uint64_t>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "count_bytes_pending"; }
+  uint64_t value( const Reassembler& r ) const override { return r.count_bytes_pending(); }
+};
+
+struct Insert : public Action<Reassembler>
+{
+  std::string data_;
+  uint64_t first_index_;
+  bool is_last_substring_ {};
+
+  Insert( std::string data, uint64_t first_index ) : data_( move( data ) ), first_index_( first_index ) {}
+
+  Insert& is_last( bool status = true )
+  {
+    is_last_substring_ = status;
+    return *this;
+  }
+
+  std::string description() const override
+  {
+    std::ostringstream ss;
+    ss << "insert \"" << pretty_print( data_ ) << "\" @ index " << first_index_;
+    if ( is_last_substring_ ) {
+      ss << " [last substring]";
+    }
+    return ss.str();
+  }
+
+  void execute( Reassembler& r ) const override { r.insert( first_index_, data_, is_last_substring_ ); }
+};

--- a/tests/reassembler_win.cc
+++ b/tests/reassembler_win.cc
@@ -1,0 +1,51 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+
+#include <algorithm>
+#include <exception>
+#include <iostream>
+#include <tuple>
+#include <vector>
+
+using namespace std;
+
+static constexpr size_t NREPS = 32;
+static constexpr size_t NSEGS = 128;
+static constexpr size_t MAX_SEG_LEN = 2048;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    // overlapping segments
+    for ( unsigned rep_no = 0; rep_no < NREPS; ++rep_no ) {
+      ReassemblerTestHarness sr { "win test " + to_string( rep_no ), NSEGS * MAX_SEG_LEN };
+
+      vector<tuple<size_t, size_t>> seq_size;
+      size_t offset = 0;
+      for ( unsigned i = 0; i < NSEGS; ++i ) {
+        const size_t size = 1 + ( rd() % ( MAX_SEG_LEN - 1 ) );
+        const size_t offs = min( offset, 1 + ( static_cast<size_t>( rd() ) % 1023 ) );
+        seq_size.emplace_back( offset - offs, size + offs );
+        offset += size;
+      }
+      shuffle( seq_size.begin(), seq_size.end(), rd );
+
+      string d( offset, 0 );
+      generate( d.begin(), d.end(), [&] { return rd(); } );
+
+      for ( auto [off, sz] : seq_size ) {
+        sr.execute( Insert { d.substr( off, sz ), off }.is_last( off + sz == offset ) );
+      }
+
+      sr.execute( ReadAll { d } );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/receiver_test_harness.hh
+++ b/tests/receiver_test_harness.hh
@@ -1,0 +1,179 @@
+#pragma once
+
+#include "common.hh"
+#include "tcp_receiver.hh"
+#include "tcp_receiver_message.hh"
+
+#include <optional>
+#include <sstream>
+#include <utility>
+
+template<std::derived_from<TestStep<Reassembler>> T>
+struct DirectReassemblerTest : public TestStep<TCPReceiver>
+{
+  T step_;
+
+  explicit DirectReassemblerTest( T sr_test_step ) : TestStep<TCPReceiver>(), step_( std::move( sr_test_step ) ) {}
+
+  std::string str() const override { return step_.str(); }
+  uint8_t color() const override { return step_.color(); }
+  void execute( TCPReceiver& sr ) const override { step_.execute( sr.reassembler() ); }
+  constexpr std::string obj() const override { return step_.obj(); }
+};
+
+template<std::derived_from<TestStep<ByteStream>> T>
+struct DirectByteStreamTest : public TestStep<TCPReceiver>
+{
+  T step_;
+
+  explicit DirectByteStreamTest( T sr_test_step ) : TestStep<TCPReceiver>(), step_( std::move( sr_test_step ) ) {}
+
+  std::string str() const override { return step_.str(); }
+  uint8_t color() const override { return step_.color(); }
+  void execute( TCPReceiver& sr ) const override { step_.execute( sr.reader() ); }
+  constexpr std::string obj() const override { return step_.obj(); }
+};
+
+class TCPReceiverTestHarness : public TestHarness<TCPReceiver>
+{
+public:
+  TCPReceiverTestHarness( std::string test_name, uint64_t capacity )
+    : TestHarness( move( test_name ),
+                   "capacity=" + std::to_string( capacity ),
+                   { TCPReceiver { Reassembler { ByteStream { capacity } } } } )
+  {}
+
+  template<std::derived_from<TestStep<Reassembler>> T>
+  void execute( const T& test )
+  {
+    TestHarness<TCPReceiver>::execute( DirectReassemblerTest { test } );
+  }
+
+  template<std::derived_from<TestStep<ByteStream>> T>
+  void execute( const T& test )
+  {
+    TestHarness<TCPReceiver>::execute( DirectByteStreamTest { test } );
+  }
+
+  using TestHarness<TCPReceiver>::execute;
+};
+
+struct ExpectWindow : public ExpectNumber<TCPReceiver, uint16_t>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "window_size"; }
+  uint16_t value( const TCPReceiver& rs ) const override { return rs.send().window_size; }
+};
+
+struct ExpectAckno : public ExpectNumber<TCPReceiver, std::optional<Wrap32>>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "ackno"; }
+  std::optional<Wrap32> value( const TCPReceiver& rs ) const override { return rs.send().ackno; }
+};
+
+struct ExpectReset : public ExpectBool<TCPReceiver>
+{
+  using ExpectBool::ExpectBool;
+  std::string name() const override { return "RST"; }
+
+  bool value( const TCPReceiver& rs ) const override { return rs.send().RST; }
+};
+
+struct ExpectAcknoBetween : public Expectation<TCPReceiver>
+{
+  Wrap32 isn_;
+  uint64_t checkpoint_;
+  uint64_t min_, max_;
+  ExpectAcknoBetween( Wrap32 isn, uint64_t checkpoint, uint64_t min, uint64_t max ) // NOLINT(*-swappable-*)
+    : isn_( isn ), checkpoint_( checkpoint ), min_( min ), max_( max )
+  {}
+
+  std::string description() const override
+  {
+    return "ackno unwraps to between " + to_string( min_ ) + " and " + to_string( max_ );
+  }
+
+  void execute( const TCPReceiver& rs ) const override
+  {
+    auto ackno = rs.send().ackno;
+    if ( not ackno.has_value() ) {
+      throw ExpectationViolation( "ackno did not have value" );
+    }
+    const uint64_t ackno_absolute = ackno.value().unwrap( isn_, checkpoint_ );
+
+    if ( ackno_absolute < min_ or ackno_absolute > max_ ) {
+      throw ExpectationViolation( "ackno outside expected range" );
+    }
+  }
+};
+
+struct HasAckno : public ExpectBool<TCPReceiver>
+{
+  using ExpectBool::ExpectBool;
+  std::string name() const override { return "ackno.has_value()"; }
+  bool value( const TCPReceiver& rs ) const override { return rs.send().ackno.has_value(); }
+};
+
+struct SegmentArrives : public Action<TCPReceiver>
+{
+  TCPSenderMessage msg_ {};
+  HasAckno ackno_expected_ { true };
+
+  SegmentArrives& with_syn()
+  {
+    msg_.SYN = true;
+    return *this;
+  }
+
+  SegmentArrives& with_fin()
+  {
+    msg_.FIN = true;
+    return *this;
+  }
+
+  SegmentArrives& with_rst()
+  {
+    msg_.RST = true;
+    return *this;
+  }
+
+  SegmentArrives& with_seqno( Wrap32 seqno_ )
+  {
+    msg_.seqno = seqno_;
+    return *this;
+  }
+
+  SegmentArrives& with_seqno( uint32_t seqno_ ) { return with_seqno( Wrap32 { seqno_ } ); }
+
+  SegmentArrives& with_data( std::string data )
+  {
+    msg_.payload = move( data );
+    return *this;
+  }
+
+  SegmentArrives& without_ackno()
+  {
+    ackno_expected_ = HasAckno { false };
+    return *this;
+  }
+
+  void execute( TCPReceiver& rs ) const override
+  {
+    rs.receive( msg_ );
+    ackno_expected_.execute( rs );
+  }
+
+  std::string description() const override
+  {
+    std::ostringstream ss;
+    ss << "receive message: " << to_string( msg_ );
+
+    if ( ackno_expected_.value_ ) {
+      ss << " with ackno expected";
+    } else {
+      ss << " with ackno not expected";
+    }
+    return ss.str();
+  }
+};

--- a/tests/recv_close.cc
+++ b/tests/recv_close.cc
@@ -1,0 +1,54 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "close 1", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn + 0 ) );
+      test.execute( IsClosed { false } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( isn + 1 ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 2 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( Peek { "" } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( IsClosed { true } );
+    }
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "close 2", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn + 0 ) );
+      test.execute( IsClosed { false } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( isn + 1 ).with_data( "a" ) );
+      test.execute( IsClosed { true } );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( ReadAll { "a" } );
+      test.execute( BytesPushed { 1 } );
+      test.execute( IsClosed { true } );
+      test.execute( IsFinished { true } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_close.cc
+++ b/tests/recv_close.cc
@@ -45,6 +45,21 @@ int main()
       test.execute( IsFinished { true } );
     }
 
+    // test credit: Derek Askaryar
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "close 3", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abc" ) );
+      test.execute( ReadAll { "abc" } );
+      test.execute( BytesPushed { 3 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 4 ).with_fin() );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( IsClosed { true } );
+      test.execute( IsFinished { true } );
+    }
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return 1;

--- a/tests/recv_connect.cc
+++ b/tests/recv_connect.cc
@@ -1,0 +1,121 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <optional>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      TCPReceiverTestHarness test { "connect 1", 4000 };
+      test.execute( ExpectWindow { 4000 } );
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( 0 ) );
+      test.execute( ExpectAckno { Wrap32 { 1 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "connect 2", 5435 };
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( 89347598 ) );
+      test.execute( ExpectAckno { Wrap32 { 89347599 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "connect 3", 5435 };
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( 893475 ).without_ackno() );
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "connect 4", 5435 };
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( 893475 ).without_ackno() );
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "connect 5", 5435 };
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( 893475 ).without_ackno() );
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( 89347598 ) );
+      test.execute( ExpectAckno { Wrap32 { 89347599 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "connect 6", 4000 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( 5 ).with_fin() );
+      test.execute( IsClosed { true } );
+      test.execute( ExpectAckno { Wrap32 { 7 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size zero", 0 };
+      test.execute( ExpectWindow { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size 50", 50 };
+      test.execute( ExpectWindow { 50 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size at max", UINT16_MAX };
+      test.execute( ExpectWindow { UINT16_MAX } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size at max+1", UINT16_MAX + 1 };
+      test.execute( ExpectWindow { UINT16_MAX } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size at max+5", UINT16_MAX + 5 };
+      test.execute( ExpectWindow { UINT16_MAX } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size at 10M", 10'000'000 };
+      test.execute( ExpectWindow { UINT16_MAX } );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_reorder.cc
+++ b/tests/recv_reorder.cc
@@ -1,0 +1,137 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "in-window, later segment", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 10 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 4 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "in-window, later segment, then hole filled", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "efgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 4 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 9 } } );
+      test.execute( ReadAll { "abcdefgh" } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 8 } );
+    }
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "hole filled bit-by-bit", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "efgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 4 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "ab" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+      test.execute( ReadAll { "ab" } );
+      test.execute( BytesPending { 4 } );
+      test.execute( BytesPushed { 2 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 3 ).with_data( "cd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 9 } } );
+      test.execute( ReadAll { "cdefgh" } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 8 } );
+    }
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "many gaps, filled bit-by-bit", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "e" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 1 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 7 ).with_data( "g" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 2 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 3 ).with_data( "c" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 3 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "ab" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 4 } } );
+      test.execute( ReadAll { "abc" } );
+      test.execute( BytesPending { 2 } );
+      test.execute( BytesPushed { 3 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 6 ).with_data( "f" ) );
+      test.execute( BytesPending { 3 } );
+      test.execute( BytesPushed { 3 } );
+      test.execute( ReadAll { "" } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 4 ).with_data( "d" ) );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 7 } );
+      test.execute( ReadAll { "defg" } );
+    }
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "many gaps, then subsumed", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "e" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 1 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 7 ).with_data( "g" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 2 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 3 ).with_data( "c" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 3 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcdefgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 9 } } );
+      test.execute( ReadAll { "abcdefgh" } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 8 } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_reorder_more.cc
+++ b/tests/recv_reorder_more.cc
@@ -1,0 +1,125 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+#include "tcp_config.hh"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+using namespace std;
+
+static constexpr unsigned NREPS = 64;
+
+void do_test_1( const TCPConfig& cfg, default_random_engine& rd )
+{
+  const Wrap32 rx_isn( rd() );
+  TCPReceiverTestHarness test_1 { "non-overlapping out-of-order segments", cfg.recv_capacity };
+  test_1.execute( SegmentArrives {}.with_seqno( rx_isn ).with_syn() );
+  vector<tuple<size_t, size_t>> seq_size;
+  size_t datalen = 0;
+  while ( datalen < cfg.recv_capacity ) {
+    const size_t size = min( 1 + ( static_cast<size_t>( rd() ) % ( TCPConfig::MAX_PAYLOAD_SIZE - 1 ) ),
+                             cfg.recv_capacity - datalen );
+    seq_size.emplace_back( datalen, size );
+    datalen += size;
+  }
+  shuffle( seq_size.begin(), seq_size.end(), rd );
+
+  string d( datalen, 0 );
+  generate( d.begin(), d.end(), [&] { return rd(); } );
+
+  uint64_t min_expect_ackno = 1;
+  uint64_t max_expect_ackno = 1;
+  for ( auto [off, sz] : seq_size ) {
+    test_1.execute( SegmentArrives {}.with_seqno( rx_isn + 1 + off ).with_data( d.substr( off, sz ) ) );
+    if ( off + 1 == min_expect_ackno ) {
+      min_expect_ackno = min_expect_ackno + sz;
+    }
+    max_expect_ackno = max_expect_ackno + sz;
+    test_1.execute( ExpectAcknoBetween { rx_isn, off, min_expect_ackno, max_expect_ackno } );
+  }
+
+  test_1.execute( BytesPending { 0 } );
+  test_1.execute( ReadAll { d } );
+}
+
+void do_test_2( const TCPConfig& cfg, default_random_engine& rd )
+{
+  const Wrap32 rx_isn( rd() );
+  TCPReceiverTestHarness test_2 { "overlapping out-of-order segments", cfg.recv_capacity };
+  test_2.execute( SegmentArrives {}.with_seqno( rx_isn ).with_syn() );
+  vector<tuple<size_t, size_t>> seq_size;
+  size_t datalen = 0;
+  while ( datalen < cfg.recv_capacity ) {
+    const size_t size = min( 1 + ( static_cast<size_t>( rd() ) % ( TCPConfig::MAX_PAYLOAD_SIZE - 1 ) ),
+                             cfg.recv_capacity - datalen );
+    const size_t rem = TCPConfig::MAX_PAYLOAD_SIZE - size;
+    size_t offs = 0;
+    if ( rem == 0 ) {
+      offs = 0;
+    } else if ( rem == 1 ) {
+      offs = min( static_cast<size_t>( 1 ), datalen );
+    } else {
+      offs = min( min( datalen, rem ), 1 + ( static_cast<size_t>( rd() ) % ( rem - 1 ) ) );
+    }
+
+    if ( size + offs > TCPConfig::MAX_PAYLOAD_SIZE ) {
+      throw runtime_error( "test 2 internal error: bad payload size" );
+    }
+    seq_size.emplace_back( datalen - offs, size + offs );
+    datalen += size;
+  }
+  if ( datalen > cfg.recv_capacity ) {
+    throw runtime_error( "test 2 internal error: bad offset sequence" );
+  }
+  shuffle( seq_size.begin(), seq_size.end(), rd );
+
+  string d( datalen, 0 );
+  generate( d.begin(), d.end(), [&] { return rd(); } );
+
+  uint64_t min_expect_ackno = 1;
+  uint64_t max_expect_ackno = 1;
+  for ( auto [off, sz] : seq_size ) {
+    test_2.execute( SegmentArrives {}.with_seqno( rx_isn + 1 + off ).with_data( d.substr( off, sz ) ) );
+    if ( off + 1 <= min_expect_ackno && off + sz + 1 > min_expect_ackno ) {
+      min_expect_ackno = sz + off;
+    }
+    max_expect_ackno = max_expect_ackno + sz; // really loose because of overlap
+    test_2.execute( ExpectAcknoBetween { rx_isn, off, min_expect_ackno, max_expect_ackno } );
+  }
+
+  test_2.execute( BytesPending { 0 } );
+  test_2.execute( ReadAll { d } );
+}
+
+int main()
+{
+  try {
+    TCPConfig cfg {};
+    cfg.recv_capacity = 65000;
+    auto rd = get_random_engine();
+
+    // non-overlapping out-of-order segments
+    for ( unsigned rep_no = 0; rep_no < NREPS; ++rep_no ) {
+      do_test_1( cfg, rd );
+    }
+
+    // overlapping out-of-order segments
+    for ( unsigned rep_no = 0; rep_no < NREPS; ++rep_no ) {
+      do_test_2( cfg, rd );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_special.cc
+++ b/tests/recv_special.cc
@@ -1,0 +1,287 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    /* segment before SYN */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment before SYN", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "hello" ).without_ackno() );
+      test.execute( HasAckno { false } );
+      test.execute( BytesPending { 0 } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( HasAckno { true } );
+      test.execute( IsClosed { false } );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+    }
+
+    /* segment with SYN + data */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment with SYN + data", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ).with_data( "Hello, CS144!" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 14 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( ReadAll { "Hello, CS144!" } );
+      test.execute( IsClosed { false } );
+    }
+
+    /* empty segment */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "empty segment", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ) );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( IsClosed { false } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ) );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( IsClosed { false } );
+    }
+
+    /* segment with null byte */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment with null byte", 4000 };
+      const string text = "Here's a null byte:"s + '\0' + "and it's gone."s;
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( text ) );
+      test.execute( ReadAll { string( text ) } );
+      test.execute( ExpectAckno { Wrap32 { isn + 35 } } );
+      test.execute( IsClosed { false } );
+    }
+
+    /* segment with data + FIN */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment with data + FIN", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_fin().with_data( "Goodbye, CS144!" ).with_seqno( isn + 1 ) );
+      test.execute( IsClosed { true } );
+      test.execute( ReadAll { "Goodbye, CS144!" } );
+      test.execute( ExpectAckno { Wrap32 { isn + 17 } } );
+      test.execute( IsFinished { true } );
+    }
+
+    /* segment with FIN (but can't be assembled yet) */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment with FIN (but can't be assembled yet)", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_fin().with_data( "oodbye, CS144!" ).with_seqno( isn + 2 ) );
+      test.execute( ReadAll { "" } );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( IsClosed { false } );
+      test.execute( SegmentArrives {}.with_data( "G" ).with_seqno( isn + 1 ) );
+      test.execute( IsClosed { true } );
+      test.execute( ReadAll { "Goodbye, CS144!" } );
+      test.execute( ExpectAckno { Wrap32 { isn + 17 } } );
+      test.execute( IsFinished { true } );
+    }
+
+    /* segment with SYN + data + FIN */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment with SYN + payload + FIN", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute(
+        SegmentArrives {}.with_syn().with_seqno( isn ).with_data( "Hello and goodbye, CS144!" ).with_fin() );
+      test.execute( IsClosed { true } );
+      test.execute( ExpectAckno { Wrap32 { isn + 27 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( ReadAll { "Hello and goodbye, CS144!" } );
+      test.execute( IsFinished { true } );
+    }
+
+    // credit: Mustafa Bayramov
+    {
+      const size_t cap = 10;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "buffer full, keep pushing", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ExpectWindow { cap } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcde" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 6 } } );
+      test.execute( ExpectWindow { cap - 5 } );
+      test.execute( BytesPushed { 5 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 6 ).with_data( "fghij" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 11 } } );
+      test.execute( ExpectWindow { 0 } );
+      test.execute( BytesPushed { 10 } );
+      // buffer we keep pushing
+      test.execute( SegmentArrives {}.with_seqno( isn + 11 ).with_data( "klmno" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 11 } } );
+      test.execute( ExpectWindow { 0 } );
+      test.execute( BytesPushed { 10 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 16 ).with_data( "pqrst" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 11 } } );
+      test.execute( ExpectWindow { 0 } );
+      test.execute( BytesPushed { 10 } );
+      test.execute( ReadAll { "abcdefghij" } );
+    }
+
+    {
+      const size_t cap = 10;
+      const uint32_t isn = 12345;
+      TCPReceiverTestHarness test { "missing first byte in the first segment", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 2 ).with_data( "a" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 4 ).with_data( "b" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 6 ).with_data( "c" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 8 ).with_data( "d" ) );
+      test.execute( BytesPushed { 0 } );
+      test.execute( ExpectWindow { 10 } );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+    }
+
+    {
+      const size_t cap = 10;
+      const uint32_t isn = 123456;
+      TCPReceiverTestHarness test { "pushing bytes in reverse order in initial SYN", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      string bytes = { 'j', 'i', 'h', 'g', 'f', 'e', 'd', 'c', 'b', 'a' };
+      for ( int i = cap - 1; i >= 1; --i ) {
+        test.execute( SegmentArrives {}.with_seqno( isn + i + 1 ).with_data( string( 1, bytes[cap - i - 1] ) ) );
+        test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+        test.execute( BytesPushed { 0 } );
+        test.execute( ExpectWindow { 10 } );
+      }
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( string( 1, bytes[cap - 1] ) ) );
+      test.execute( BytesPushed { bytes.size() } );
+      test.execute( ExpectWindow { 0 } );
+      test.execute( ExpectAckno { Wrap32 { static_cast<uint32_t>( isn + bytes.size() + 1 ) } } );
+      test.execute( ReadAll { "abcdefghij" } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "Stream error -> RST flag", 10 };
+      test.execute( SetError {} );
+      test.execute( ExpectReset { true } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "No stream error -> no RST flag", 10 };
+      test.execute( ExpectReset { false } );
+    }
+
+    {
+      // The spec is more restrictive on RST acceptance; we use simpler logic in CS144.
+      TCPReceiverTestHarness test { "RST flag set -> stream error", 10 };
+      test.execute( SegmentArrives {}.with_seqno( rd() ).with_rst().without_ackno() );
+      test.execute( HasError { true } );
+    }
+
+    {
+      // test credit: Majd Nasra
+      ReassemblerTestHarness test { "segment already seen in full", 3 };
+
+      test.execute( Insert { "abc", 0 } );
+      test.execute( ReadAll( "abc" ) );
+      test.execute( BytesPushed( 3 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( Insert { "ab", 0 } );
+      test.execute( ReadAll( "" ) ); // tests if the code double-pushes segments already seen in the stream.
+      test.execute( BytesPushed( 3 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Credit: Max Jardetzky
+      ReassemblerTestHarness test { "insert within capacity", 4 };
+
+      test.execute( Insert { "bc", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 2 ) );
+
+      test.execute( Insert { "bcd", 1 } );
+      test.execute( BytesPending( 3 ) );
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    // test credit: Tanmay Garg and Agam Mohan Singh Bhatia
+    {
+      ReassemblerTestHarness test { "insert last fully beyond capacity + empty string is last", 2 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "abc", 0 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "", 3 }.is_last() );
+      test.execute( IsFinished { false } );
+
+      test.execute( ReadAll( "ab" ) );
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( ReadAll( "c" ) );
+      test.execute( IsFinished { true } );
+    }
+
+    // test credit: Noah Schechter
+    // More than 2^16 bytes sent in sets of 1000
+    {
+      TCPReceiverTestHarness test { "proper wrapping when sending more than 2^16bytes", 4000 };
+      const uint32_t block_size = 1000;
+      const uint32_t n_rounds = 67;
+      const uint32_t isn = 0;
+      size_t bytes_sent = 0;
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      for ( uint32_t i = 0; i < n_rounds; ++i ) {
+        string data;
+        for ( uint32_t j = 0; j < block_size; ++j ) {
+          const uint8_t c = 'a' + ( ( i + j ) % 26 );
+          data.push_back( static_cast<char>( c ) );
+        }
+        test.execute( ExpectAckno { make_optional<Wrap32>( isn + bytes_sent + 1 ) } );
+        test.execute( BytesPushed { bytes_sent } );
+        test.execute( SegmentArrives {}.with_seqno( isn + bytes_sent + 1 ).with_data( data ) );
+        bytes_sent += block_size;
+        test.execute( ReadAll { move( data ) } );
+      }
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_special.cc
+++ b/tests/recv_special.cc
@@ -278,6 +278,19 @@ int main()
         test.execute( ReadAll { move( data ) } );
       }
     }
+
+    // credit for test: Danica Xiong
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "retransmission of FIN", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "a" ) );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( isn + 2 ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( isn + 2 ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+    }
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return 1;

--- a/tests/recv_transmit.cc
+++ b/tests/recv_transmit.cc
@@ -1,0 +1,115 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPReceiverTestHarness test { "transmit 1", 4000 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( 0 ) );
+      test.execute( SegmentArrives {}.with_seqno( 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { 5 } } );
+      test.execute( ReadAll { "abcd" } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 4 } );
+    }
+
+    {
+      const uint32_t isn = 384678;
+      TCPReceiverTestHarness test { "transmit 2", 4000 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 4 } );
+      test.execute( ReadAll { "abcd" } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "efgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 9 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 8 } );
+      test.execute( ReadAll { "efgh" } );
+    }
+
+    {
+      const uint32_t isn = 5;
+      TCPReceiverTestHarness test { "transmit 3", 4000 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 4 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "efgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 9 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 8 } );
+      test.execute( ReadAll { "abcdefgh" } );
+    }
+
+    // Many (arrive/read)s
+    {
+      TCPReceiverTestHarness test { "transmit 4", 4000 };
+      const uint32_t max_block_size = 10;
+      const uint32_t n_rounds = 10000;
+      const uint32_t isn = 893472;
+      size_t bytes_sent = 0;
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      for ( uint32_t i = 0; i < n_rounds; ++i ) {
+        string data;
+        const uint32_t block_size = uniform_int_distribution<uint32_t> { 1, max_block_size }( rd );
+        for ( uint32_t j = 0; j < block_size; ++j ) {
+          const uint8_t c = 'a' + ( ( i + j ) % 26 );
+          data.push_back( static_cast<char>( c ) );
+        }
+        test.execute( ExpectAckno { make_optional<Wrap32>( isn + bytes_sent + 1 ) } );
+        test.execute( BytesPushed { bytes_sent } );
+        test.execute( SegmentArrives {}.with_seqno( isn + bytes_sent + 1 ).with_data( data ) );
+        bytes_sent += block_size;
+        test.execute( ReadAll { move( data ) } );
+      }
+    }
+
+    // Many arrives, one read
+    {
+      const uint64_t max_block_size = 10;
+      const uint64_t n_rounds = 100;
+      TCPReceiverTestHarness test { "transmit 5", max_block_size * n_rounds };
+      const uint32_t isn = 238;
+      size_t bytes_sent = 0;
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      string all_data;
+      for ( uint32_t i = 0; i < n_rounds; ++i ) {
+        string data;
+        const uint32_t block_size = uniform_int_distribution<uint32_t> { 1, max_block_size }( rd );
+        for ( uint32_t j = 0; j < block_size; ++j ) {
+          const uint8_t c = 'a' + ( ( i + j ) % 26 );
+          const char ch = static_cast<char>( c );
+          data.push_back( ch );
+          all_data.push_back( ch );
+        }
+        test.execute( ExpectAckno { make_optional<Wrap32>( isn + bytes_sent + 1 ) } );
+        test.execute( BytesPushed { bytes_sent } );
+        test.execute( SegmentArrives {}.with_seqno( isn + bytes_sent + 1 ).with_data( data ) );
+        bytes_sent += block_size;
+      }
+      test.execute( ReadAll { move( all_data ) } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_window.cc
+++ b/tests/recv_window.cc
@@ -1,0 +1,115 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      const size_t cap = 4000;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "window size decreases appropriately", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ExpectWindow { cap } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( ExpectWindow { cap - 4 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 9 ).with_data( "ijkl" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( ExpectWindow { cap - 4 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "efgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 13 } } );
+      test.execute( ExpectWindow { cap - 12 } );
+    }
+
+    {
+      const size_t cap = 4000;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "window size expands after pop", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ExpectWindow { cap } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( ExpectWindow { cap - 4 } );
+      test.execute( ReadAll { "abcd" } );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( ExpectWindow { cap } );
+    }
+
+    {
+      const size_t cap = 2;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "arriving segment with high seqno", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 2 ).with_data( "bc" ) );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "a" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+      test.execute( ExpectWindow { 0 } );
+      test.execute( BytesPushed { 2 } );
+      test.execute( ReadAll { "ab" } );
+      test.execute( ExpectWindow { 2 } );
+    }
+
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 294058;
+      TCPReceiverTestHarness test { "arriving segment with low seqno", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_data( "ab" ).with_seqno( isn + 1 ) );
+      test.execute( BytesPushed { 2 } );
+      test.execute( ExpectWindow { cap - 2 } );
+      test.execute( SegmentArrives {}.with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( BytesPushed { 3 } );
+      test.execute( ExpectWindow { cap - 3 } );
+      test.execute( ReadAll { "abc" } );
+    }
+
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "segment overflowing window on left side", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "ab" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 3 ).with_data( "cdef" ) );
+      test.execute( ReadAll { "abcd" } );
+    }
+
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "segment matching window", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "ab" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 3 ).with_data( "cd" ) );
+      test.execute( ReadAll { "abcd" } );
+    }
+
+    // credit for test: Jared Wasserman + Anonymous
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "byte with invalid stream index should be ignored", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn ).with_data( "a" ) );
+      test.execute( BytesPushed { 0 } );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( BytesPending( 0 ) );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/router.cc
+++ b/tests/router.cc
@@ -1,0 +1,361 @@
+#include "router.hh"
+#include "network_interface_test_harness.hh"
+
+#include <algorithm>
+#include <iostream>
+#include <list>
+#include <random>
+#include <unordered_map>
+#include <utility>
+
+using namespace std;
+
+EthernetAddress random_host_ethernet_address()
+{
+  EthernetAddress addr;
+  for ( auto& byte : addr ) {
+    byte = random_device()(); // use a random local Ethernet address
+  }
+  addr.at( 0 ) |= 0x02; // "10" in last two binary digits marks a private Ethernet address
+  addr.at( 0 ) &= 0xfe;
+
+  return addr;
+}
+
+EthernetAddress random_router_ethernet_address()
+{
+  EthernetAddress addr;
+  for ( auto& byte : addr ) {
+    byte = random_device()(); // use a random local Ethernet address
+  }
+  addr.at( 0 ) = 0x02; // "10" in last two binary digits marks a private Ethernet address
+  addr.at( 1 ) = 0;
+  addr.at( 2 ) = 0;
+
+  return addr;
+}
+
+uint32_t ip( const string& str )
+{
+  return Address { str }.ipv4_numeric();
+}
+
+class NetworkSegment : public NetworkInterface::OutputPort
+{
+  vector<weak_ptr<NetworkInterface>> connections_ {};
+
+  queue<pair<string, EthernetFrame>> in_flight_ {};
+
+public:
+  void run()
+  {
+    while ( not in_flight_.empty() ) {
+      for ( auto& i : connections_ ) {
+        const shared_ptr<NetworkInterface> interface { i };
+        if ( in_flight_.front().first != interface->name() ) {
+          cerr << "Transferring frame from " << in_flight_.front().first << " to " << interface->name() << ": "
+               << summary( in_flight_.front().second ) << "\n";
+          interface->recv_frame( clone( in_flight_.front().second ) );
+        }
+      }
+      in_flight_.pop();
+    }
+  }
+
+  void transmit( const NetworkInterface& sender, const EthernetFrame& frame ) override
+  {
+    in_flight_.emplace( sender.name(), clone( frame ) );
+  }
+
+  void connect( const shared_ptr<NetworkInterface>& interface ) { connections_.push_back( interface ); }
+};
+
+class Host
+{
+  string _name;
+  Address _my_address;
+  shared_ptr<NetworkInterface> _interface;
+  Address _next_hop;
+
+  list<InternetDatagram> _expecting_to_receive {};
+
+  bool expecting( const InternetDatagram& expected ) const
+  {
+    return ranges::any_of( _expecting_to_receive, [&expected]( const auto& x ) { return equal( x, expected ); } );
+  }
+
+  void remove_expectation( const InternetDatagram& expected )
+  {
+    for ( auto it = _expecting_to_receive.begin(); it != _expecting_to_receive.end(); ++it ) {
+      if ( equal( *it, expected ) ) {
+        _expecting_to_receive.erase( it );
+        return;
+      }
+    }
+  }
+
+public:
+  // NOLINTNEXTLINE(*-easily-swappable-*)
+  Host( string name, const Address& my_address, const Address& next_hop, shared_ptr<NetworkSegment> network )
+    : _name( move( name ) )
+    , _my_address( my_address )
+    , _interface(
+        make_shared<NetworkInterface>( _name, move( network ), random_host_ethernet_address(), _my_address ) )
+    , _next_hop( next_hop )
+  {}
+
+  InternetDatagram send_to( const Address& destination, const uint8_t ttl = 64 )
+  {
+    InternetDatagram dgram;
+    dgram.header.src = _my_address.ipv4_numeric();
+    dgram.header.dst = destination.ipv4_numeric();
+    dgram.header.proto = 144;
+    dgram.payload.emplace_back( string { "Cardinal " + to_string( random_device()() % 1000 ) } );
+    dgram.header.len = static_cast<uint64_t>( dgram.header.hlen ) * 4 + dgram.payload.back()->size();
+    dgram.header.ttl = ttl;
+    dgram.header.compute_checksum();
+
+    cerr << "Host " << _name << " trying to send datagram (with next hop = " << _next_hop.ip()
+         << "): " << dgram.header.to_string() << +" payload=\"" + pretty_print( concat( dgram.payload ) ) + "\"\n";
+
+    _interface->send_datagram( dgram, _next_hop );
+
+    return dgram;
+  }
+
+  const Address& address() { return _my_address; }
+
+  shared_ptr<NetworkInterface> interface() { return _interface; }
+
+  void expect( const InternetDatagram& expected ) { _expecting_to_receive.push_back( clone( expected ) ); }
+
+  const string& name() { return _name; }
+
+  void check()
+  {
+    while ( not _interface->datagrams_received().empty() ) {
+      auto& dgram_received = _interface->datagrams_received().front();
+      if ( not expecting( dgram_received ) ) {
+        throw runtime_error( "Host " + _name
+                             + " received unexpected Internet datagram: " + dgram_received.header.to_string() );
+      }
+      remove_expectation( dgram_received );
+      _interface->datagrams_received().pop();
+    }
+
+    if ( not _expecting_to_receive.empty() ) {
+      throw runtime_error( "Host " + _name + " did NOT receive an expected Internet datagram: "
+                           + _expecting_to_receive.front().header.to_string() );
+    }
+  }
+};
+
+class Network
+{
+private:
+  Router _router {};
+
+  vector<shared_ptr<NetworkSegment>> segments_ { 6, make_shared<NetworkSegment>() };
+
+  shared_ptr<NetworkSegment> upstream { segments_.at( 0 ) };
+  shared_ptr<NetworkSegment> eth0_applesauce { segments_.at( 1 ) };
+  shared_ptr<NetworkSegment> eth2_cherrypie { segments_.at( 2 ) };
+  shared_ptr<NetworkSegment> uun { segments_.at( 3 ) };
+  shared_ptr<NetworkSegment> hs { segments_.at( 4 ) };
+  shared_ptr<NetworkSegment> empty { segments_.at( 5 ) };
+
+  size_t default_id, eth0_id, eth1_id, eth2_id, uun3_id, hs4_id, mit5_id;
+
+  unordered_map<string, Host> _hosts {};
+
+public:
+  Network()
+    : default_id( _router.add_interface( make_shared<NetworkInterface>( "default",
+                                                                        upstream,
+                                                                        random_router_ethernet_address(),
+                                                                        Address { "171.67.76.46" } ) ) )
+    , eth0_id( _router.add_interface( make_shared<NetworkInterface>( "eth0",
+                                                                     eth0_applesauce,
+                                                                     random_router_ethernet_address(),
+                                                                     Address { "10.0.0.1" } ) ) )
+    , eth1_id( _router.add_interface( make_shared<NetworkInterface>( "eth1",
+                                                                     empty,
+                                                                     random_router_ethernet_address(),
+                                                                     Address { "172.16.0.1" } ) ) )
+    , eth2_id( _router.add_interface( make_shared<NetworkInterface>( "eth2",
+                                                                     eth2_cherrypie,
+                                                                     random_router_ethernet_address(),
+                                                                     Address { "192.168.0.1" } ) ) )
+    , uun3_id( _router.add_interface( make_shared<NetworkInterface>( "uun3",
+                                                                     uun,
+                                                                     random_router_ethernet_address(),
+                                                                     Address { "198.178.229.1" } ) ) )
+    , hs4_id( _router.add_interface(
+        make_shared<NetworkInterface>( "hs4", hs, random_router_ethernet_address(), Address { "143.195.0.2" } ) ) )
+    , mit5_id( _router.add_interface( make_shared<NetworkInterface>( "mit5",
+                                                                     empty,
+                                                                     random_router_ethernet_address(),
+                                                                     Address { "128.30.76.255" } ) ) )
+  {
+    _hosts.insert(
+      { "applesauce", Host { "applesauce", Address { "10.0.0.2" }, Address { "10.0.0.1" }, eth0_applesauce } } );
+    _hosts.insert(
+      { "default_router", Host { "default_router", Address { "171.67.76.1" }, Address { "0" }, upstream } } );
+    _hosts.insert(
+      { "cherrypie", Host { "cherrypie", Address { "192.168.0.2" }, Address { "192.168.0.1" }, eth2_cherrypie } } );
+    _hosts.insert( { "hs_router", Host { "hs_router", Address { "143.195.0.1" }, Address { "0" }, hs } } );
+    _hosts.insert( { "dm42", Host { "dm42", Address { "198.178.229.42" }, Address { "198.178.229.1" }, uun } } );
+    _hosts.insert( { "dm43", Host { "dm43", Address { "198.178.229.43" }, Address { "198.178.229.1" }, uun } } );
+
+    upstream->connect( _router.interface( default_id ) );
+    upstream->connect( host( "default_router" ).interface() );
+
+    eth0_applesauce->connect( _router.interface( eth0_id ) );
+    eth0_applesauce->connect( host( "applesauce" ).interface() );
+
+    eth2_cherrypie->connect( _router.interface( eth2_id ) );
+    eth2_cherrypie->connect( host( "cherrypie" ).interface() );
+
+    uun->connect( _router.interface( uun3_id ) );
+    uun->connect( host( "dm42" ).interface() );
+    uun->connect( host( "dm43" ).interface() );
+
+    hs->connect( _router.interface( hs4_id ) );
+    hs->connect( host( "hs_router" ).interface() );
+
+    _router.add_route( ip( "10.0.0.0" ), 8, {}, eth0_id );
+    _router.add_route( ip( "172.16.0.0" ), 16, {}, eth1_id );
+    _router.add_route( ip( "192.168.0.0" ), 24, {}, eth2_id );
+    _router.add_route( ip( "0.0.0.0" ), 0, host( "default_router" ).address(), default_id );
+    _router.add_route( ip( "198.178.229.0" ), 24, {}, uun3_id );
+    _router.add_route( ip( "143.195.0.0" ), 17, host( "hs_router" ).address(), hs4_id );
+    _router.add_route( ip( "143.195.128.0" ), 18, host( "hs_router" ).address(), hs4_id );
+    _router.add_route( ip( "143.195.192.0" ), 19, host( "hs_router" ).address(), hs4_id );
+    _router.add_route( ip( "128.30.76.255" ), 16, Address { "128.30.0.1" }, mit5_id );
+  }
+
+  void simulate()
+  {
+    for ( unsigned int i = 0; i < 256; i++ ) {
+      _router.route();
+      for ( auto& seg : segments_ ) {
+        seg->run();
+      }
+    }
+
+    for ( auto& host : _hosts ) {
+      host.second.check();
+    }
+  }
+
+  Host& host( const string& name )
+  {
+    auto it = _hosts.find( name );
+    if ( it == _hosts.end() ) {
+      throw runtime_error( "unknown host: " + name );
+    }
+    if ( it->second.name() != name ) {
+      throw runtime_error( "invalid host: " + name );
+    }
+    return it->second;
+  }
+};
+
+void network_simulator()
+{
+  const string green = "\033[32;1m";
+  const string normal = "\033[m";
+
+  cerr << green << "Constructing network." << normal << "\n";
+
+  Network network;
+
+  cout << green << "\n\nTesting traffic between two ordinary hosts (applesauce to cherrypie)..." << normal
+       << "\n\n";
+  {
+    auto dgram_sent = network.host( "applesauce" ).send_to( network.host( "cherrypie" ).address() );
+    dgram_sent.header.ttl--;
+    dgram_sent.header.compute_checksum();
+    network.host( "cherrypie" ).expect( dgram_sent );
+    network.simulate();
+  }
+
+  cout << green << "\n\nTesting traffic between two ordinary hosts (cherrypie to applesauce)..." << normal
+       << "\n\n";
+  {
+    auto dgram_sent = network.host( "cherrypie" ).send_to( network.host( "applesauce" ).address() );
+    dgram_sent.header.ttl--;
+    dgram_sent.header.compute_checksum();
+    network.host( "applesauce" ).expect( dgram_sent );
+    network.simulate();
+  }
+
+  cout << green << "\n\nSuccess! Testing applesauce sending to the Internet." << normal << "\n\n";
+  {
+    auto dgram_sent = network.host( "applesauce" ).send_to( Address { "1.2.3.4" } );
+    dgram_sent.header.ttl--;
+    dgram_sent.header.compute_checksum();
+    network.host( "default_router" ).expect( dgram_sent );
+    network.simulate();
+  }
+
+  cout << green << "\n\nSuccess! Testing sending to the HS network and Internet." << normal << "\n\n";
+  {
+    auto dgram_sent = network.host( "applesauce" ).send_to( Address { "143.195.131.17" } );
+    dgram_sent.header.ttl--;
+    dgram_sent.header.compute_checksum();
+    network.host( "hs_router" ).expect( dgram_sent );
+    network.simulate();
+
+    dgram_sent = network.host( "cherrypie" ).send_to( Address { "143.195.193.52" } );
+    dgram_sent.header.ttl--;
+    dgram_sent.header.compute_checksum();
+    network.host( "hs_router" ).expect( dgram_sent );
+    network.simulate();
+
+    dgram_sent = network.host( "cherrypie" ).send_to( Address { "143.195.223.255" } );
+    dgram_sent.header.ttl--;
+    dgram_sent.header.compute_checksum();
+    network.host( "hs_router" ).expect( dgram_sent );
+    network.simulate();
+
+    dgram_sent = network.host( "cherrypie" ).send_to( Address { "143.195.224.0" } );
+    dgram_sent.header.ttl--;
+    dgram_sent.header.compute_checksum();
+    network.host( "default_router" ).expect( dgram_sent );
+    network.simulate();
+  }
+
+  cout << green << "\n\nSuccess! Testing two hosts on the same network (dm42 to dm43)..." << normal << "\n\n";
+  {
+    auto dgram_sent = network.host( "dm42" ).send_to( network.host( "dm43" ).address() );
+    dgram_sent.header.ttl--;
+    dgram_sent.header.compute_checksum();
+    network.host( "dm43" ).expect( dgram_sent );
+    network.simulate();
+  }
+
+  cout << green << "\n\nSuccess! Testing TTL expiration..." << normal << "\n\n";
+  {
+    auto dgram_sent = network.host( "applesauce" ).send_to( Address { "1.2.3.4" }, 1 );
+    network.simulate();
+
+    dgram_sent = network.host( "applesauce" ).send_to( Address { "1.2.3.4" }, 0 );
+    network.simulate();
+  }
+
+  cout << "\n\n\033[32;1mCongratulations! All datagrams were routed successfully.\033[m\n";
+}
+
+int main()
+{
+  try {
+    network_simulator();
+  } catch ( const exception& e ) {
+    cerr << "\n\n\n";
+    cerr << "\033[31;1mError: " << e.what() << "\033[m\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_ack.cc
+++ b/tests/send_ack.cc
@@ -1,0 +1,77 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Repeat ACK is ignored", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( Push { "a" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "a" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Old ACK is ignored", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( Push { "a" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "a" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 2 } } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "b" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "b" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    // credit for test: Jared Wasserman (2020)
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Impossible ackno (beyond next seqno) is ignored", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 2 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( HasError { false } );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_close.cc
+++ b/tests/send_close.cc
@@ -1,0 +1,155 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN sent test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN with data", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "hello" }.with_close() );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ).with_data( "hello" ) );
+      test.execute( ExpectSeqno { isn + 7 } );
+      test.execute( ExpectSeqnosInFlight { 6 } );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "SYN + FIN", cfg };
+      test.execute( Receive { { {}, 1024 } }.without_push() );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_syn( true ).with_payload_size( 0 ).with_seqno( isn ).with_fin( true ) );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN acked test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 2 } } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN not acked test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN retx test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { TCPConfig::TIMEOUT_DFLT - 1 } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 2 } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_connect.cc
+++ b/tests/send_connect.cc
@@ -1,0 +1,91 @@
+#include "sender_test_harness.hh"
+
+#include "random.hh"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "SYN sent after first push", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "SYN acked test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { isn + 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "SYN -> wrong ack test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { isn } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "SYN acked, data", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { isn + 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "abcdefgh" } );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectMessage {}.with_seqno( isn + 1 ).with_data( "abcdefgh" ) );
+      test.execute( ExpectSeqno { isn + 9 } );
+      test.execute( ExpectSeqnosInFlight { 8 } );
+      test.execute( AckReceived { isn + 9 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectSeqno { isn + 9 } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_extra.cc
+++ b/tests/send_extra.cc
@@ -1,0 +1,717 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "If already running, timer stays running when new segment sent", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( Tick { rto - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push( "def" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ) );
+      test.execute( Tick { 6 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Retransmission still happens when expiration time not hit exactly", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( Tick { rto - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push( "def" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ) );
+      test.execute( Tick { 200 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Timer restarts on ACK of new data", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( Tick { rto - 5 } );
+      test.execute( Push( "def" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ).with_seqno( isn + 4 ) );
+      test.execute( AckReceived { Wrap32 { isn + 4 } }.with_win( 1000 ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 2 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ).with_seqno( isn + 4 ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Timer doesn't restart without ACK of new data", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( Tick { rto - 5 } );
+      test.execute( Push( "def" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ).with_seqno( isn + 4 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( Tick { 6 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { rto * 2 - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 8 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "RTO resets on ACK of new data", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( Tick { rto - 5 } );
+      test.execute( Push( "def" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ).with_seqno( isn + 4 ) );
+      test.execute( Push( "ghi" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "ghi" ).with_seqno( isn + 7 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( Tick { 6 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { rto * 2 - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 5 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { rto * 4 - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 4 } }.with_win( 1000 ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 2 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ).with_seqno( isn + 4 ) );
+      test.execute( ExpectNoSegment {} );
+    }
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      const string nicechars = "abcdefghijklmnopqrstuvwxyz";
+      string bigstring;
+      for ( unsigned int i = 0; i < TCPConfig::DEFAULT_CAPACITY; i++ ) {
+        bigstring.push_back( nicechars.at( rd() % nicechars.size() ) );
+      }
+
+      const size_t window_size = uniform_int_distribution<uint16_t> { 50000, 63000 }( rd );
+
+      TCPSenderTestHarness test { "fill_window() correctly fills a big window", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( window_size ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { bigstring } );
+
+      for ( unsigned int i = 0; i + TCPConfig::MAX_PAYLOAD_SIZE < min( bigstring.size(), window_size );
+            i += TCPConfig::MAX_PAYLOAD_SIZE ) {
+        const size_t expected_size = min( TCPConfig::MAX_PAYLOAD_SIZE, min( bigstring.size(), window_size ) - i );
+        test.execute( ExpectMessage {}
+                        .with_no_flags()
+                        .with_payload_size( expected_size )
+                        .with_data( bigstring.substr( i, expected_size ) )
+                        .with_seqno( isn + 1 + i ) );
+      }
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Retransmit a FIN-containing segment same as any other", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "abc" }.with_close() );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ).with_fin( true ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 2 } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ).with_fin( true ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Retransmit a FIN-only segment same as any other", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "abc" } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ).with_no_flags() );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_payload_size( 0 ).with_seqno( isn + 4 ).with_fin( true ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { isn + 4 }.with_win( 1000 ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 2 } );
+      test.execute( ExpectMessage {}.with_payload_size( 0 ).with_seqno( isn + 4 ).with_fin( true ) );
+      test.execute( Tick { 2 * rto - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 10 } );
+      test.execute( ExpectMessage {}.with_payload_size( 0 ).with_seqno( isn + 4 ).with_fin( true ) );
+      test.execute( ExpectSeqno { isn + 5 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Don't add FIN if this would make the segment exceed the receiver's window",
+                                  cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( Push( "abc" ).with_close() );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 3 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ).with_no_flags() );
+      test.execute( ExpectSeqno { isn + 4 } );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( AckReceived { Wrap32 { isn + 2 } }.with_win( 2 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 3 } }.with_win( 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 4 } }.with_win( 1 ) );
+      test.execute( ExpectMessage {}.with_payload_size( 0 ).with_seqno( isn + 4 ).with_fin( true ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Don't send FIN by itself if the window is full", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 3 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ).with_no_flags() );
+      test.execute( ExpectSeqno { isn + 4 } );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( Close {} );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 2 } }.with_win( 2 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 3 } }.with_win( 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 4 } }.with_win( 1 ) );
+      test.execute( ExpectMessage {}.with_payload_size( 0 ).with_seqno( isn + 4 ).with_fin( true ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      const string nicechars = "abcdefghijklmnopqrstuvwxyz";
+      string bigstring;
+      for ( unsigned int i = 0; i < TCPConfig::MAX_PAYLOAD_SIZE; i++ ) {
+        bigstring.push_back( nicechars.at( rd() % nicechars.size() ) );
+      }
+
+      TCPSenderTestHarness test { "MAX_PAYLOAD_SIZE limits payload only", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( Push { string( bigstring ) }.with_close() );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 40000 ) );
+      test.execute( ExpectMessage {}
+                      .with_payload_size( TCPConfig::MAX_PAYLOAD_SIZE )
+                      .with_data( string( bigstring ) )
+                      .with_seqno( isn + 1 )
+                      .with_fin( true ) );
+      test.execute( ExpectSeqno { isn + 2 + TCPConfig::MAX_PAYLOAD_SIZE } );
+      test.execute( ExpectSeqnosInFlight { 1 + TCPConfig::MAX_PAYLOAD_SIZE } );
+      test.execute( AckReceived( isn + 2 + TCPConfig::MAX_PAYLOAD_SIZE ) );
+      test.execute( ExpectSeqno { isn + 2 + TCPConfig::MAX_PAYLOAD_SIZE } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test {
+        "When filling window, treat a '0' window size as equal to '1' but don't back off RTO", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 0 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( Close {} );
+      test.execute( ExpectNoSegment {} );
+
+      for ( unsigned int i = 0; i < 5; i++ ) {
+        test.execute( Tick { rto - 1 } );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 } );
+        test.execute(
+          ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+      }
+
+      test.execute( AckReceived { isn + 2 }.with_win( 0 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "b" ).with_seqno( isn + 2 ).with_no_flags() );
+
+      for ( unsigned int i = 0; i < 5; i++ ) {
+        test.execute( Tick { rto - 1 } );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 } );
+        test.execute(
+          ExpectMessage {}.with_payload_size( 1 ).with_data( "b" ).with_seqno( isn + 2 ).with_no_flags() );
+      }
+
+      test.execute( AckReceived { isn + 3 }.with_win( 0 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "c" ).with_seqno( isn + 3 ).with_no_flags() );
+
+      for ( unsigned int i = 0; i < 5; i++ ) {
+        test.execute( Tick { rto - 1 } );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 } );
+        test.execute(
+          ExpectMessage {}.with_payload_size( 1 ).with_data( "c" ).with_seqno( isn + 3 ).with_no_flags() );
+      }
+
+      test.execute( AckReceived { isn + 4 }.with_win( 0 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 0 ).with_data( "" ).with_seqno( isn + 4 ).with_fin( true ) );
+
+      for ( unsigned int i = 0; i < 5; i++ ) {
+        test.execute( Tick { rto - 1 } );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 } );
+        test.execute(
+          ExpectMessage {}.with_payload_size( 0 ).with_data( "" ).with_seqno( isn + 4 ).with_fin( true ) );
+      }
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Unlike a zero-size window, a full window of nonzero size should be respected",
+                                  cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+
+      test.execute( Close {} );
+
+      test.execute( Tick { 2 * rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+
+      test.execute( Tick { 4 * rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+
+      test.execute( AckReceived { Wrap32 { isn + 2 } }.with_win( 3 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 2 ).with_data( "bc" ).with_seqno( isn + 2 ).with_fin( true ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Repeated ACKs and outdated ACKs are harmless", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abcdefg" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 7 ).with_data( "abcdefg" ).with_seqno( isn + 1 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push( "ijkl" ).with_close() );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 4 ).with_data( "ijkl" ).with_seqno( isn + 8 ).with_fin( true ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 12 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 12 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 12 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( Tick { 5 * rto } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 4 ).with_data( "ijkl" ).with_seqno( isn + 8 ).with_fin( true ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived( Wrap32 { isn + 13 } ).with_win( 1000 ) );
+      test.execute( AckReceived( Wrap32 { isn + 1 } ).with_win( 1000 ) );
+      test.execute( Tick { 5 * rto } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+    }
+
+    // test credit: DD152
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+      const string nicechars = "abcdefghijklmnopqrstuvwxyz";
+      string bigstring;
+      for ( unsigned int i = 0; i < TCPConfig::DEFAULT_CAPACITY; i++ ) {
+        bigstring.push_back( nicechars.at( rd() % nicechars.size() ) );
+      }
+      // max window size
+      const size_t window_size = 65535;
+      TCPSenderTestHarness test { "Only the last segment has FIN", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( window_size ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { bigstring }.with_close() );
+      unsigned int i = 0;
+      while ( ( i + TCPConfig::MAX_PAYLOAD_SIZE ) < bigstring.size() ) {
+        test.execute( ExpectMessage {}
+                        .with_no_flags()
+                        .with_payload_size( TCPConfig::MAX_PAYLOAD_SIZE )
+                        .with_data( bigstring.substr( i, TCPConfig::MAX_PAYLOAD_SIZE ) )
+                        .with_seqno( isn + 1 + i ) );
+        i += TCPConfig::MAX_PAYLOAD_SIZE;
+      }
+      test.execute( ExpectMessage {}
+                      .with_fin( true )
+                      .with_payload_size( bigstring.size() - i )
+                      .with_data( bigstring.substr( i, bigstring.size() - 1 ) )
+                      .with_seqno( isn + 1 + i ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 2 + bigstring.size() } );
+      test.execute( ExpectSeqnosInFlight { bigstring.size() + 1 } );
+      test.execute( AckReceived { isn + 2 + bigstring.size() } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectSeqno { isn + 2 + bigstring.size() } );
+    }
+
+    // Sender must set RST iff stream has suffered an error
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+      TCPSenderTestHarness test { "Stream error -> RST flag", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ) );
+      test.execute( SetError {} );
+      test.execute( ExpectReset { true } );
+    }
+
+    // Sender must set RST iff stream has suffered an error
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+      TCPSenderTestHarness test { "Stream error -> RST flag (non-empty segment)", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 100 ) );
+      test.execute( SetError {} );
+      test.execute( Push { "hello" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_rst( true ).with_seqno( isn + 1 ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "RST flag -> stream error", cfg };
+      test.execute( Receive { TCPReceiverMessage { .RST = true } } );
+      test.execute( HasError { true } );
+    }
+
+    // Newly added test: check RTO timer on invalid ackno
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+      cfg.rt_timeout = 10;
+      TCPSenderTestHarness test { "invalid ackno -> should not reset RTO timer", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 4 ) );
+      test.execute( Push { "abcd" } );
+      test.execute( ExpectMessage {}.with_payload_size( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 10 }.with_max_retx_exceeded( false ) ); // RTO timer should double here
+      test.execute( ExpectMessage {}.with_payload_size( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1000 } } );       // invalid ackno received here, should not reset
+      test.execute( Tick { 10 }.with_max_retx_exceeded( false ) ); // RTO timer should still be double
+      test.execute( ExpectNoSegment {} );
+    }
+
+    // test credit: Ava Jih-Schiff
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Receiving before transmit I", cfg };
+      test.execute(
+        AckReceived { Wrap32 { cfg.isn } }.with_win( 3 ).without_push() ); // invalid ack but window is set
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "abc" }.with_close() );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 2 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 3 } );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( AckReceived { Wrap32 { isn + 3 } }.with_win( 1 ) );
+      test.execute( ExpectMessage {}.with_no_flags().with_payload_size( 1 ).with_seqno( isn + 3 ) );
+      test.execute( AckReceived { Wrap32 { isn + 4 } }.with_win( 1 ) );
+      test.execute(
+        ExpectMessage {}.with_no_flags().with_fin( true ).with_payload_size( 0 ).with_seqno( isn + 4 ) );
+    }
+
+    // test credit: Majd Nasra
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "When queue is empty, timer is stopped", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( Tick { rto - 1 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_data( "abc" ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectMessage {}.with_data( "abc" ) );
+    }
+
+    // test credit: Majd Nasra
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Receiving before transmit II", cfg };
+      test.execute( Receive { { {}, 1024 } }.without_push() );
+      test.execute( Push( "01234567" ).with_close() );
+      test.execute( ExpectMessage {}.with_data( "01234567" ).with_syn( true ).with_seqno( isn ).with_fin( true ) );
+      test.execute( ExpectSeqno { isn + 10 } );
+      test.execute( ExpectSeqnosInFlight { 10 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    // test credit: Sasha Moore
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Receiving before transmit III", cfg };
+      //  Set window size without having sent an acknowledgment
+      test.execute( Receive { { {}, 1024 } }.without_push() );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_syn( true ).with_fin( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    // test credit: Chuyi Zhang
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+      const string nicechars = "abcdefghijklmnopqrstuvwxyz";
+      string bigstring;
+      for ( unsigned int i = 0; i < TCPConfig::DEFAULT_CAPACITY; i++ ) {
+        bigstring.push_back( nicechars.at( rd() % nicechars.size() ) );
+      }
+      // const size_t window_size = uniform_int_distribution<uint16_t> { 50000, 63000 }( rd );
+      const size_t window_size = 63999;
+      TCPSenderTestHarness test { "Large payload and FIN", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( window_size ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { bigstring }.with_close() );
+      unsigned int i = 0;
+      while ( ( i + TCPConfig::MAX_PAYLOAD_SIZE ) < window_size ) {
+        test.execute( ExpectMessage {}
+                        .with_no_flags()
+                        .with_payload_size( TCPConfig::MAX_PAYLOAD_SIZE )
+                        .with_data( bigstring.substr( i, TCPConfig::MAX_PAYLOAD_SIZE ) )
+                        .with_seqno( isn + 1 + i ) );
+        i += TCPConfig::MAX_PAYLOAD_SIZE;
+      }
+
+      test.execute( ExpectMessage {}
+                      .with_payload_size( window_size - i )
+                      .with_data( bigstring.substr( i, 999 ) )
+                      .with_no_flags() );
+      test.execute( ExpectSeqnosInFlight { window_size } );
+      test.execute( AckReceived { isn + window_size + 1 }.with_win( window_size ) );
+      test.execute( ExpectMessage {}
+                      .with_payload_size( 1 )
+                      .with_data( bigstring.substr( bigstring.size() - 1, 1 ) )
+                      .with_fin( true ) );
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( AckReceived { isn + bigstring.size() + 2 }.with_win( window_size ) );
+      test.execute( ExpectSeqno { isn + bigstring.size() + 2 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_retx.cc
+++ b/tests/send_retx.cc
@@ -1,0 +1,207 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const uint16_t retx_timeout = uniform_int_distribution<uint16_t> { 10, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = retx_timeout;
+
+      TCPSenderTestHarness test { "Retx SYN twice at the right times, then ack", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( Tick { retx_timeout - 1U } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      // Wait twice as long b/c exponential back-off
+      test.execute( Tick { 2 * retx_timeout - 1U } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const uint16_t retx_timeout = uniform_int_distribution<uint16_t> { 10, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = retx_timeout;
+
+      TCPSenderTestHarness test { "Retx SYN until too many retransmissions", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      for ( size_t attempt_no = 0; attempt_no < TCPConfig::MAX_RETX_ATTEMPTS; attempt_no++ ) {
+        test.execute( Tick { ( retx_timeout << attempt_no ) - 1U }.with_max_retx_exceeded( false ) );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 }.with_max_retx_exceeded( false ) );
+        test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+        test.execute( ExpectSeqno { isn + 1 } );
+        test.execute( ExpectSeqnosInFlight { 1 } );
+      }
+      test.execute(
+        Tick { ( retx_timeout << TCPConfig::MAX_RETX_ATTEMPTS ) - 1U }.with_max_retx_exceeded( false ) );
+      test.execute( Tick { 1 }.with_max_retx_exceeded( true ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const uint16_t retx_timeout = uniform_int_distribution<uint16_t> { 10, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = retx_timeout;
+
+      TCPSenderTestHarness test { "Send some data, the retx and succeed, then retx till limit", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( Push { "abcd" } );
+      test.execute( ExpectMessage {}.with_payload_size( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 5 } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "efgh" } );
+      test.execute( ExpectMessage {}.with_payload_size( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { retx_timeout }.with_max_retx_exceeded( false ) );
+      test.execute( ExpectMessage {}.with_payload_size( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 9 } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "ijkl" } );
+      test.execute( ExpectMessage {}.with_payload_size( 4 ).with_seqno( isn + 9 ) );
+      for ( size_t attempt_no = 0; attempt_no < TCPConfig::MAX_RETX_ATTEMPTS; attempt_no++ ) {
+        test.execute( Tick { ( retx_timeout << attempt_no ) - 1U }.with_max_retx_exceeded( false ) );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 }.with_max_retx_exceeded( false ) );
+        test.execute( ExpectMessage {}.with_payload_size( 4 ).with_seqno( isn + 9 ) );
+        test.execute( ExpectSeqnosInFlight { 4 } );
+      }
+      test.execute(
+        Tick { ( retx_timeout << TCPConfig::MAX_RETX_ATTEMPTS ) - 1U }.with_max_retx_exceeded( false ) );
+      test.execute( Tick { 1 }.with_max_retx_exceeded( true ) );
+    }
+
+    // test credit: Cooper de Nicola
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const uint16_t retx_timeout = uniform_int_distribution<uint16_t> { 10, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = retx_timeout;
+
+      // test that lowest seqno is sent on consecutive resends
+      TCPSenderTestHarness test { "Retx after multiple sends, retx earliest packet", cfg };
+      // syn + syn/ack to increase window size
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+
+      // segment A. Send
+      test.execute( Push { "A" } );
+      test.execute( ExpectMessage {}.with_payload_size( 1 ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+
+      // segment B. Queue.
+      test.execute( Push { "BB" } );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+
+      // timeout to queue A. Should send packet A and B, order does not matter
+      test.execute( Tick { retx_timeout }.with_max_retx_exceeded( false ) );
+      test.execute( ExpectMessage {} ); // either A or B
+      test.execute( ExpectMessage {} ); // either A or B
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( ExpectConsecutiveRetransmissions { 1 } );
+
+      // timeout. Should send segment A
+      test.execute( Tick { static_cast<uint64_t>( retx_timeout ) << 1 }.with_max_retx_exceeded( false ) );
+      test.execute( ExpectMessage {}.with_payload_size( 1 ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( ExpectConsecutiveRetransmissions { 2 } );
+
+      // continue communications as expected
+      test.execute( AckReceived { Wrap32 { isn + 1 + 1 } } ); // ack A
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( ExpectConsecutiveRetransmissions { 0 } ); // B is still outstanding
+      test.execute( Tick { static_cast<uint64_t>( retx_timeout ) }.with_max_retx_exceeded( false ) );
+      test.execute( ExpectMessage {}.with_payload_size( 2 ).with_seqno( isn + 1 + 1 ) ); // packet B
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectConsecutiveRetransmissions { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 + 1 + 2 } } ); // ack B
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    // test credit: Kosthi
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const uint16_t retx_timeout = uniform_int_distribution<uint16_t> { 10, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = retx_timeout;
+
+      TCPSenderTestHarness test { "timer correctness", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Tick( retx_timeout ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "a" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "a" ) );
+      test.execute( Tick( 1 ) ); // no timeout, no msg send
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( Tick( retx_timeout - 1U ) );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "a" ) );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 2 } } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( HasError { false } );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_transmit.cc
+++ b/tests/send_transmit.cc
@@ -1,0 +1,174 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Three short writes", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "ab" } );
+      test.execute( ExpectMessage {}.with_data( "ab" ).with_seqno( isn + 1 ) );
+      test.execute( Push { "cd" } );
+      test.execute( ExpectMessage {}.with_data( "cd" ).with_seqno( isn + 3 ) );
+      test.execute( Push { "abcd" } );
+      test.execute( ExpectMessage {}.with_data( "abcd" ).with_seqno( isn + 5 ) );
+      test.execute( ExpectSeqno { isn + 9 } );
+      test.execute( ExpectSeqnosInFlight { 8 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Many short writes, continuous acks", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      constexpr uint32_t max_block_size = 10;
+      constexpr uint32_t n_rounds = 10000;
+      size_t bytes_sent = 0;
+      for ( uint32_t i = 0; i < n_rounds; ++i ) {
+        string data;
+        const uint32_t block_size = uniform_int_distribution<uint32_t> { 1, max_block_size }( rd );
+        for ( uint32_t j = 0; j < block_size; ++j ) {
+          const uint8_t c = 'a' + ( ( i + j ) % 26 );
+          data.push_back( static_cast<char>( c ) );
+        }
+        test.execute( ExpectSeqno { isn + static_cast<uint32_t>( bytes_sent ) + 1 } );
+        test.execute( Push { data } );
+        bytes_sent += block_size;
+        test.execute( ExpectSeqnosInFlight { block_size } );
+        test.execute( ExpectMessage {}
+                        .with_seqno( isn + 1 + static_cast<uint32_t>( bytes_sent - block_size ) )
+                        .with_data( move( data ) ) );
+        test.execute( ExpectNoSegment {} );
+        test.execute( AckReceived { Wrap32 { isn + 1 + static_cast<uint32_t>( bytes_sent ) } } );
+      }
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Many short writes, ack at end", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { isn + 1 }.with_win( 65000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      constexpr uint32_t max_block_size = 10;
+      constexpr uint32_t n_rounds = 1000;
+      size_t bytes_sent = 0;
+      for ( uint32_t i = 0; i < n_rounds; ++i ) {
+        string data;
+        const uint32_t block_size = uniform_int_distribution<uint32_t> { 1, max_block_size }( rd );
+        for ( uint32_t j = 0; j < block_size; ++j ) {
+          const uint8_t c = 'a' + ( ( i + j ) % 26 );
+          data.push_back( static_cast<char>( c ) );
+        }
+        test.execute( ExpectSeqno { Wrap32 { isn + static_cast<uint32_t>( bytes_sent ) + 1 } } );
+        test.execute( Push( string( data ) ) );
+        bytes_sent += block_size;
+        test.execute( ExpectSeqnosInFlight { bytes_sent } );
+        test.execute( ExpectMessage {}
+                        .with_seqno( isn + 1 + static_cast<uint32_t>( bytes_sent - block_size ) )
+                        .with_data( move( data ) ) );
+        test.execute( ExpectNoSegment {} );
+      }
+      test.execute( ExpectSeqnosInFlight { bytes_sent } );
+      test.execute( AckReceived { Wrap32 { isn + 1 + static_cast<uint32_t>( bytes_sent ) } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Window filling", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 3 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "01234567" ) );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( ExpectMessage {}.with_data( "012" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { Wrap32 { isn + 1 + 3 } } );
+      test.execute( AckReceived { Wrap32 { isn + 1 + 3 } }.with_win( 3 ) );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( ExpectMessage {}.with_data( "345" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { Wrap32 { isn + 1 + 6 } } );
+      test.execute( AckReceived { Wrap32 { isn + 1 + 6 } }.with_win( 3 ) );
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( ExpectMessage {}.with_data( "67" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { Wrap32 { isn + 1 + 8 } } );
+      test.execute( AckReceived { Wrap32 { isn + 1 + 8 } }.with_win( 3 ) );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Immediate writes respect the window", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 3 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "01" ) );
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( ExpectMessage {}.with_data( "01" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { Wrap32 { isn + 1 + 2 } } );
+      test.execute( Push( "23" ) );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( ExpectMessage {}.with_data( "2" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { Wrap32 { isn + 1 + 3 } } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_window.cc
+++ b/tests/send_window.cc
@@ -1,0 +1,146 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Initial receiver advertised window is respected", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "abcdefg" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "abcd" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Immediate window is respected", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 6 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "abcdefg" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "abcdef" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      const size_t MIN_WIN = 5;
+      const size_t MAX_WIN = 100;
+      const size_t N_REPS = 1000;
+      for ( size_t i = 0; i < N_REPS; ++i ) {
+        const size_t len = MIN_WIN + rd() % ( MAX_WIN - MIN_WIN );
+        TCPConfig cfg;
+        const Wrap32 isn( rd() );
+        cfg.isn = isn;
+
+        TCPSenderTestHarness test { "Window " + to_string( i ), cfg };
+        test.execute( Push {} );
+        test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+        test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( len ) );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Push { string( 2 * N_REPS, 'a' ) } );
+        test.execute( ExpectMessage {}.with_no_flags().with_payload_size( len ) );
+        test.execute( ExpectNoSegment {} );
+      }
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Window growth is exploited", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "0123456789" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "0123" ) );
+      test.execute( AckReceived { Wrap32 { isn + 5 } }.with_win( 5 ) );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "45678" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN flag occupies space in window", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 7 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "1234567" } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "1234567" ) );
+      test.execute( ExpectNoSegment {} ); // window is full
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1 ) );
+      test.execute( ExpectMessage {}.with_fin( true ).with_data( "" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN flag occupies space in window (part II)", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 7 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "1234567" } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "1234567" ) );
+      test.execute( ExpectNoSegment {} ); // window is full
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 8 ) );
+      test.execute( ExpectMessage {}.with_fin( true ).with_data( "" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Piggyback FIN in segment when space is available", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 3 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "1234567" } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "123" ) );
+      test.execute( ExpectNoSegment {} ); // window is full
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 8 ) );
+      test.execute( ExpectMessage {}.with_fin( true ).with_data( "4567" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/sender_test_harness.hh
+++ b/tests/sender_test_harness.hh
@@ -1,0 +1,406 @@
+#pragma once
+
+#include "common.hh"
+#include "helpers.hh"
+#include "tcp_config.hh"
+#include "tcp_receiver_message.hh"
+#include "tcp_sender.hh"
+#include "wrapping_integers.hh"
+
+#include <optional>
+#include <queue>
+#include <sstream>
+#include <utility>
+
+const unsigned int DEFAULT_TEST_WINDOW = 137;
+
+struct SenderAndOutput
+{
+  TCPSender sender;
+  std::queue<TCPSenderMessage> output {};
+
+  auto make_transmit()
+  {
+    return [&]( const TCPSenderMessage& x ) { output.push( x ); };
+  }
+
+  TCPSenderMessage expect_message() const
+  {
+    if ( output.empty() ) {
+      throw ExpectationViolation( "should have sent a message" );
+    }
+    auto& mutable_output = const_cast<decltype( output )&>( output ); // NOLINT(*-const-cast)
+    TCPSenderMessage ret { std::move( mutable_output.front() ) };
+    mutable_output.pop();
+    return ret;
+  }
+};
+
+template<std::derived_from<TestStep<TCPSender>> T>
+struct SenderTestStep : public TestStep<SenderAndOutput>
+{
+  T step_;
+
+  explicit SenderTestStep( T inner ) : TestStep<SenderAndOutput>(), step_( std::move( inner ) ) {}
+
+  std::string str() const override { return step_.str(); }
+  uint8_t color() const override { return step_.color(); }
+  void execute( SenderAndOutput& so ) const override { step_.execute( so.sender ); }
+  constexpr std::string obj() const override { return step_.obj(); }
+};
+
+class TCPSenderTestHarness : public TestHarness<SenderAndOutput>
+{
+public:
+  TCPSenderTestHarness( std::string name, TCPConfig config )
+    : TestHarness( move( name ),
+                   "initial_RTO_ms=" + to_string( config.rt_timeout ) + " and ISN=" + to_string( config.isn ),
+                   { TCPSender { ByteStream { config.send_capacity }, config.isn, config.rt_timeout } } )
+  {}
+
+  template<std::derived_from<TestStep<TCPSender>> T>
+  void execute( const T& test )
+  {
+    TestHarness<SenderAndOutput>::execute( SenderTestStep { test } );
+  }
+
+  using TestHarness<SenderAndOutput>::execute;
+};
+
+struct ExpectSeqno : public ExpectNumber<TCPSender, Wrap32>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "make_empty_message().seqno"; }
+
+  Wrap32 value( const TCPSender& sender ) const override
+  {
+    auto seg = sender.make_empty_message();
+    if ( seg.sequence_length() ) {
+      throw ExpectationViolation( "make_empty_message() returned non-empty message" );
+    }
+    return seg.seqno;
+  }
+};
+
+struct ExpectReset : public ExpectBool<TCPSender>
+{
+  using ExpectBool::ExpectBool;
+  std::string name() const override { return "make_empty_message().RST"; }
+
+  bool value( const TCPSender& sender ) const override { return sender.make_empty_message().RST; }
+};
+
+struct ExpectSeqnosInFlight : public ExpectNumber<TCPSender, uint64_t>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "sequence_numbers_in_flight"; }
+  uint64_t value( const TCPSender& sender ) const override { return sender.sequence_numbers_in_flight(); }
+};
+
+struct ExpectConsecutiveRetransmissions : public ExpectNumber<TCPSender, uint64_t>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "consecutive_retransmissions"; }
+  uint64_t value( const TCPSender& sender ) const override { return sender.consecutive_retransmissions(); }
+};
+
+struct ExpectNoSegment : public Expectation<SenderAndOutput>
+{
+  std::string description() const override { return "nothing to send"; }
+  void execute( const SenderAndOutput& ss ) const override
+  {
+    if ( not ss.output.empty() ) {
+      throw ExpectationViolation { "sent unexpected message: " + to_string( ss.output.front() ) };
+    }
+  }
+  constexpr std::string obj() const override { return "TCPSender"; }
+};
+
+struct SetError : public Action<TCPSender>
+{
+  std::string description() const override { return "set_error"; }
+  void execute( TCPSender& sender ) const override { sender.writer().set_error(); }
+};
+
+struct HasError : public ExpectBool<TCPSender>
+{
+  using ExpectBool::ExpectBool;
+  std::string name() const override { return "has_error"; }
+  bool value( const TCPSender& sender ) const override { return sender.writer().has_error(); }
+};
+
+struct Push : public Action<SenderAndOutput>
+{
+  std::string data_;
+  bool close_ {};
+
+  explicit Push( std::string data = "" ) : data_( move( data ) ) {}
+  std::string description() const override
+  {
+    if ( data_.empty() and not close_ ) {
+      return "push";
+    }
+
+    if ( data_.empty() and close_ ) {
+      return "close stream, then push";
+    }
+
+    return "push \"" + pretty_print( data_ ) + "\" to stream" + ( close_ ? ", close it" : "" )
+           + ", then push to TCPSender";
+  }
+  void execute( SenderAndOutput& ss ) const override
+  {
+    if ( not data_.empty() ) {
+      ss.sender.writer().push( data_ );
+    }
+    if ( close_ ) {
+      ss.sender.writer().close();
+    }
+    ss.sender.push( ss.make_transmit() );
+  }
+
+  Push& with_close()
+  {
+    close_ = true;
+    return *this;
+  }
+
+  constexpr std::string obj() const override { return "TCPSender"; }
+};
+
+struct Tick : public Action<SenderAndOutput>
+{
+  uint64_t ms_;
+  std::optional<bool> max_retx_exceeded_ {};
+
+  explicit Tick( uint64_t ms ) : ms_( ms ) {}
+
+  Tick& with_max_retx_exceeded( bool val )
+  {
+    max_retx_exceeded_ = val;
+    return *this;
+  }
+
+  std::string description() const override
+  {
+    std::ostringstream desc;
+    desc << ms_ << " ms pass";
+    if ( max_retx_exceeded_.has_value() ) {
+      desc << ( max_retx_exceeded_.value() ? " (max # retransmissions exceeded)"
+                                           : " (max # retransmissions not exceeded)" );
+    }
+    return desc.str();
+  }
+
+  void execute( SenderAndOutput& ss ) const override
+  {
+    ss.sender.tick( ms_, ss.make_transmit() );
+    if ( max_retx_exceeded_.has_value()
+         and max_retx_exceeded_ != ( ss.sender.consecutive_retransmissions() > TCPConfig::MAX_RETX_ATTEMPTS ) ) {
+      std::ostringstream desc;
+      desc << "after " << ms_ << " ms passed the TCP Sender reported\n\tconsecutive_retransmissions = "
+           << ss.sender.consecutive_retransmissions() << "\nbut it should have been\n\t";
+      if ( max_retx_exceeded_.value() ) {
+        desc << "greater than ";
+      } else {
+        desc << "less than or equal to ";
+      }
+      desc << TCPConfig::MAX_RETX_ATTEMPTS << "\n";
+      throw ExpectationViolation( desc.str() );
+    }
+  }
+
+  constexpr std::string obj() const override { return "TCPSender"; }
+};
+
+struct Receive : public Action<SenderAndOutput>
+{
+  TCPReceiverMessage msg_;
+  bool push_ = true;
+
+  explicit Receive( TCPReceiverMessage msg ) : msg_( msg ) {}
+  std::string description() const override
+  {
+    std::ostringstream desc;
+    desc << "receive(ack=" << to_string( msg_.ackno ) << ", win=" << msg_.window_size << ")";
+    if ( push_ ) {
+      desc << ", then push";
+    }
+    return desc.str();
+  }
+
+  Receive& with_win( uint16_t win )
+  {
+    msg_.window_size = win;
+    return *this;
+  }
+
+  void execute( SenderAndOutput& ss ) const override
+  {
+    ss.sender.receive( msg_ );
+    if ( push_ ) {
+      ss.sender.push( ss.make_transmit() );
+    }
+  }
+
+  Receive& without_push()
+  {
+    push_ = false;
+    return *this;
+  }
+
+  constexpr std::string obj() const override { return "TCPSender"; }
+};
+
+struct AckReceived : public Receive
+{
+  explicit AckReceived( Wrap32 ackno ) : Receive( { ackno, DEFAULT_TEST_WINDOW } ) {}
+};
+
+struct Close : public Push
+{
+  Close() : Push( "" ) { with_close(); }
+};
+
+class MessageExpectationViolation : public ExpectationViolation
+{
+public:
+  template<typename T>
+  MessageExpectationViolation( const TCPSenderMessage& msg,
+                               const std::string& property_name,
+                               const T& expected,
+                               const T& actual )
+    : ExpectationViolation( "sent a message " + to_string( msg ) + " that should have had " + property_name + " = "
+                            + to_string( expected ) + ", but instead it was " + to_string( actual ) )
+  {}
+};
+
+struct ExpectMessage : public Expectation<SenderAndOutput>
+{
+  std::optional<bool> syn {};
+  std::optional<bool> fin {};
+  std::optional<bool> rst {};
+  std::optional<Wrap32> seqno {};
+  std::optional<std::string> data {};
+  std::optional<size_t> payload_size {};
+
+  bool empty() const { return not( syn or fin or rst or seqno or data or payload_size ); }
+
+  ExpectMessage& with_syn( bool syn_ )
+  {
+    syn = syn_;
+    return *this;
+  }
+
+  ExpectMessage& with_fin( bool fin_ )
+  {
+    fin = fin_;
+    return *this;
+  }
+
+  ExpectMessage& with_no_flags()
+  {
+    syn = fin = rst = false;
+    return *this;
+  }
+
+  ExpectMessage& with_rst( bool rst_ )
+  {
+    rst = rst_;
+    return *this;
+  }
+
+  ExpectMessage& with_seqno( Wrap32 seqno_ )
+  {
+    seqno = seqno_;
+    return *this;
+  }
+
+  ExpectMessage& with_seqno( uint32_t seqno_ ) { return with_seqno( Wrap32 { seqno_ } ); }
+
+  ExpectMessage& with_payload_size( size_t payload_size_ )
+  {
+    payload_size = payload_size_;
+    return *this;
+  }
+
+  ExpectMessage& with_data( std::string data_ )
+  {
+    data = std::move( data_ );
+    return *this;
+  }
+
+  std::string message_description() const
+  {
+    std::ostringstream o;
+    if ( seqno.has_value() ) {
+      o << " seqno=" << seqno.value();
+    }
+    if ( syn.has_value() ) {
+      o << ( syn.value() ? " +SYN" : " -SYN" );
+    }
+
+    if ( data.has_value() and data.value().size() <= 32 ) {
+      o << " payload=\"" << pretty_print( data.value(), 32 ) << "\"";
+    } else {
+      if ( payload_size.has_value() ) {
+        if ( payload_size.value() ) {
+          o << " payload_len=" << payload_size.value();
+        } else {
+          o << " (no payload)";
+        }
+      }
+      if ( data.has_value() ) {
+        o << " payload=\"" << pretty_print( data.value(), 32 ) << "\"";
+      }
+    }
+
+    if ( fin.has_value() ) {
+      o << ( fin.value() ? " +FIN" : " -FIN" );
+    }
+    if ( rst.has_value() ) {
+      o << ( rst.value() ? " +RST" : " -RST" );
+    }
+    return o.str();
+  }
+
+  std::string description() const override
+  {
+    return empty() ? "message sent" : "message sent with" + message_description();
+  }
+
+  void execute( const SenderAndOutput& ss ) const override
+  {
+    if ( payload_size.has_value() and data.has_value() and payload_size.value() != data.value().size() ) {
+      throw std::runtime_error( "inconsistent test: invalid ExpectMessage" );
+    }
+
+    const TCPSenderMessage seg = ss.expect_message();
+
+    if ( seg.payload.size() > TCPConfig::MAX_PAYLOAD_SIZE ) {
+      throw ExpectationViolation( "sent a message with a " + std::to_string( seg.payload.size() )
+                                  + "-byte payload, which is longer than the maximum ("
+                                  + std::to_string( TCPConfig::MAX_PAYLOAD_SIZE ) + ")" );
+    }
+    if ( syn.has_value() and seg.SYN != syn.value() ) {
+      throw MessageExpectationViolation( seg, "SYN flag", syn.value(), seg.SYN );
+    }
+    if ( fin.has_value() and seg.FIN != fin.value() ) {
+      throw MessageExpectationViolation( seg, "FIN flag", fin.value(), seg.FIN );
+    }
+    if ( rst.has_value() and seg.RST != rst.value() ) {
+      throw MessageExpectationViolation( seg, "RST flag", rst.value(), seg.RST );
+    }
+    if ( seqno.has_value() and seg.seqno != seqno.value() ) {
+      throw MessageExpectationViolation( seg, "sequence number", seqno.value(), seg.seqno );
+    }
+    if ( payload_size.has_value() and seg.payload.size() != payload_size.value() ) {
+      throw MessageExpectationViolation( seg, "payload size", payload_size.value(), seg.payload.size() );
+    }
+    if ( data.has_value() and data.value() != static_cast<std::string>( seg.payload ) ) {
+      throw MessageExpectationViolation( seg, "payload", data.value(), static_cast<std::string>( seg.payload ) );
+    }
+  }
+
+  constexpr std::string obj() const override { return "TCPSender"; }
+};

--- a/tests/test_should_be.hh
+++ b/tests/test_should_be.hh
@@ -52,10 +52,10 @@ inline std::string human_compare( uint64_t actual, uint64_t expected )
 {
   std::ostringstream ss;
   if ( actual > expected ) {
-    uint64_t diff = actual - expected;
+    const uint64_t diff = actual - expected;
     ss << "The actual value was too high by " << diff << human( diff ) << ".\n";
   } else {
-    uint64_t diff = expected - actual;
+    const uint64_t diff = expected - actual;
     ss << "The actual value was too low by " << diff << human( diff ) << ".\n";
   }
   return ss.str();
@@ -65,10 +65,10 @@ inline std::string human_compare( uint64_t actual, uint64_t expected )
 inline std::string human_compare( const Wrap32& actual, const Wrap32& expected )
 {
   std::ostringstream ss;
-  uint32_t actual_raw = minnow_conversions::DebugWrap32 { actual }.debug_get_raw_value();
-  uint32_t expected_raw = minnow_conversions::DebugWrap32 { expected }.debug_get_raw_value();
-  uint32_t diff_high = actual_raw - expected_raw;
-  uint32_t diff_low = expected_raw - actual_raw;
+  const uint32_t actual_raw = minnow_conversions::DebugWrap32 { actual }.debug_get_raw_value();
+  const uint32_t expected_raw = minnow_conversions::DebugWrap32 { expected }.debug_get_raw_value();
+  const uint32_t diff_high = actual_raw - expected_raw;
+  const uint32_t diff_low = expected_raw - actual_raw;
   if ( diff_high < diff_low ) {
     ss << "The Wrap32's raw value was too high by " << diff_high << human( diff_high ) << ".\n";
   } else {

--- a/tests/wrapping_integers_cmp.cc
+++ b/tests/wrapping_integers_cmp.cc
@@ -1,0 +1,36 @@
+#include "random.hh"
+#include "test_should_be.hh"
+#include "wrapping_integers.hh"
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    // Comparing low-number adjacent seqnos
+    test_should_be( Wrap32( 3 ) != Wrap32( 1 ), true );
+    test_should_be( Wrap32( 3 ) == Wrap32( 1 ), false );
+
+    constexpr size_t N_REPS = 32768;
+
+    auto rd = get_random_engine();
+
+    for ( size_t i = 0; i < N_REPS; i++ ) {
+      const uint32_t n = rd();
+      const uint8_t diff = rd();
+      const uint32_t m = n + diff;
+      test_should_be( Wrap32( n ) == Wrap32( m ), n == m );
+      test_should_be( Wrap32( n ) != Wrap32( m ), n != m );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/wrapping_integers_extra.cc
+++ b/tests/wrapping_integers_extra.cc
@@ -1,0 +1,80 @@
+#include "test_should_be.hh"
+#include "wrapping_integers.hh"
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    for ( uint64_t checkpoint = 0; checkpoint < 100000; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 0UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ), 0UL );
+    }
+
+    for ( uint64_t checkpoint = 0; checkpoint < 100000; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 1UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ), 1UL );
+    }
+
+    for ( uint64_t checkpoint = UINT32_MAX - 100000UL; checkpoint < UINT32_MAX + 100000UL; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( UINT32_MAX - 1UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      UINT32_MAX - 1UL );
+    }
+
+    for ( uint64_t checkpoint = UINT32_MAX - 100000UL; checkpoint < UINT32_MAX + 100000UL; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( UINT32_MAX, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      uint64_t { UINT32_MAX } );
+    }
+
+    for ( uint64_t checkpoint = UINT32_MAX - 100000UL; checkpoint < UINT32_MAX + 100000UL; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( UINT32_MAX + 1UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      UINT32_MAX + 1UL );
+    }
+
+    for ( uint64_t checkpoint = UINT32_MAX - 100000UL; checkpoint < UINT32_MAX + 100000UL; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( UINT32_MAX + 2UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      UINT32_MAX + 2UL );
+    }
+
+    for ( uint64_t checkpoint = 2UL * UINT32_MAX - 100000UL; checkpoint < 2UL * UINT32_MAX + 100000UL;
+          ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 2UL * UINT32_MAX - 1UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      2UL * UINT32_MAX - 1UL );
+    }
+
+    for ( uint64_t checkpoint = 2UL * UINT32_MAX - 100000UL; checkpoint < 2UL * UINT32_MAX + 100000UL;
+          ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 2UL * UINT32_MAX, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      2UL * UINT32_MAX );
+    }
+
+    for ( uint64_t checkpoint = 2UL * UINT32_MAX - 100000UL; checkpoint < 2UL * UINT32_MAX + 100000UL;
+          ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 2UL * UINT32_MAX + 1UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      2UL * UINT32_MAX + 1UL );
+    }
+
+    for ( uint64_t checkpoint = 2UL * UINT32_MAX - 100000UL; checkpoint < 2UL * UINT32_MAX + 100000UL;
+          ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 2UL * UINT32_MAX + 2UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      2UL * UINT32_MAX + 2UL );
+    }
+
+    for ( int64_t i = -100000; i < 100000; ++i ) {
+      test_should_be( Wrap32::wrap( UINT32_MAX + i, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, UINT32_MAX ),
+                      uint64_t( UINT32_MAX + i ) );
+    }
+
+    for ( int64_t i = -100000; i < 100000; ++i ) {
+      test_should_be( Wrap32::wrap( 2UL * UINT32_MAX + i, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, 2UL * UINT32_MAX ),
+                      2UL * UINT32_MAX + i );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/wrapping_integers_roundtrip.cc
+++ b/tests/wrapping_integers_roundtrip.cc
@@ -1,0 +1,54 @@
+#include "conversions.hh"
+#include "random.hh"
+#include "wrapping_integers.hh"
+
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+using namespace std;
+
+void check_roundtrip( const Wrap32 isn, const uint64_t value, const uint64_t checkpoint )
+{
+  if ( Wrap32::wrap( value, isn ).unwrap( isn, checkpoint ) != value ) {
+    ostringstream ss;
+
+    ss << "Expected unwrap(wrap()) to recover same value, and it didn't!\n";
+    ss << "  unwrap(wrap(value, isn), isn, checkpoint) did not equal value\n";
+    ss << "  where value = " << value << ", isn = " << isn << ", and checkpoint = " << checkpoint << "\n";
+    ss << "  (Difference between value and checkpoint is " << value - checkpoint << ".)\n";
+    throw runtime_error( ss.str() );
+  }
+}
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+    uniform_int_distribution<uint32_t> dist31minus1 { 0, ( uint32_t { 1 } << 31 ) - 1 };
+    uniform_int_distribution<uint32_t> dist32 { 0, numeric_limits<uint32_t>::max() };
+    const uint64_t big_offset = ( uint64_t { 1 } << 31 ) - 1;
+    // credit: Ammar Ratnani
+    uniform_int_distribution<uint64_t> dist63 { big_offset, uint64_t { 1 } << 63 };
+
+    for ( unsigned int i = 0; i < 250000; i++ ) {
+      const Wrap32 isn { dist32( rd ) };
+      const uint64_t val { dist63( rd ) };
+      const uint64_t offset { dist31minus1( rd ) };
+
+      check_roundtrip( isn, val, val );
+      check_roundtrip( isn, val + 1, val );
+      check_roundtrip( isn, val - 1, val );
+      check_roundtrip( isn, val + offset, val );
+      check_roundtrip( isn, val - offset, val );
+      check_roundtrip( isn, val + big_offset, val );
+      check_roundtrip( isn, val - big_offset, val );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/wrapping_integers_unwrap.cc
+++ b/tests/wrapping_integers_unwrap.cc
@@ -1,0 +1,43 @@
+#include "test_should_be.hh"
+#include "wrapping_integers.hh"
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    // Unwrap the first byte after ISN
+    test_should_be( Wrap32( 1 ).unwrap( Wrap32( 0 ), 0 ), 1UL );
+    // Unwrap the first byte after the first wrap
+    test_should_be( Wrap32( 1 ).unwrap( Wrap32( 0 ), UINT32_MAX ), ( 1UL << 32 ) + 1 );
+    // Unwrap the last byte before the third wrap
+    test_should_be( Wrap32( UINT32_MAX - 1 ).unwrap( Wrap32( 0 ), 3 * ( 1UL << 32 ) ), 3 * ( 1UL << 32 ) - 2 );
+    // Unwrap the 10th from last byte before the third wrap
+    test_should_be( Wrap32( UINT32_MAX - 10 ).unwrap( Wrap32( 0 ), 3 * ( 1UL << 32 ) ), 3 * ( 1UL << 32 ) - 11 );
+    // Non-zero ISN
+    test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( 10 ), 3 * ( 1UL << 32 ) ), 3 * ( 1UL << 32 ) - 11 );
+    // Big unwrap
+    test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( 0 ), 0 ), static_cast<uint64_t>( UINT32_MAX ) );
+    // Unwrap a non-zero ISN
+    test_should_be( Wrap32( 16 ).unwrap( Wrap32( 16 ), 0 ), 0UL );
+
+    // Big unwrap with non-zero ISN
+    test_should_be( Wrap32( 15 ).unwrap( Wrap32( 16 ), 0 ), static_cast<uint64_t>( UINT32_MAX ) );
+    // Big unwrap with non-zero ISN
+    test_should_be( Wrap32( 0 ).unwrap( Wrap32( INT32_MAX ), 0 ), static_cast<uint64_t>( INT32_MAX ) + 2 );
+    // Barely big unwrap with non-zero ISN
+    test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( INT32_MAX ), 0 ), static_cast<uint64_t>( 1 ) << 31 );
+    // Nearly big unwrap with non-zero ISN
+    test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( 1UL << 31 ), 0 ),
+                    static_cast<uint64_t>( UINT32_MAX ) >> 1 );
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/wrapping_integers_unwrap.cc
+++ b/tests/wrapping_integers_unwrap.cc
@@ -34,6 +34,9 @@ int main()
     // Nearly big unwrap with non-zero ISN
     test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( 1UL << 31 ), 0 ),
                     static_cast<uint64_t>( UINT32_MAX ) >> 1 );
+    // Big unwrap with non-zero ISN and low non-zero checkpoint
+    // test credit: Thanawan Atchariyachanvanit
+    test_should_be( Wrap32( 0 ).unwrap( Wrap32( 1 ), 1 ), static_cast<uint64_t>( UINT32_MAX ) );
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return 1;

--- a/tests/wrapping_integers_wrap.cc
+++ b/tests/wrapping_integers_wrap.cc
@@ -1,0 +1,21 @@
+#include "test_should_be.hh"
+#include "wrapping_integers.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    test_should_be( Wrap32::wrap( 3 * ( 1LL << 32 ), Wrap32( 0 ) ), Wrap32( 0 ) );
+    test_should_be( Wrap32::wrap( 3 * ( 1LL << 32 ) + 17, Wrap32( 15 ) ), Wrap32( 32 ) );
+    test_should_be( Wrap32::wrap( 7 * ( 1LL << 32 ) - 2, Wrap32( 15 ) ), Wrap32( 13 ) );
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/util/arp_message.cc
+++ b/util/arp_message.cc
@@ -1,0 +1,81 @@
+#include "arp_message.hh"
+
+#include <arpa/inet.h>
+#include <sstream>
+
+using namespace std;
+
+bool ARPMessage::supported() const
+{
+  return hardware_type == TYPE_ETHERNET and protocol_type == EthernetHeader::TYPE_IPv4
+         and hardware_address_size == sizeof( EthernetHeader::src )
+         and protocol_address_size == sizeof( IPv4Header::src )
+         and ( ( opcode == OPCODE_REQUEST ) or ( opcode == OPCODE_REPLY ) );
+}
+
+string ARPMessage::to_string() const
+{
+  stringstream ss {};
+  string opcode_str = "(unknown type)";
+  if ( opcode == OPCODE_REQUEST ) {
+    opcode_str = "REQUEST";
+  }
+  if ( opcode == OPCODE_REPLY ) {
+    opcode_str = "REPLY";
+  }
+  ss << "opcode=" << opcode_str << ", sender=" << ::to_string( sender_ethernet_address ) << "/"
+     << inet_ntoa( { htobe32( sender_ip_address ) } ) << ", target=" << ::to_string( target_ethernet_address )
+     << "/" << inet_ntoa( { htobe32( target_ip_address ) } );
+  return ss.str();
+}
+
+void ARPMessage::parse( Parser& parser )
+{
+  parser.integer( hardware_type );
+  parser.integer( protocol_type );
+  parser.integer( hardware_address_size );
+  parser.integer( protocol_address_size );
+  parser.integer( opcode );
+
+  if ( not supported() ) {
+    parser.set_error();
+    return;
+  }
+
+  // read sender addresses (Ethernet and IP)
+  for ( auto& b : sender_ethernet_address ) {
+    parser.integer( b );
+  }
+  parser.integer( sender_ip_address );
+
+  // read target addresses (Ethernet and IP)
+  for ( auto& b : target_ethernet_address ) {
+    parser.integer( b );
+  }
+  parser.integer( target_ip_address );
+}
+
+void ARPMessage::serialize( Serializer& serializer ) const
+{
+  if ( not supported() ) {
+    throw runtime_error( "ARPMessage: unsupported field combination (must be Ethernet/IP, and request or reply)" );
+  }
+
+  serializer.integer( hardware_type );
+  serializer.integer( protocol_type );
+  serializer.integer( hardware_address_size );
+  serializer.integer( protocol_address_size );
+  serializer.integer( opcode );
+
+  // read sender addresses (Ethernet and IP)
+  for ( const auto& b : sender_ethernet_address ) {
+    serializer.integer( b );
+  }
+  serializer.integer( sender_ip_address );
+
+  // read target addresses (Ethernet and IP)
+  for ( const auto& b : target_ethernet_address ) {
+    serializer.integer( b );
+  }
+  serializer.integer( target_ip_address );
+}

--- a/util/arp_message.hh
+++ b/util/arp_message.hh
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "ethernet_header.hh"
+#include "ipv4_header.hh"
+#include "parser.hh"
+
+// [ARP](\ref rfc::rfc826) message
+struct ARPMessage
+{
+  static constexpr size_t LENGTH = 28;         // ARP message length in bytes
+  static constexpr uint16_t TYPE_ETHERNET = 1; // ARP type for Ethernet/Wi-Fi as link-layer protocol
+  static constexpr uint16_t OPCODE_REQUEST = 1;
+  static constexpr uint16_t OPCODE_REPLY = 2;
+
+  uint16_t hardware_type = TYPE_ETHERNET;             // Type of the link-layer protocol (generally Ethernet/Wi-Fi)
+  uint16_t protocol_type = EthernetHeader::TYPE_IPv4; // Type of the Internet-layer protocol (generally IPv4)
+  uint8_t hardware_address_size = sizeof( EthernetHeader::src );
+  uint8_t protocol_address_size = sizeof( IPv4Header::src );
+  uint16_t opcode {}; // Request or reply
+
+  EthernetAddress sender_ethernet_address {};
+  uint32_t sender_ip_address {};
+
+  EthernetAddress target_ethernet_address {};
+  uint32_t target_ip_address {};
+
+  // Return a string containing the ARP message in human-readable format
+  std::string to_string() const;
+
+  // Is this type of ARP message supported by the parser?
+  bool supported() const;
+
+  void parse( Parser& parser );
+  void serialize( Serializer& serializer ) const;
+};

--- a/util/checksum.hh
+++ b/util/checksum.hh
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+#include <ranges>
+
+//! The internet checksum algorithm
+class InternetChecksum
+{
+private:
+  uint32_t sum_;
+  bool parity_ {};
+
+public:
+  explicit InternetChecksum( const uint32_t sum = 0 ) : sum_( sum ) {}
+  void add( std::string_view data )
+  {
+    for ( const uint8_t i : data ) {
+      uint16_t val = i;
+      if ( not parity_ ) {
+        val <<= 8;
+      }
+      sum_ += val;
+      parity_ = !parity_;
+    }
+  }
+
+  uint16_t value() const
+  {
+    uint32_t ret = sum_;
+
+    while ( ret > 0xffff ) {
+      ret = ( ret >> 16 ) + static_cast<uint16_t>( ret );
+    }
+
+    return ~ret;
+  }
+
+  void add( std::ranges::range auto&& data )
+  {
+    for ( const auto& x : data ) {
+      add( std::string_view { x } );
+    }
+  }
+};

--- a/util/debug.cc
+++ b/util/debug.cc
@@ -10,8 +10,10 @@ void default_debug_handler( void* /*unused*/, std::string_view message )
 }
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-static void ( *debug_handler )( void*, std::string_view ) = default_debug_handler;
-static void* debug_arg = nullptr;
+namespace {
+void ( *debug_handler )( void*, std::string_view ) = default_debug_handler;
+void* debug_arg = nullptr;
+} // namespace
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 void debug_str( string_view message )

--- a/util/debug.hh
+++ b/util/debug.hh
@@ -11,7 +11,7 @@
 void debug_str( std::string_view message );
 
 template<typename... Args>
-void debug( std::format_string<Args...> fmt, Args&&... args )
+void debug( std::format_string<Args...> fmt [[maybe_unused]], Args&&... args [[maybe_unused]] )
 {
 #ifndef NDEBUG
   debug_str( format( fmt, std::forward<Args>( args )... ) );

--- a/util/debug.hh
+++ b/util/debug.hh
@@ -11,6 +11,7 @@
 void debug_str( std::string_view message );
 
 template<typename... Args>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
 void debug( std::format_string<Args...> fmt [[maybe_unused]], Args&&... args [[maybe_unused]] )
 {
 #ifndef NDEBUG
@@ -18,5 +19,5 @@ void debug( std::format_string<Args...> fmt [[maybe_unused]], Args&&... args [[m
 #endif
 }
 
-void set_debug_handler( void ( * )( void*, std::string_view ), void* arg );
+void set_debug_handler( void ( *handler )( void*, std::string_view ), void* arg );
 void reset_debug_handler();

--- a/util/ethernet_frame.hh
+++ b/util/ethernet_frame.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ethernet_header.hh"
+#include "parser.hh"
+
+#include <vector>
+
+struct EthernetFrame
+{
+  EthernetHeader header {};
+  std::vector<Ref<std::string>> payload {};
+
+  void parse( Parser& parser )
+  {
+    header.parse( parser );
+    parser.all_remaining( payload );
+  }
+
+  void serialize( Serializer& serializer ) const
+  {
+    header.serialize( serializer );
+    serializer.buffer( payload );
+  }
+};

--- a/util/ethernet_header.cc
+++ b/util/ethernet_header.cc
@@ -1,0 +1,74 @@
+#include "ethernet_header.hh"
+
+#include <iomanip>
+#include <sstream>
+
+using namespace std;
+
+//! \returns A string with a textual representation of an Ethernet address
+string to_string( const EthernetAddress address )
+{
+  stringstream ss {};
+  for ( size_t index = 0; index < address.size(); index++ ) {
+    ss.width( 2 );
+    ss << setfill( '0' ) << hex << static_cast<int>( address.at( index ) );
+    if ( index != address.size() - 1 ) {
+      ss << ":";
+    }
+  }
+  return ss.str();
+}
+
+//! \returns A string with the header's contents
+string EthernetHeader::to_string() const
+{
+  stringstream ss {};
+  ss << "dst=" << ::to_string( dst );
+  ss << " src=" << ::to_string( src );
+  ss << " type=";
+  switch ( type ) {
+    case TYPE_IPv4:
+      ss << "IPv4";
+      break;
+    case TYPE_ARP:
+      ss << "ARP";
+      break;
+    default:
+      ss << "[unknown type " << hex << type << "!]";
+      break;
+  }
+
+  return ss.str();
+}
+
+void EthernetHeader::parse( Parser& parser )
+{
+  // read destination address
+  for ( auto& b : dst ) {
+    parser.integer( b );
+  }
+
+  // read source address
+  for ( auto& b : src ) {
+    parser.integer( b );
+  }
+
+  // read frame type (e.g. IPv4, ARP, or something else)
+  parser.integer( type );
+}
+
+void EthernetHeader::serialize( Serializer& serializer ) const
+{
+  // write destination address
+  for ( const auto& b : dst ) {
+    serializer.integer( b );
+  }
+
+  // write source address
+  for ( const auto& b : src ) {
+    serializer.integer( b );
+  }
+
+  // write frame type (e.g. IPv4, ARP, or something else)
+  serializer.integer( type );
+}

--- a/util/ethernet_header.hh
+++ b/util/ethernet_header.hh
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "parser.hh"
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+// Helper type for an Ethernet address (an array of six bytes)
+using EthernetAddress = std::array<uint8_t, 6>;
+
+// Ethernet broadcast address (ff:ff:ff:ff:ff:ff)
+constexpr EthernetAddress ETHERNET_BROADCAST = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+
+// Printable representation of an EthernetAddress
+std::string to_string( EthernetAddress address );
+
+// Ethernet frame header
+struct EthernetHeader
+{
+  static constexpr uint8_t LENGTH = 14;        //!< Ethernet header length in bytes
+  static constexpr uint16_t TYPE_IPv4 = 0x800; //!< Type number for [IPv4](\ref rfc::rfc791)
+  static constexpr uint16_t TYPE_ARP = 0x806;  //!< Type number for [ARP](\ref rfc::rfc826)
+
+  EthernetAddress dst;
+  EthernetAddress src;
+  uint16_t type;
+
+  // Return a string containing a header in human-readable format
+  std::string to_string() const;
+
+  void parse( Parser& parser );
+  void serialize( Serializer& serializer ) const;
+};

--- a/util/fd_adapter.hh
+++ b/util/fd_adapter.hh
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "tcp_config.hh"
+
+//! \brief Basic functionality for file descriptor adaptors
+//! \details See TCPOverIPv4OverTunFdAdapter for more information.
+class FdAdapterBase
+{
+private:
+  FdAdapterConfig _cfg {}; //!< Configuration values
+  bool _listen = false;    //!< Is the connected TCP FSM in listen state?
+
+protected:
+  FdAdapterConfig& config_mutable() { return _cfg; }
+
+public:
+  //! \brief Set the listening flag
+  //! \param[in] l is the new value for the flag
+  void set_listening( const bool l ) { _listen = l; }
+
+  //! \brief Get the listening flag
+  //! \returns whether the FdAdapter is listening for a new connection
+  bool listening() const { return _listen; }
+
+  //! \brief Get the current configuration
+  //! \returns a const reference
+  const FdAdapterConfig& config() const { return _cfg; }
+
+  //! \brief Get the current configuration (mutable)
+  //! \returns a mutable reference
+  FdAdapterConfig& config_mut() { return _cfg; }
+
+  //! Called periodically when time elapses
+  void tick( const size_t unused [[maybe_unused]] ) {}
+};

--- a/util/helpers.cc
+++ b/util/helpers.cc
@@ -23,7 +23,7 @@ string pretty_print( string_view str, size_t max_length )
   string ret = ss.str();
   if ( truncated ) {
     if ( ret.size() >= 3 ) {
-      ret.substr( ret.size() - 3, 3 ) = "...";
+      ret.replace( ret.size() - 3, 3, "..." );
     } else {
       ret += "...";
     }

--- a/util/helpers.hh
+++ b/util/helpers.hh
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "ethernet_frame.hh"
 #include "ipv4_datagram.hh"
 #include "parser.hh"
 #include "ref.hh"
 
+#include <numeric>
 #include <ranges>
 #include <string>
 #include <vector>
@@ -46,6 +48,16 @@ std::string concat( std::ranges::range auto&& r )
 
 // Pretty-print a string (escaping unprintable characters, and with a maximum length)
 std::string pretty_print( std::string_view str, size_t max_length = 32 );
+
+// Summarize an Ethernet frame into a string
+std::string summary( const EthernetFrame& frame );
+
+// Explicitly copy ("clone") a frame or datagram
+inline EthernetFrame clone( const EthernetFrame& x )
+{
+  auto duplicate_payload = x.payload | std::views::transform( []( auto& i ) { return i.get(); } );
+  return { x.header, { duplicate_payload.begin(), duplicate_payload.end() } };
+}
 
 inline InternetDatagram clone( const InternetDatagram& x )
 {

--- a/util/helpers.hh
+++ b/util/helpers.hh
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "ipv4_datagram.hh"
 #include "parser.hh"
 #include "ref.hh"
 
-#include <numeric>
 #include <ranges>
 #include <string>
 #include <vector>
@@ -46,3 +46,9 @@ std::string concat( std::ranges::range auto&& r )
 
 // Pretty-print a string (escaping unprintable characters, and with a maximum length)
 std::string pretty_print( std::string_view str, size_t max_length = 32 );
+
+inline InternetDatagram clone( const InternetDatagram& x )
+{
+  auto duplicate_payload = x.payload | std::views::transform( []( auto& i ) { return i.get(); } );
+  return { x.header, { duplicate_payload.begin(), duplicate_payload.end() } };
+}

--- a/util/ipv4_datagram.hh
+++ b/util/ipv4_datagram.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "ipv4_header.hh"
+#include "parser.hh"
+#include "ref.hh"
+
+#include <string>
+#include <vector>
+
+//! \brief [IPv4](\ref rfc::rfc791) Internet datagram
+struct IPv4Datagram
+{
+  IPv4Header header {};
+  std::vector<Ref<std::string>> payload {};
+
+  void parse( Parser& parser )
+  {
+    header.parse( parser );
+    parser.truncate( header.payload_length() );
+    parser.all_remaining( payload );
+  }
+
+  void serialize( Serializer& serializer ) const
+  {
+    header.serialize( serializer );
+    serializer.buffer( payload );
+  }
+};
+
+using InternetDatagram = IPv4Datagram;

--- a/util/ipv4_header.cc
+++ b/util/ipv4_header.cc
@@ -1,0 +1,124 @@
+#include "ipv4_header.hh"
+#include "checksum.hh"
+
+#include <arpa/inet.h>
+#include <sstream>
+
+using namespace std;
+
+// Parse from string.
+void IPv4Header::parse( Parser& parser )
+{
+  uint8_t first_byte {};
+  parser.integer( first_byte );
+  ver = first_byte >> 4;    // version
+  hlen = first_byte & 0x0f; // header length
+  parser.integer( tos );    // type of service
+  parser.integer( len );
+  parser.integer( id );
+
+  uint16_t fo_val {};
+  parser.integer( fo_val );
+  df = static_cast<bool>( fo_val & 0x4000 ); // don't fragment
+  mf = static_cast<bool>( fo_val & 0x2000 ); // more fragments
+  offset = fo_val & 0x1fff;                  // offset
+
+  parser.integer( ttl );
+  parser.integer( proto );
+  parser.integer( cksum );
+  parser.integer( src );
+  parser.integer( dst );
+
+  if ( ver != 4 ) {
+    parser.set_error();
+  }
+
+  if ( hlen < 5 ) {
+    parser.set_error();
+  }
+
+  if ( parser.has_error() ) {
+    return;
+  }
+
+  parser.remove_prefix( static_cast<uint64_t>( hlen ) * 4 - IPv4Header::LENGTH );
+
+  // Verify checksum
+  const uint16_t given_cksum = cksum;
+  compute_checksum();
+  if ( cksum != given_cksum ) {
+    parser.set_error();
+  }
+}
+
+// Serialize the IPv4Header (does not recompute the checksum)
+void IPv4Header::serialize( Serializer& serializer ) const
+{
+  // consistency checks
+  if ( ver != 4 ) {
+    throw runtime_error( "wrong IP version" );
+  }
+
+  const uint8_t first_byte = ( static_cast<uint32_t>( ver ) << 4 ) | ( hlen & 0xfU );
+  serializer.integer( first_byte ); // version and header length
+  serializer.integer( tos );
+  serializer.integer( len );
+  serializer.integer( id );
+
+  const uint16_t fo_val = ( df ? 0x4000U : 0 ) | ( mf ? 0x2000U : 0 ) | ( offset & 0x1fffU );
+  serializer.integer( fo_val );
+
+  serializer.integer( ttl );
+  serializer.integer( proto );
+
+  serializer.integer( cksum );
+
+  serializer.integer( src );
+  serializer.integer( dst );
+}
+
+uint16_t IPv4Header::payload_length() const
+{
+  return len - 4 * hlen;
+}
+
+//! \details This value is needed when computing the checksum of an encapsulated TCP segment.
+//! ~~~{.txt}
+//!   0      7 8     15 16    23 24    31
+//!  +--------+--------+--------+--------+
+//!  |          source address           |
+//!  +--------+--------+--------+--------+
+//!  |        destination address        |
+//!  +--------+--------+--------+--------+
+//!  |  zero  |protocol|  payload length |
+//!  +--------+--------+--------+--------+
+//! ~~~
+uint32_t IPv4Header::pseudo_checksum() const
+{
+  uint32_t pcksum = ( src >> 16 ) + static_cast<uint16_t>( src ); // source addr
+  pcksum += ( dst >> 16 ) + static_cast<uint16_t>( dst );
+  pcksum += proto;            // protocol
+  pcksum += payload_length(); // payload length
+  return pcksum;
+}
+
+void IPv4Header::compute_checksum()
+{
+  cksum = 0;
+  Serializer s;
+  serialize( s );
+
+  // calculate checksum -- taken over header only
+  InternetChecksum check;
+  check.add( s.finish() );
+  cksum = check.value();
+}
+
+string IPv4Header::to_string() const
+{
+  stringstream ss {};
+  ss << hex << boolalpha << "IPv" << +ver << " len=" << dec << +len << " proto=" << +proto
+     << " ttl=" + ::to_string( ttl ) << " src=" << inet_ntoa( { htobe32( src ) } )
+     << " dst=" << inet_ntoa( { htobe32( dst ) } );
+  return ss.str();
+}

--- a/util/ipv4_header.hh
+++ b/util/ipv4_header.hh
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "parser.hh"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+// IPv4 Internet datagram header (note: IP options are not supported)
+struct IPv4Header
+{
+  static constexpr uint8_t LENGTH = 20;       // IPv4 header length, not including options
+  static constexpr uint8_t DEFAULT_TTL = 128; // A reasonable default TTL value
+  static constexpr uint8_t PROTO_TCP = 6;     // Protocol number for TCP
+
+  static constexpr uint64_t serialized_length() { return LENGTH; }
+
+  /*
+   *   0                   1                   2                   3
+   *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |Version|  IHL  |Type of Service|          Total Length         |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |         Identification        |Flags|      Fragment Offset    |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |  Time to Live |    Protocol   |         Header Checksum       |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |                       Source Address                          |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |                    Destination Address                        |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |                    Options                    |    Padding    |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   */
+
+  // IPv4 Header fields
+  uint8_t ver = 4;           // IP version
+  uint8_t hlen = LENGTH / 4; // header length (multiples of 32 bits)
+  uint8_t tos = 0;           // type of service
+  uint16_t len = 0;          // total length of packet
+  uint16_t id = 0;           // identification number
+  bool df = true;            // don't fragment flag
+  bool mf = false;           // more fragments flag
+  uint16_t offset = 0;       // fragment offset field
+  uint8_t ttl = DEFAULT_TTL; // time to live field
+  uint8_t proto = PROTO_TCP; // protocol field
+  uint16_t cksum = 0;        // checksum field
+  uint32_t src = 0;          // src address
+  uint32_t dst = 0;          // dst address
+
+  // Length of the payload
+  uint16_t payload_length() const;
+
+  // Pseudo-header's contribution to the TCP checksum
+  uint32_t pseudo_checksum() const;
+
+  // Set checksum to correct value
+  void compute_checksum();
+
+  // Return a string containing a header in human-readable format
+  std::string to_string() const;
+
+  void parse( Parser& parser );
+  void serialize( Serializer& serializer ) const;
+};

--- a/util/lossy_fd_adapter.hh
+++ b/util/lossy_fd_adapter.hh
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "file_descriptor.hh"
+#include "random.hh"
+#include "tcp_config.hh"
+#include "tcp_segment.hh"
+
+#include <optional>
+#include <random>
+#include <utility>
+
+//! An adapter class that adds random dropping behavior to an FD adapter
+template<typename AdapterT>
+class LossyFdAdapter
+{
+private:
+  //! Fast RNG used by _should_drop()
+  std::default_random_engine _rand { get_random_engine() };
+
+  //! The underlying FD adapter
+  AdapterT _adapter;
+
+  //! \brief Determine whether or not to drop a given read or write
+  //! \param[in] uplink is `true` to use the uplink loss probability, else use the downlink loss probability
+  //! \returns `true` if the segment should be dropped
+  bool _should_drop( bool uplink )
+  {
+    const auto& cfg = _adapter.config();
+    const uint16_t loss = uplink ? cfg.loss_rate_up : cfg.loss_rate_dn;
+    return loss != 0 && static_cast<uint16_t>( _rand() ) < loss;
+  }
+
+public:
+  //! Conversion to a FileDescriptor by returning the underlying AdapterT
+  FileDescriptor& fd() { return _adapter.fd(); }
+
+  //! Construct from a FileDescriptor appropriate to the AdapterT constructor
+  explicit LossyFdAdapter( AdapterT&& adapter ) : _adapter( std::move( adapter ) ) {}
+
+  //! \brief Read from the underlying AdapterT instance, potentially dropping the read datagram
+  //! \returns std::optional<TCPSegment> that is empty if the segment was dropped or if
+  //!          the underlying AdapterT returned an empty value
+  std::optional<TCPMessage> read()
+  {
+    auto ret = _adapter.read();
+    if ( _should_drop( false ) ) {
+      return {};
+    }
+    return ret;
+  }
+
+  //! \brief Write to the underlying AdapterT instance, potentially dropping the datagram to be written
+  //! \param[in] seg is the packet to either write or drop
+  void write( const TCPMessage& seg )
+  {
+    if ( _should_drop( true ) ) {
+      return;
+    }
+    return _adapter.write( seg );
+  }
+
+  //! \name
+  //! Passthrough functions to the underlying AdapterT instance
+
+  void set_listening( const bool l ) { _adapter.set_listening( l ); } //!< FdAdapterBase::set_listening passthrough
+  const FdAdapterConfig& config() const { return _adapter.config(); } //!< FdAdapterBase::config passthrough
+  FdAdapterConfig& config_mut() { return _adapter.config_mut(); }     //!< FdAdapterBase::config_mut passthrough
+  void tick( const size_t ms_since_last_tick ) { _adapter.tick( ms_since_last_tick ); }
+};

--- a/util/parser.cc
+++ b/util/parser.cc
@@ -1,0 +1,168 @@
+#include "parser.hh"
+
+#include <cassert>
+#include <string>
+
+using namespace std;
+
+string_view Parser::BufferList::peek() const
+{
+  if ( buffer_.empty() ) {
+    throw runtime_error( "peek on empty BufferList" );
+  }
+  return string_view { buffer_.front().get() }.substr( skip_ );
+}
+
+void Parser::BufferList::remove_prefix( uint64_t len )
+{
+  while ( len and not buffer_.empty() ) {
+    const uint64_t to_pop_now = min( len, peek().size() );
+    skip_ += to_pop_now;
+    len -= to_pop_now;
+    size_ -= to_pop_now;
+    if ( skip_ == buffer_.front()->size() ) {
+      buffer_.pop_front();
+      skip_ = 0;
+    }
+  }
+}
+
+void Parser::BufferList::truncate( size_t len )
+{
+  if ( size_ <= len ) {
+    return;
+  }
+
+  if ( len == 0 ) {
+    buffer_.clear();
+    size_ = 0;
+    return;
+  }
+
+  size_t size_so_far = 0;
+  auto it = buffer_.begin();
+  while ( it != buffer_.end() ) {
+    if ( size_so_far + it->get().size() < len ) {
+      size_so_far += it->get().size();
+      ++it;
+      continue;
+    }
+
+    if ( size_so_far + it->get().size() == len ) {
+      ++it;
+      break;
+    }
+
+    assert( !it->get().empty() );
+    assert( len > size_so_far );
+    assert( len - size_so_far < it->get().size() );
+    it->get_mut().resize( len - size_so_far );
+    break;
+  }
+
+  while ( it != buffer_.end() ) {
+    it = buffer_.erase( it );
+  }
+
+  size_ = len;
+}
+
+void Parser::BufferList::dump_all( vector<Ref<std::string>>& out )
+{
+  out.clear();
+  if ( empty() ) {
+    return;
+  }
+  if ( skip_ ) {
+    out.emplace_back( buffer_.front()->substr( skip_ ) );
+  } else {
+    out.push_back( move( buffer_.front() ) );
+  }
+  buffer_.pop_front();
+  for ( auto&& x : buffer_ ) {
+    out.emplace_back( move( x ) );
+  }
+}
+
+vector<string_view> Parser::BufferList::buffer() const
+{
+  if ( empty() ) {
+    return {};
+  }
+  vector<string_view> ret;
+  ret.reserve( buffer_segment_count() );
+  auto tmp_skip = skip_;
+  for ( const auto& x : buffer_ ) {
+    ret.push_back( string_view { x.get() }.substr( tmp_skip ) );
+    tmp_skip = 0;
+  }
+  return ret;
+}
+
+void Parser::string( span<char> out )
+{
+  check_size( out.size() );
+  if ( has_error() ) {
+    return;
+  }
+
+  auto next = out.begin();
+  while ( next != out.end() ) {
+    const auto view = input_.peek().substr( 0, out.end() - next );
+    next = copy( view.begin(), view.end(), next );
+    input_.remove_prefix( view.size() );
+  }
+}
+
+void Parser::concatenate_all_remaining( std::string& out )
+{
+  vector<Ref<std::string>> concat;
+  all_remaining( concat );
+  if ( concat.empty() ) {
+    out.clear();
+    return;
+  }
+  out = concat.front().release();
+  if ( concat.size() > 1 ) {
+    for ( auto it = concat.begin() + 1; it != concat.end(); ++it ) {
+      out.append( *it );
+    }
+  }
+}
+
+void Serializer::flush()
+{
+  if ( not buffer_.empty() ) {
+    output_.emplace_back( move( buffer_ ) );
+    buffer_.clear();
+  }
+}
+
+void Serializer::buffer( string buf )
+{
+  if ( not buf.empty() ) {
+    flush();
+    output_.emplace_back( move( buf ) );
+  }
+}
+
+void Serializer::buffer( Ref<string> buf )
+{
+  if ( not buf.get().empty() ) {
+    flush();
+    output_.emplace_back( move( buf ) );
+  }
+}
+
+void Serializer::buffer( const vector<Ref<string>>& bufs )
+{
+  for ( const auto& b : bufs ) {
+    buffer( b.borrow() );
+  }
+}
+
+vector<Ref<string>> Serializer::finish()
+{
+  flush();
+  return move( output_ );
+}

--- a/util/ref.hh
+++ b/util/ref.hh
@@ -57,6 +57,7 @@ public:
       obj_ = other.get();
       borrowed_obj_ = nullptr;
     }
+    return *this;
   }
 #else
   // forbid implicit copies

--- a/util/tcp_config.hh
+++ b/util/tcp_config.hh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "address.hh"
+#include "wrapping_integers.hh"
+
+#include <cstddef>
+#include <cstdint>
+
+//! Config for TCP sender and receiver
+class TCPConfig
+{
+public:
+  static constexpr size_t DEFAULT_CAPACITY = 64000; //!< Default capacity
+  static constexpr size_t MAX_PAYLOAD_SIZE = 1000;  //!< Conservative max payload size for real Internet
+  static constexpr uint16_t TIMEOUT_DFLT = 1000;    //!< Default re-transmit timeout is 1 second
+  static constexpr unsigned MAX_RETX_ATTEMPTS = 8;  //!< Maximum re-transmit attempts before giving up
+
+  uint16_t rt_timeout = TIMEOUT_DFLT;      //!< Initial value of the retransmission timeout, in milliseconds
+  size_t recv_capacity = DEFAULT_CAPACITY; //!< Receive capacity, in bytes
+  size_t send_capacity = DEFAULT_CAPACITY; //!< Sender capacity, in bytes
+  Wrap32 isn { 137 };                      //!< Default initial sequence number
+};
+
+//! Config for classes derived from FdAdapter
+class FdAdapterConfig
+{
+public:
+  Address source { "0", 0 };      //!< Source address and port
+  Address destination { "0", 0 }; //!< Destination address and port
+
+  uint16_t loss_rate_dn = 0; //!< Downlink loss rate (for LossyFdAdapter)
+  uint16_t loss_rate_up = 0; //!< Uplink loss rate (for LossyFdAdapter)
+};

--- a/util/tcp_minnow_socket.hh
+++ b/util/tcp_minnow_socket.hh
@@ -1,0 +1,137 @@
+#pragma once
+
+#include "eventloop.hh"
+#include "file_descriptor.hh"
+#include "socket.hh"
+#include "tcp_config.hh"
+#include "tcp_peer.hh"
+#include "tuntap_adapter.hh"
+
+#include <atomic>
+#include <cstdint>
+#include <optional>
+#include <thread>
+
+//! Multithreaded wrapper around TCPPeer that approximates the Unix sockets API
+template<TCPDatagramAdapter AdaptT>
+class TCPMinnowSocket : public LocalStreamSocket
+{
+public:
+  //! Construct from the interface that the TCPPeer thread will use to read and write datagrams
+  explicit TCPMinnowSocket( AdaptT&& datagram_interface );
+
+  //! Close socket, and wait for TCPPeer to finish
+  //! \note Calling this function is only advisable if the socket has reached EOF,
+  //! or else may wait foreever for remote peer to close the TCP connection.
+  void wait_until_closed();
+
+  //! Connect using the specified configurations; blocks until connect succeeds or fails
+  void connect( const TCPConfig& c_tcp, const FdAdapterConfig& c_ad );
+
+  //! Listen and accept using the specified configurations; blocks until accept succeeds or fails
+  void listen_and_accept( const TCPConfig& c_tcp, const FdAdapterConfig& c_ad );
+
+  //! When a connected socket is destructed, it will send a RST
+  ~TCPMinnowSocket();
+
+  //! \name
+  //! This object cannot be safely moved or copied, since it is in use by two threads simultaneously
+
+  //!@{
+  TCPMinnowSocket( const TCPMinnowSocket& ) = delete;
+  TCPMinnowSocket( TCPMinnowSocket&& ) = delete;
+  TCPMinnowSocket& operator=( const TCPMinnowSocket& ) = delete;
+  TCPMinnowSocket& operator=( TCPMinnowSocket&& ) = delete;
+  //!@}
+
+  //! \name
+  //! Some methods of the parent Socket wouldn't work as expected on the TCP socket, so delete them
+
+  //!@{
+  void bind( const Address& address ) = delete;
+  Address local_address() const = delete;
+  void set_reuseaddr() = delete;
+  //!@}
+
+  // Return peer address from underlying datagram adapter
+  const Address& peer_address() const { return _datagram_adapter.config().destination; }
+
+protected:
+  //! Adapter to underlying datagram socket (e.g., UDP or IP)
+  AdaptT _datagram_adapter;
+
+private:
+  //! Stream socket for reads and writes between owner and TCP thread
+  LocalStreamSocket _thread_data;
+
+  //! Set up the TCPPeer and the event loop
+  void _initialize_TCP( const TCPConfig& config );
+
+  //! TCP state machine
+  std::optional<TCPPeer> _tcp {};
+
+  //! eventloop that handles all the events (new inbound datagram, new outbound bytes, new inbound bytes)
+  EventLoop _eventloop {};
+
+  //! Process events while specified condition is true
+  void _tcp_loop( const std::function<bool()>& condition );
+
+  //! Main loop of TCPPeer thread
+  void _tcp_main();
+
+  //! Handle to the TCPPeer thread; owner thread calls join() in the destructor
+  std::thread _tcp_thread {};
+
+  //! Construct LocalStreamSocket fds from socket pair, initialize eventloop
+  TCPMinnowSocket( std::pair<FileDescriptor, FileDescriptor> data_socket_pair, AdaptT&& datagram_interface );
+
+  std::atomic_bool _abort { false }; //!< Flag used by the owner to force the TCPPeer thread to shut down
+
+  bool _inbound_shutdown { false }; //!< Has TCPMinnowSocket shut down the incoming data to the owner?
+
+  bool _outbound_shutdown { false }; //!< Has the owner shut down the outbound data to the TCP connection?
+
+  bool _fully_acked { false }; //!< Has the outbound data been fully acknowledged by the peer?
+};
+
+using TCPOverIPv4MinnowSocket = TCPMinnowSocket<TCPOverIPv4OverTunFdAdapter>;
+using LossyTCPOverIPv4MinnowSocket = TCPMinnowSocket<LossyFdAdapter<TCPOverIPv4OverTunFdAdapter>>;
+
+//! \class TCPMinnowSocket
+//! This class involves the simultaneous operation of two threads.
+//!
+//! One, the "owner" or foreground thread, interacts with this class in much the
+//! same way as one would interact with a TCPSocket: it connects or listens, writes to
+//! and reads from a reliable data stream, etc. Only the owner thread calls public
+//! methods of this class.
+//!
+//! The other, the "TCPPeer" thread, takes care of the back-end tasks that the kernel would
+//! perform for a TCPSocket: reading and parsing datagrams from the wire, filtering out
+//! segments unrelated to the connection, etc.
+//!
+//! There are a few notable differences between the TCPMinnowSocket and TCPSocket interfaces:
+//!
+//! - a TCPMinnowSocket can only accept a single connection
+//! - listen_and_accept() is a blocking function call that acts as both [listen(2)](\ref man2::listen)
+//!   and [accept(2)](\ref man2::accept)
+//! - if TCPMinnowSocket is destructed while a TCP connection is open, the connection is
+//!   immediately terminated with a RST (call `wait_until_closed` to avoid this)
+
+//! Helper class that makes a TCPOverIPv4MinnowSocket behave more like a (kernel) TCPSocket
+class CS144TCPSocket : public TCPOverIPv4MinnowSocket
+{
+public:
+  CS144TCPSocket() : TCPOverIPv4MinnowSocket( TCPOverIPv4OverTunFdAdapter { TunFD { "tun144" } } ) {}
+  void connect( const Address& address )
+  {
+    TCPConfig tcp_config;
+    tcp_config.rt_timeout = 100;
+
+    FdAdapterConfig multiplexer_config;
+    multiplexer_config.source
+      = { "169.254.144.9", std::to_string( static_cast<uint16_t>( std::random_device()() ) ) };
+    multiplexer_config.destination = address;
+
+    TCPOverIPv4MinnowSocket::connect( tcp_config, multiplexer_config );
+  }
+};

--- a/util/tcp_minnow_socket_impl.hh
+++ b/util/tcp_minnow_socket_impl.hh
@@ -1,0 +1,289 @@
+#include "tcp_minnow_socket.hh"
+
+#include "exception.hh"
+
+#include <cstddef>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <utility>
+
+static constexpr size_t TCP_TICK_MS = 10;
+
+inline uint64_t timestamp_ms()
+{
+  static_assert( std::is_same_v<std::chrono::steady_clock::duration, std::chrono::nanoseconds> );
+
+  return std::chrono::steady_clock::now().time_since_epoch().count() / 1000000;
+}
+
+//! \param[in] condition is a function returning true if loop should continue
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::_tcp_loop( const std::function<bool()>& condition )
+{
+  auto base_time = timestamp_ms();
+  while ( condition() ) {
+    auto ret = _eventloop.wait_next_event( TCP_TICK_MS );
+    if ( ret == EventLoop::Result::Exit or _abort ) {
+      break;
+    }
+
+    if ( not _tcp.has_value() ) {
+      throw std::runtime_error( "_tcp_loop entered before TCPPeer initialized" );
+    }
+
+    if ( _tcp.value().active() ) {
+      const auto next_time = timestamp_ms();
+      _tcp.value().tick( next_time - base_time, [&]( auto x ) { _datagram_adapter.write( x ); } );
+      _datagram_adapter.tick( next_time - base_time );
+      base_time = next_time;
+    }
+  }
+}
+
+//! \param[in] data_socket_pair is a pair of connected AF_UNIX SOCK_STREAM sockets
+//! \param[in] datagram_interface is the interface for reading and writing datagrams
+template<TCPDatagramAdapter AdaptT>
+TCPMinnowSocket<AdaptT>::TCPMinnowSocket( std::pair<FileDescriptor, FileDescriptor> data_socket_pair,
+                                          AdaptT&& datagram_interface )
+  : LocalStreamSocket( std::move( data_socket_pair.first ) )
+  , _datagram_adapter( std::move( datagram_interface ) )
+  , _thread_data( std::move( data_socket_pair.second ) )
+{
+  _thread_data.set_blocking( false );
+  set_blocking( false );
+}
+
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::_initialize_TCP( const TCPConfig& config )
+{
+  _tcp.emplace( config );
+
+  // Set up the event loop
+
+  // There are three events to handle:
+  //
+  // 1) Incoming datagram received (needs to be given to TCPPeer::receive method)
+  //
+  // 2) Outbound bytes received from local application via a write()
+  //    call (needs to be read from the local stream socket and
+  //    given to TCPPeer)
+  //
+  // 3) Incoming bytes reassembled by the Reassembler
+  //    (needs to be read from the inbound_stream and written
+  //    to the local stream socket back to the application)
+
+  // rule 1: read from filtered packet stream and dump into TCPConnection
+  _eventloop.add_rule(
+    "receive TCP segment from the network",
+    _datagram_adapter.fd(),
+    Direction::In,
+    [&] {
+      if ( auto seg = _datagram_adapter.read() ) {
+        _tcp->receive( std::move( seg.value() ), [&]( auto x ) { _datagram_adapter.write( x ); } );
+      }
+
+      // debugging output:
+      if ( _thread_data.eof() and _tcp.value().sender().sequence_numbers_in_flight() == 0 and not _fully_acked ) {
+        std::cerr << "DEBUG: minnow outbound stream to " << _datagram_adapter.config().destination.to_string()
+                  << " has been fully acknowledged.\n";
+        _fully_acked = true;
+      }
+    },
+    [&] { return _tcp->active(); } );
+
+  // rule 2: read from pipe into outbound buffer
+  _eventloop.add_rule(
+    "push bytes to TCPPeer",
+    _thread_data,
+    Direction::In,
+    [&] {
+      std::string data;
+      data.resize( _tcp->outbound_writer().available_capacity() );
+      _thread_data.read( data );
+      _tcp->outbound_writer().push( move( data ) );
+
+      if ( _thread_data.eof() ) {
+        _tcp->outbound_writer().close();
+        _outbound_shutdown = true;
+
+        // debugging output:
+        std::cerr << "DEBUG: minnow outbound stream to " << _datagram_adapter.config().destination.to_string()
+                  << " finished (" << _tcp.value().sender().sequence_numbers_in_flight() << " seqno"
+                  << ( _tcp.value().sender().sequence_numbers_in_flight() == 1 ? "" : "s" )
+                  << " still in flight).\n";
+      }
+
+      _tcp->push( [&]( auto x ) { _datagram_adapter.write( x ); } );
+    },
+    [&] {
+      return ( _tcp->active() ) and ( not _outbound_shutdown )
+             and ( _tcp->outbound_writer().available_capacity() > 0 );
+    },
+    [&] {
+      _tcp->outbound_writer().close();
+      _outbound_shutdown = true;
+    },
+    [&] {
+      std::cerr << "DEBUG: minnow outbound stream had error.\n";
+      _tcp->outbound_writer().set_error();
+    } );
+
+  // rule 3: read from inbound buffer into pipe
+  _eventloop.add_rule(
+    "read bytes from inbound stream",
+    _thread_data,
+    Direction::Out,
+    [&] {
+      Reader& inbound = _tcp->inbound_reader();
+      // Write from the inbound_stream into
+      // the pipe, handling the possibility of a partial
+      // write (i.e., only pop what was actually written).
+      if ( inbound.bytes_buffered() ) {
+        const std::string_view buffer = inbound.peek();
+        const auto bytes_written = _thread_data.write( buffer );
+        inbound.pop( bytes_written );
+      }
+
+      if ( inbound.is_finished() or inbound.has_error() ) {
+        _thread_data.shutdown( SHUT_WR );
+        _inbound_shutdown = true;
+
+        // debugging output:
+        std::cerr << "DEBUG: minnow inbound stream from " << _datagram_adapter.config().destination.to_string()
+                  << " finished " << ( inbound.has_error() ? "uncleanly.\n" : "cleanly.\n" );
+      }
+    },
+    [&] {
+      return _tcp->inbound_reader().bytes_buffered()
+             or ( ( _tcp->inbound_reader().is_finished() or _tcp->inbound_reader().has_error() )
+                  and not _inbound_shutdown );
+    },
+    [&] {},
+    [&] {
+      std::cerr << "DEBUG: minnow inbound stream had error.\n";
+      _tcp->inbound_reader().set_error();
+    } );
+}
+
+//! \brief Call [socketpair](\ref man2::socketpair) and return connected Unix-domain sockets of specified type
+//! \param[in] type is the type of AF_UNIX sockets to create (e.g., SOCK_SEQPACKET)
+//! \returns a std::pair of connected sockets
+template<std::derived_from<Socket> SocketType>
+inline std::pair<SocketType, SocketType> socket_pair_helper( int domain, int type, int protocol = 0 )
+{
+  std::array<int, 2> fds {};
+  CheckSystemCall( "socketpair", ::socketpair( domain, type, protocol, fds.data() ) );
+  return { SocketType { FileDescriptor { fds[0] } }, SocketType { FileDescriptor { fds[1] } } };
+}
+
+//! \param[in] datagram_interface is the underlying interface (e.g. to UDP, IP, or Ethernet)
+template<TCPDatagramAdapter AdaptT>
+TCPMinnowSocket<AdaptT>::TCPMinnowSocket( AdaptT&& datagram_interface )
+  : TCPMinnowSocket( socket_pair_helper<LocalStreamSocket>( AF_UNIX, SOCK_STREAM ),
+                     std::move( datagram_interface ) )
+{}
+
+template<TCPDatagramAdapter AdaptT>
+TCPMinnowSocket<AdaptT>::~TCPMinnowSocket()
+{
+  try {
+    if ( _tcp_thread.joinable() ) {
+      std::cerr << "Warning: unclean shutdown of TCPMinnowSocket\n";
+      // force the other side to exit
+      _abort.store( true );
+      _tcp_thread.join();
+    }
+  } catch ( const std::exception& e ) {
+    std::cerr << "Exception destructing TCPMinnowSocket: " << e.what() << "\n";
+  }
+}
+
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::wait_until_closed()
+{
+  shutdown( SHUT_RDWR );
+  if ( _tcp_thread.joinable() ) {
+    std::cerr << "DEBUG: minnow waiting for clean shutdown... ";
+    _tcp_thread.join();
+    std::cerr << "done.\n";
+  }
+}
+
+//! \param[in] c_tcp is the TCPConfig for the TCPConnection
+//! \param[in] c_ad is the FdAdapterConfig for the FdAdapter
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::connect( const TCPConfig& c_tcp, const FdAdapterConfig& c_ad )
+{
+  if ( _tcp ) {
+    throw std::runtime_error( "connect() with TCPConnection already initialized" );
+  }
+
+  _initialize_TCP( c_tcp );
+
+  _datagram_adapter.config_mut() = c_ad;
+
+  std::cerr << "DEBUG: minnow connecting to " << c_ad.destination.to_string() << "...\n";
+
+  if ( not _tcp.has_value() ) {
+    throw std::runtime_error( "TCPPeer not successfully initialized" );
+  }
+
+  _tcp->push( [&]( auto x ) { _datagram_adapter.write( x ); } );
+
+  if ( _tcp->sender().sequence_numbers_in_flight() != 1 ) {
+    throw std::runtime_error( "After TCPConnection::connect(), expected sequence_numbers_in_flight() == 1" );
+  }
+
+  _tcp_loop( [&] { return _tcp->sender().sequence_numbers_in_flight() == 1; } );
+  if ( _tcp->inbound_reader().has_error() ) {
+    std::cerr << "DEBUG: minnow error on connecting to " << c_ad.destination.to_string() << ".\n";
+  } else {
+    std::cerr << "DEBUG: minnow successfully connected to " << c_ad.destination.to_string() << ".\n";
+  }
+
+  _tcp_thread = std::thread( &TCPMinnowSocket::_tcp_main, this );
+}
+
+//! \param[in] c_tcp is the TCPConfig for the TCPConnection
+//! \param[in] c_ad is the FdAdapterConfig for the FdAdapter
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::listen_and_accept( const TCPConfig& c_tcp, const FdAdapterConfig& c_ad )
+{
+  if ( _tcp ) {
+    throw std::runtime_error( "listen_and_accept() with TCPConnection already initialized" );
+  }
+
+  _initialize_TCP( c_tcp );
+
+  _datagram_adapter.config_mut() = c_ad;
+  _datagram_adapter.set_listening( true );
+
+  std::cerr << "DEBUG: minnow listening for incoming connection...\n";
+  _tcp_loop( [&] { return ( not _tcp->has_ackno() ) or ( _tcp->sender().sequence_numbers_in_flight() ); } );
+  std::cerr << "DEBUG: minnow new connection from " << _datagram_adapter.config().destination.to_string() << ".\n";
+
+  _tcp_thread = std::thread( &TCPMinnowSocket::_tcp_main, this );
+}
+
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::_tcp_main()
+{
+  try {
+    if ( not _tcp.has_value() ) {
+      throw std::runtime_error( "no TCP" );
+    }
+    _tcp_loop( [] { return true; } );
+    shutdown( SHUT_RDWR );
+    if ( not _tcp.value().active() ) {
+      std::cerr << "DEBUG: minnow TCP connection finished "
+                << ( _tcp->inbound_reader().has_error() ? "uncleanly.\n" : "cleanly.\n" );
+    }
+    _tcp.reset();
+  } catch ( const std::exception& e ) {
+    std::cerr << "Exception in TCPConnection runner thread: " << e.what() << "\n";
+    throw e;
+  }
+}

--- a/util/tcp_over_ip.cc
+++ b/util/tcp_over_ip.cc
@@ -1,0 +1,96 @@
+#include "tcp_over_ip.hh"
+
+#include "helpers.hh"
+#include "ipv4_datagram.hh"
+#include "ipv4_header.hh"
+
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <utility>
+
+using namespace std;
+
+//! \details This function attempts to parse a TCP segment from
+//! the IP datagram's payload.
+//!
+//! If this succeeds, it then checks that the received segment is related to the
+//! current connection. When a TCP connection has been established, this means
+//! checking that the source and destination ports in the TCP header are correct.
+//!
+//! If the TCP connection is listening (i.e., TCPOverIPv4OverTunFdAdapter::_listen is `true`)
+//! and the TCP segment read from the wire includes a SYN, this function clears the
+//! `_listen` flag and records the source and destination addresses and port numbers
+//! from the TCP header; it uses this information to filter future reads.
+//! \returns a std::optional<TCPSegment> that is empty if the segment was invalid or unrelated
+optional<TCPMessage> TCPOverIPv4Adapter::unwrap_tcp_in_ip( InternetDatagram ip_dgram )
+{
+  // is the IPv4 datagram for us?
+  // Note: it's valid to bind to address "0" (INADDR_ANY) and reply from actual address contacted
+  if ( not listening() and ( ip_dgram.header.dst != config().source.ipv4_numeric() ) ) {
+    return {};
+  }
+
+  // is the IPv4 datagram from our peer?
+  if ( not listening() and ( ip_dgram.header.src != config().destination.ipv4_numeric() ) ) {
+    return {};
+  }
+
+  // does the IPv4 datagram claim that its payload is a TCP segment?
+  if ( ip_dgram.header.proto != IPv4Header::PROTO_TCP ) {
+    return {};
+  }
+
+  // is the payload a valid TCP segment?
+  TCPSegment tcp_seg;
+  if ( not parse( tcp_seg, move( ip_dgram.payload ), ip_dgram.header.pseudo_checksum() ) ) {
+    return {};
+  }
+
+  // is the TCP segment for us?
+  if ( tcp_seg.udinfo.dst_port != config().source.port() ) {
+    return {};
+  }
+
+  // should we target this source addr/port (and use its destination addr as our source) in reply?
+  if ( listening() ) {
+    if ( tcp_seg.message.sender->SYN and not tcp_seg.message.sender->RST ) {
+      config_mutable().source = Address { inet_ntoa( { htobe32( ip_dgram.header.dst ) } ), config().source.port() };
+      config_mutable().destination
+        = Address { inet_ntoa( { htobe32( ip_dgram.header.src ) } ), tcp_seg.udinfo.src_port };
+      set_listening( false );
+    } else {
+      return {};
+    }
+  }
+
+  // is the TCP segment from our peer?
+  if ( tcp_seg.udinfo.src_port != config().destination.port() ) {
+    return {};
+  }
+
+  return move( tcp_seg.message );
+}
+
+//! Takes a TCP segment, sets port numbers as necessary, and wraps it in an IPv4 datagram
+//! \param[in] seg is the TCP segment to convert
+InternetDatagram TCPOverIPv4Adapter::wrap_tcp_in_ip( const TCPMessage& msg )
+{
+  const size_t payload_size = msg.sender->payload.size();
+  TCPSegment seg { .message = { msg.sender.borrow(), msg.receiver.borrow() } };
+  // set the port numbers in the TCP segment
+  seg.udinfo.src_port = config().source.port();
+  seg.udinfo.dst_port = config().destination.port();
+
+  // create an Internet Datagram and set its addresses and length
+  InternetDatagram ip_dgram;
+  ip_dgram.header.src = config().source.ipv4_numeric();
+  ip_dgram.header.dst = config().destination.ipv4_numeric();
+  ip_dgram.header.len = ip_dgram.header.hlen * 4 + 20 /* tcp header len */ + payload_size;
+
+  // set payload, calculating TCP checksum using information from IP header
+  seg.compute_checksum( ip_dgram.header.pseudo_checksum() );
+  ip_dgram.header.compute_checksum();
+  ip_dgram.payload = serialize( seg );
+
+  return ip_dgram;
+}

--- a/util/tcp_over_ip.hh
+++ b/util/tcp_over_ip.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "fd_adapter.hh"
+#include "ipv4_datagram.hh"
+#include "tcp_segment.hh"
+
+#include <optional>
+
+//! \brief A converter from TCP segments to serialized IPv4 datagrams
+class TCPOverIPv4Adapter : public FdAdapterBase
+{
+public:
+  std::optional<TCPMessage> unwrap_tcp_in_ip( InternetDatagram ip_dgram );
+
+  InternetDatagram wrap_tcp_in_ip( const TCPMessage& msg );
+};

--- a/util/tcp_peer.hh
+++ b/util/tcp_peer.hh
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "tcp_config.hh"
+#include "tcp_receiver.hh"
+#include "tcp_receiver_message.hh"
+#include "tcp_segment.hh"
+#include "tcp_sender.hh"
+#include "tcp_sender_message.hh"
+
+#include <functional>
+#include <optional>
+
+class TCPPeer
+{
+  auto make_send( const auto& transmit )
+  {
+    return [&]( const TCPSenderMessage& x ) { send( x, transmit ); };
+  }
+
+public:
+  explicit TCPPeer( const TCPConfig& cfg ) : cfg_( cfg ) {}
+
+  Writer& outbound_writer() { return sender_.writer(); }
+  Reader& inbound_reader() { return receiver_.reader(); }
+
+  /* Type of the `transmit` function that the push and tick methods can use to send messages */
+  using TransmitFunction = std::function<void( TCPMessage )>;
+
+  /* Passthrough methods */
+  void push( const TransmitFunction& transmit ) { sender_.push( make_send( transmit ) ); }
+  void tick( uint64_t t, const TransmitFunction& transmit )
+  {
+    cumulative_time_ += t;
+    sender_.tick( t, make_send( transmit ) );
+  }
+  bool has_ackno() const { return receiver_.send().ackno.has_value(); }
+
+  /* Is the peer still active? */
+  bool active() const
+  {
+    const bool any_errors = receiver_.reader().has_error() or sender_.writer().has_error();
+    const bool sender_active = sender_.sequence_numbers_in_flight() or not sender_.reader().is_finished();
+    const bool receiver_active = not receiver_.writer().is_closed();
+    const bool lingering
+      = linger_after_streams_finish_ and ( cumulative_time_ < time_of_last_receipt_ + 10UL * cfg_.rt_timeout );
+
+    return ( not any_errors ) and ( sender_active or receiver_active or lingering );
+  }
+
+  void receive( TCPMessage msg, const TransmitFunction& transmit )
+  {
+    if ( not active() ) {
+      return;
+    }
+
+    // Record time in case this peer has to linger after streams finish.
+    time_of_last_receipt_ = cumulative_time_;
+
+    // If SenderMessage occupies a sequence number, make sure to reply.
+    need_send_ |= ( msg.sender->sequence_length() > 0 );
+
+    // If SenderMessage is a "keep-alive" (with intentionally invalid seqno), make sure to reply.
+    // (N.B. orthodox TCP rules require a reply on any unacceptable segment.)
+    const auto our_ackno = receiver_.send().ackno;
+    need_send_ |= ( our_ackno.has_value() and msg.sender->seqno + 1 == our_ackno.value() );
+
+    // Give incoming TCPSenderMessage to receiver.
+    receiver_.receive( std::move( msg.sender ) );
+
+    // Give incoming TCPReceiverMessage to sender.
+    sender_.receive( msg.receiver );
+
+    // Send reply if needed.
+    push( transmit );
+    if ( need_send_ ) {
+      send( sender_.make_empty_message(), transmit );
+    }
+
+    // Did the inbound stream finish before the outbound stream? If so, no need to linger after streams finish.
+    if ( receiver_.writer().is_closed() and not std::as_const( sender_ ).reader().is_finished() ) {
+      linger_after_streams_finish_ = false;
+    }
+  }
+
+  // Testing interface
+  const TCPReceiver& receiver() const { return receiver_; }
+  const TCPSender& sender() const { return sender_; }
+
+private:
+  TCPConfig cfg_;
+  TCPSender sender_ { ByteStream { cfg_.send_capacity }, cfg_.isn, cfg_.rt_timeout };
+  TCPReceiver receiver_ { Reassembler { ByteStream { cfg_.recv_capacity } } };
+
+  bool need_send_ {};
+
+  void send( const TCPSenderMessage& sender_message, const TransmitFunction& transmit )
+  {
+    transmit( { borrow( sender_message ), receiver_.send() } );
+    need_send_ = false;
+  }
+
+  bool linger_after_streams_finish_ { true }; // one peer may need to linger to make sure all closure conditions met
+  uint64_t cumulative_time_ {};
+  uint64_t time_of_last_receipt_ {};
+};

--- a/util/tcp_receiver_message.hh
+++ b/util/tcp_receiver_message.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "wrapping_integers.hh"
+
+#include <optional>
+
+/*
+ * The TCPReceiverMessage structure contains the information sent from a TCP receiver to its sender.
+ *
+ * It contains three fields:
+ *
+ * 1) The acknowledgment number (ackno): the *next* sequence number needed by the TCP Receiver.
+ *    This is an optional field that is empty if the TCPReceiver hasn't yet received the Initial Sequence Number.
+ *
+ * 2) The window size. This is the number of sequence numbers that the TCP receiver is interested
+ *    to receive, starting from the ackno if present. The maximum value is 65,535 (UINT16_MAX from
+ *    the <cstdint> header).
+ *
+ * 3) The RST (reset) flag. If set, the stream has suffered an error and the connection should be aborted.
+ */
+
+struct TCPReceiverMessage
+{
+  std::optional<Wrap32> ackno {};
+  uint16_t window_size {};
+  bool RST {};
+};

--- a/util/tcp_segment.cc
+++ b/util/tcp_segment.cc
@@ -1,0 +1,119 @@
+#include "tcp_segment.hh"
+#include "checksum.hh"
+#include "helpers.hh"
+#include "wrapping_integers.hh"
+
+#include <sstream>
+
+using namespace std;
+
+static_assert( !( TCPSegment::HEADER_LENGTH & 0x03 ) ); // header length must be divisible by 4
+
+void TCPSegment::parse( Parser& parser, uint32_t datagram_layer_pseudo_checksum )
+{
+  /* verify checksum */
+  InternetChecksum check { datagram_layer_pseudo_checksum };
+  check.add( parser.buffer() );
+  if ( check.value() ) {
+    parser.set_error();
+    return;
+  }
+
+  uint32_t raw32 {};
+  uint16_t raw16 {};
+  uint8_t octet {};
+
+  parser.integer( udinfo.src_port );
+  parser.integer( udinfo.dst_port );
+
+  parser.integer( raw32 );
+  message.sender->seqno = Wrap32 { raw32 };
+
+  parser.integer( raw32 );
+  message.receiver->ackno = Wrap32 { raw32 };
+
+  parser.integer( octet );
+  const uint8_t data_offset = octet >> 4;
+
+  parser.integer( octet ); // flags
+  if ( not( octet & 0b0001'0000 ) ) {
+    message.receiver->ackno.reset(); // no ACK
+  }
+
+  message.sender->RST = message.receiver->RST = octet & 0b0000'0100;
+  message.sender->SYN = octet & 0b0000'0010;
+  message.sender->FIN = octet & 0b0000'0001;
+
+  parser.integer( message.receiver->window_size );
+  parser.integer( udinfo.cksum );
+  parser.integer( raw16 ); // urgent pointer
+
+  // skip any options or anything extra in the header
+  if ( data_offset < ( HEADER_LENGTH >> 2 ) ) {
+    parser.set_error();
+    return;
+  }
+  parser.remove_prefix( data_offset * 4 - HEADER_LENGTH );
+
+  parser.concatenate_all_remaining( message.sender->payload );
+}
+
+class Wrap32Serializable : public Wrap32
+{
+public:
+  uint32_t raw_value() const { return raw_value_; }
+};
+
+void TCPSegment::serialize( Serializer& serializer ) const
+{
+  serializer.integer( udinfo.src_port );
+  serializer.integer( udinfo.dst_port );
+  serializer.integer( Wrap32Serializable { message.sender->seqno }.raw_value() );
+  serializer.integer( Wrap32Serializable { message.receiver->ackno.value_or( Wrap32 { 0 } ) }.raw_value() );
+  serializer.integer( uint8_t { ( HEADER_LENGTH >> 2 ) << 4 } ); // data offset
+  const bool reset = message.sender->RST or message.receiver->RST;
+  const uint8_t flags = ( message.receiver->ackno.has_value() ? 0b0001'0000U : 0 ) | ( reset ? 0b0000'0100U : 0 )
+                        | ( message.sender->SYN ? 0b0000'0010U : 0 ) | ( message.sender->FIN ? 0b0000'0001U : 0 );
+  serializer.integer( flags );
+  serializer.integer( message.receiver->window_size );
+  serializer.integer( udinfo.cksum );
+  serializer.integer( uint16_t { 0 } ); // urgent pointer
+  serializer.buffer( message.sender->payload );
+}
+
+void TCPSegment::compute_checksum( uint32_t datagram_layer_pseudo_checksum )
+{
+  udinfo.cksum = 0;
+  Serializer s;
+  serialize( s );
+
+  InternetChecksum check { datagram_layer_pseudo_checksum };
+  check.add( s.finish() );
+  udinfo.cksum = check.value();
+}
+
+string TCPSegment::to_string() const
+{
+  stringstream ss {};
+  ss << "TCP";
+  ss << " seqno=" << Wrap32Serializable { message.sender->seqno }.raw_value();
+  if ( message.sender->SYN ) {
+    ss << " +SYN";
+  }
+  if ( not message.sender->payload.empty() ) {
+    ss << " payload=\"" << pretty_print( message.sender->payload ) << "\"";
+  }
+  if ( message.sender->FIN ) {
+    ss << " +FIN";
+  }
+  if ( message.sender->RST or message.receiver->RST ) {
+    ss << " +RST";
+  }
+  auto ackno = message.receiver->ackno;
+  if ( ackno.has_value() ) {
+    ss << " ACK<" << Wrap32Serializable { *ackno }.raw_value() << ">";
+  }
+  ss << " winsize=" << message.receiver->window_size;
+  ss << " src=" << udinfo.src_port << " dst=" << udinfo.dst_port;
+  return ss.str();
+}

--- a/util/tcp_segment.hh
+++ b/util/tcp_segment.hh
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "parser.hh"
+#include "ref.hh"
+#include "tcp_receiver_message.hh"
+#include "tcp_sender_message.hh"
+#include "udinfo.hh"
+
+// A TCPMessage (a concept used only in CS144) models the full
+// messages sent between TCP endpoints, omitting the multiplexing
+// information and checksum.
+struct TCPMessage
+{
+  Ref<TCPSenderMessage> sender {};
+  Ref<TCPReceiverMessage> receiver {};
+};
+
+// A TCPSegment represents a complete (STD 7 / RFC 9293) TCP segment.
+// It includes a TCPMessage plus the UDP-like information included in the TCP header.
+struct TCPSegment
+{
+  TCPMessage message {};
+  UserDatagramInfo udinfo {};
+
+  void parse( Parser& parser, uint32_t datagram_layer_pseudo_checksum );
+  void serialize( Serializer& serializer ) const;
+
+  void compute_checksum( uint32_t datagram_layer_pseudo_checksum );
+
+  static constexpr uint8_t HEADER_LENGTH = 20; // TCP header length, not including options
+
+  // Return a string containing a summary in human-readable format
+  std::string to_string() const;
+};

--- a/util/tcp_sender_message.hh
+++ b/util/tcp_sender_message.hh
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "wrapping_integers.hh"
+
+#include <string>
+
+/*
+ * The TCPSenderMessage structure contains the information sent from a TCP sender to its receiver.
+ *
+ * It contains five fields:
+ *
+ * 1) The sequence number (seqno) of the beginning of the segment. If the SYN flag is set, this is the
+ *    sequence number of the SYN flag. Otherwise, it's the sequence number of the beginning of the payload.
+ *
+ * 2) The SYN flag. If set, this segment is the beginning of the byte stream, and the seqno field
+ *    contains the Initial Sequence Number (ISN) -- the zero point.
+ *
+ * 3) The payload: a substring (possibly empty) of the byte stream.
+ *
+ * 4) The FIN flag. If set, the payload represents the ending of the byte stream.
+ *
+ * 5) The RST (reset) flag. If set, the stream has suffered an error and the connection should be aborted.
+ */
+
+struct TCPSenderMessage
+{
+  Wrap32 seqno { 0 };
+
+  bool SYN {};
+  std::string payload {};
+  bool FIN {};
+
+  bool RST {};
+
+  // How many sequence numbers does this segment use?
+  size_t sequence_length() const { return SYN + payload.size() + FIN; }
+};

--- a/util/tun.cc
+++ b/util/tun.cc
@@ -1,0 +1,38 @@
+#include "tun.hh"
+#include "exception.hh"
+
+#include <cstring>
+#include <fcntl.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#include <sys/ioctl.h>
+
+static constexpr const char* CLONEDEV = "/dev/net/tun";
+
+using namespace std;
+
+//! \param[in] devname is the name of the TUN or TAP device, specified at its creation.
+//! \param[in] is_tun is `true` for a TUN device (expects IP datagrams), or `false` for a TAP device (expects
+//! Ethernet frames)
+//!
+//! To create a TUN device, you should already have run
+//!
+//!     ip tuntap add mode tun user `username` name `devname`
+//!
+//! as root before calling this function.
+
+TunTapFD::TunTapFD( const string& devname, const bool is_tun )
+  : FileDescriptor( ::CheckSystemCall( "open", open( CLONEDEV, O_RDWR | O_CLOEXEC ) ) )
+{
+  struct ifreq tun_req
+  {};
+
+  tun_req.ifr_flags = static_cast<int16_t>( ( is_tun ? IFF_TUN : IFF_TAP ) | IFF_NO_PI ); // no packetinfo
+
+  // copy devname to ifr_name, making sure to null terminate
+
+  strncpy( static_cast<char*>( tun_req.ifr_name ), devname.data(), IFNAMSIZ - 1 );
+  tun_req.ifr_name[IFNAMSIZ - 1] = '\0';
+
+  CheckSystemCall( "ioctl", ioctl( fd_num(), TUNSETIFF, static_cast<void*>( &tun_req ) ) );
+}

--- a/util/tun.hh
+++ b/util/tun.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "file_descriptor.hh"
+
+#include <string>
+
+//! A FileDescriptor to a [Linux TUN/TAP](https://www.kernel.org/doc/Documentation/networking/tuntap.txt) device
+class TunTapFD : public FileDescriptor
+{
+public:
+  //! Open an existing persistent [TUN or TAP
+  //! device](https://www.kernel.org/doc/Documentation/networking/tuntap.txt).
+  explicit TunTapFD( const std::string& devname, bool is_tun );
+};
+
+//! A FileDescriptor to a [Linux TUN](https://www.kernel.org/doc/Documentation/networking/tuntap.txt) device
+class TunFD : public TunTapFD
+{
+public:
+  //! Open an existing persistent [TUN device](https://www.kernel.org/doc/Documentation/networking/tuntap.txt).
+  explicit TunFD( const std::string& devname ) : TunTapFD( devname, true ) {}
+};
+
+//! A FileDescriptor to a [Linux TAP](https://www.kernel.org/doc/Documentation/networking/tuntap.txt) device
+class TapFD : public TunTapFD
+{
+public:
+  //! Open an existing persistent [TAP device](https://www.kernel.org/doc/Documentation/networking/tuntap.txt).
+  explicit TapFD( const std::string& devname ) : TunTapFD( devname, false ) {}
+};

--- a/util/tuntap_adapter.cc
+++ b/util/tuntap_adapter.cc
@@ -1,0 +1,26 @@
+#include "tuntap_adapter.hh"
+#include "helpers.hh"
+
+using namespace std;
+
+optional<TCPMessage> TCPOverIPv4OverTunFdAdapter::read()
+{
+  vector<string> strs( 3 );
+  strs[0].resize( IPv4Header::LENGTH );
+  strs[1].resize( TCPSegment::HEADER_LENGTH );
+  _tun.read( strs );
+
+  InternetDatagram ip_dgram;
+  if ( parse( ip_dgram, move( strs ) ) ) {
+    return unwrap_tcp_in_ip( move( ip_dgram ) );
+  }
+  return {};
+}
+
+void TCPOverIPv4OverTunFdAdapter::write( const TCPMessage& seg )
+{
+  _tun.write( serialize( wrap_tcp_in_ip( seg ) ) );
+}
+
+//! Specialize LossyFdAdapter to TCPOverIPv4OverTunFdAdapter
+template class LossyFdAdapter<TCPOverIPv4OverTunFdAdapter>;

--- a/util/tuntap_adapter.hh
+++ b/util/tuntap_adapter.hh
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "lossy_fd_adapter.hh"
+#include "tcp_over_ip.hh"
+#include "tcp_segment.hh"
+#include "tun.hh"
+
+#include <optional>
+#include <utility>
+
+template<class T>
+concept TCPDatagramAdapter = requires( T a, TCPMessage seg ) {
+  { a.write( seg ) } -> std::same_as<void>;
+
+  { a.read() } -> std::same_as<std::optional<TCPMessage>>;
+};
+
+//! \brief A FD adapter for IPv4 datagrams read from and written to a TUN device
+class TCPOverIPv4OverTunFdAdapter : public TCPOverIPv4Adapter
+{
+private:
+  TunFD _tun;
+
+public:
+  //! Construct from a TunFD
+  explicit TCPOverIPv4OverTunFdAdapter( TunFD&& tun ) : _tun( std::move( tun ) ) {}
+
+  //! Attempts to read and parse an IPv4 datagram containing a TCP segment related to the current connection
+  std::optional<TCPMessage> read();
+
+  //! Creates an IPv4 datagram from a TCP segment and writes it to the TUN device
+  void write( const TCPMessage& seg );
+
+  //! Access the underlying TUN device
+  explicit operator TunFD&() { return _tun; }
+
+  //! Access the underlying TUN device
+  explicit operator const TunFD&() const { return _tun; }
+
+  //! Access underlying file descriptor
+  FileDescriptor& fd() { return _tun; }
+};
+
+static_assert( TCPDatagramAdapter<TCPOverIPv4OverTunFdAdapter> );
+static_assert( TCPDatagramAdapter<LossyFdAdapter<TCPOverIPv4OverTunFdAdapter>> );

--- a/util/udinfo.hh
+++ b/util/udinfo.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+// Small struct to represent "user datagram" information (UDP, or the "UDP-like" portion of a TCP header)
+
+struct UserDatagramInfo
+{
+  uint16_t src_port;
+  uint16_t dst_port;
+  uint16_t cksum;
+};

--- a/writeups/check0.md
+++ b/writeups/check0.md
@@ -1,19 +1,19 @@
 Checkpoint 0 Writeup
 ====================
 
-My name: [your name here]
+My name: Raymond Llata
 
-My SUNet ID: [your sunetid here]
+My SUNet ID: rllata
 
-I collaborated with: [list sunetids here]
+I collaborated with: N/A
 
-I would like to credit/thank these classmates for their help: [list sunetids here]
+I would like to credit/thank these classmates for their help: N/A
 
-This lab took me about [n] hours to do. I [did/did not] attend the lab session.
+This lab took me about [6] hours to do. I did not attend the lab session.
 
-My secret code from section 2.1 was: [code here]
+My secret code from section 2.1 was: 766565
 
-I was surprised by or edified to learn that: [describe]
+I was surprised by or edified to learn that: An amazing Bytestream implementation could achieve 10.00 Gbit/s.
 
 Describe ByteStream implementation. [Describe data structures and
 approach taken. Describe alternative designs considered or tested.
@@ -23,11 +23,47 @@ bugs, asymptotic performance, empirical performance, required
 implementation time and difficulty, and other factors. Include any
 measurements if applicable.]
 
-- Optional: I had unexpected difficulty with: [describe]
+For my main data structure I only used a queue to store the bits, meaning information was being stored one char at a time. Aside from this, I permanently stored a string representing the current state of the queue to reference for quick peek times, storage complexity O(n). For pushing items I would add them to the queue, append a char to the string, and then mark up/down the respective int values O(1), for popping items I would pop them from queue, call substr to remove them from the peek string, and mark down the values O(n). All other functions simply called member variables to return an internal state, which runs in O(1). Asymptotically, Popping was definietly my weakest function, and I struggled to find a solution that would keep the peek values in internal memory, so that I could return them (See optional section). The implementation time took around 8 hours, but a large portion of that was spent fiddling with VScode. My code was being compiled with optimizations when debugging on VSCode (but not terminal GDB), and it ended up taking a while to figure out why.
+
+
+- Optional: I had unexpected difficulty with: Setting up my VSCode debugger over SSH. I also had difficulty with the return values for peek. Since peek returns a string_view (not a string), it does not have access over it's internal memory; my original implementation returned a temporary string instead, which would turn to garbage as soon as the function ended. I ended up redoing my implementation of Bytestream because I did not realize peek was returning a string_view and not a string when I started.
+
+My scores:
+Test project /home/cs144/checkpoint0/minnow/build
+      Start  1: compile with bug-checkers
+ 1/11 Test  #1: compile with bug-checkers ........   Passed    1.26 sec
+      Start  2: t_webget
+ 2/11 Test  #2: t_webget .........................   Passed    0.70 sec
+      Start  3: byte_stream_basics
+ 3/11 Test  #3: byte_stream_basics ...............   Passed    0.01 sec
+      Start  4: byte_stream_capacity
+ 4/11 Test  #4: byte_stream_capacity .............   Passed    0.01 sec
+      Start  5: byte_stream_one_write
+ 5/11 Test  #5: byte_stream_one_write ............   Passed    0.01 sec
+      Start  6: byte_stream_two_writes
+ 6/11 Test  #6: byte_stream_two_writes ...........   Passed    0.01 sec
+      Start  7: byte_stream_many_writes
+ 7/11 Test  #7: byte_stream_many_writes ..........   Passed    5.25 sec
+      Start  8: byte_stream_stress_test
+ 8/11 Test  #8: byte_stream_stress_test ..........   Passed    0.67 sec
+      Start 37: no_skip
+ 9/11 Test #37: no_skip ..........................   Passed    0.01 sec
+      Start 38: compile with optimization
+10/11 Test #38: compile with optimization ........   Passed    0.38 sec
+      Start 39: byte_stream_speed_test
+        ByteStream throughput (pop length 4096):  2.43 Gbit/s
+        ByteStream throughput (pop length 128):   0.97 Gbit/s
+        ByteStream throughput (pop length 32):    0.39 Gbit/s
+11/11 Test #39: byte_stream_speed_test ...........   Passed    0.51 sec
+
+100% tests passed, 0 tests failed out of 11
+
+Total Test time (real) =   8.83 sec
+Built target check0
 
 - Optional: I think you could make this lab better by: [describe]
 
-- Optional: I'm not sure about: [describe]
+- Optional: I'm not sure about: What improvements I could obviously make to get to a higher gbips score.
 
 - Optional: I contributed a new test case that catches a plausible bug
   not otherwise caught: [provide Pull Request URL]

--- a/writeups/check1.md
+++ b/writeups/check1.md
@@ -1,0 +1,37 @@
+Checkpoint 1 Writeup
+====================
+
+My name: [your name here]
+
+My SUNet ID: [your sunetid here]
+
+I collaborated with: [list sunetids here]
+
+I would like to thank/reward these classmates for their help: [list sunetids here]
+
+This lab took me about [n] hours to do. I [did/did not] attend the lab session.
+
+I was surprised by or edified to learn that: [describe]
+
+Report from the hands-on component of the lab checkpoint: [include
+information from 2.1(4), and report on your experience in 2.2]
+
+Describe Reassembler structure and design. [Describe data structures and
+approach taken. Describe alternative designs considered or tested.
+Describe benefits and weaknesses of your design compared with
+alternatives -- perhaps in terms of simplicity/complexity, risk of
+bugs, asymptotic performance, empirical performance, required
+implementation time and difficulty, and other factors. Include any
+measurements if applicable.]
+
+Implementation Challenges:
+[]
+
+Remaining Bugs:
+[]
+
+- Optional: I had unexpected difficulty with: [describe]
+
+- Optional: I think you could make this lab better by: [describe]
+
+- Optional: I'm not sure about: [describe]

--- a/writeups/check1.md
+++ b/writeups/check1.md
@@ -9,9 +9,9 @@ I collaborated with: kyles7
 
 I would like to thank/reward these classmates for their help: [list sunetids here]
 
-This lab took me about [n] hours to do. I [did/did not] attend the lab session.
+This lab took me about [6] hours to do. I [did] attend the lab session.
 
-I was surprised by or edified to learn that: [describe]
+I was surprised by or edified to learn that: [The Reassembler is releveant to the actual internet and TCP abstraction as discussed in 1/17 lecture]
 
 Report from the hands-on component of the lab checkpoint: [include
 information from 2.1(4), and report on your experience in 2.2]
@@ -33,11 +33,17 @@ bugs, asymptotic performance, empirical performance, required
 implementation time and difficulty, and other factors. Include any
 measurements if applicable.]
 
+I used a unordered_map to store information that could not be enqueued. This was because adding to the 
+map would be O(1) (average) and accessing would also be O(1). I opted to store each char individually, which would make it easier to access when I was requeueing them. An alternative approach I considered was storing whole strings together, and I could just reattempt to add all strings when I needed to, but I figured storing strings vs individual chars was only saving a small amount of overhead (if any) and wasn't even worth it.
+
+An alternative DS I considered was some sort of priority queue, because I could only add the next number in the queue, so some sort of sorted DS would be good for this objective. I decided against it for several reasons. PQ's have slower push + pop due to the bubble up algorithm O(logn). The convience of sorted order was unecessary since I more specifically could only add last_number+1, not just the most recent one. I am able to check for the existence of last_number+1 with an unordered_map with the same expected runtime as peak for a PQ, so the map seemed like the all around better choice here.
+
+
 Implementation Challenges:
-[]
+[Mac UTM default compiler made it so I couldnt pass reassembler_win for a while. Ed post #251 helped alot, thanks Keith!!]
 
 Remaining Bugs:
-[]
+[None (hopefully)]
 
 - Optional: I had unexpected difficulty with: [describe]
 

--- a/writeups/check1.md
+++ b/writeups/check1.md
@@ -1,11 +1,11 @@
 Checkpoint 1 Writeup
 ====================
 
-My name: [your name here]
+My name: Raymond Llata
 
-My SUNet ID: [your sunetid here]
+My SUNet ID: rllata
 
-I collaborated with: [list sunetids here]
+I collaborated with: kyles7
 
 I would like to thank/reward these classmates for their help: [list sunetids here]
 
@@ -15,6 +15,15 @@ I was surprised by or edified to learn that: [describe]
 
 Report from the hands-on component of the lab checkpoint: [include
 information from 2.1(4), and report on your experience in 2.2]
+
+Average Time Taken: 11.2 ms
+1676 packets transmitted, 1676 received, 0% packet loss, time 339811ms
+rtt min/avg/max/mdev = 6.076/11.200/126.409/9.767 ms
+0% packet loss?
+Did not see some DUP messages
+Yes, saw Source/DST/TTL and a few others.
+The TTL is different and requests say reply and vice versa.
+
 
 Describe Reassembler structure and design. [Describe data structures and
 approach taken. Describe alternative designs considered or tested.

--- a/writeups/check1.md
+++ b/writeups/check1.md
@@ -24,6 +24,11 @@ Did not see some DUP messages
 Yes, saw Source/DST/TTL and a few others.
 The TTL is different and requests say reply and vice versa.
 
+In order to recieve a datagram from my partner I needed to use the code snippet from lecture but replace Address{ "1" } with our
+target IP address. We would not recieve the datagram otherwise. Sending UDP datagrams allowed us to view the message locally, for some
+raw datagrams (protocol 5) we would not be able to view the contents. We later resolved this using the -v (verbose) flag on the tcpdump
+function.
+
 
 Describe Reassembler structure and design. [Describe data structures and
 approach taken. Describe alternative designs considered or tested.
@@ -34,13 +39,33 @@ implementation time and difficulty, and other factors. Include any
 measurements if applicable.]
 
 I used a unordered_map to store information that could not be enqueued. This was because adding to the 
-map would be O(1) (average) and accessing would also be O(1). I opted to store each char individually, which would make it easier to access when I was requeueing them. An alternative approach I considered was storing whole strings together, and I could just reattempt to add all strings when I needed to, but I figured storing strings vs individual chars was only saving a small amount of overhead (if any) and wasn't even worth it.
+map would be O(1) (average) and accessing would also be O(1). I opted to store each char individually, 
+which would make it easier to access when I was requeueing them (I would be able to search for an index
+without getting creative in finding an index within a string). 
 
-An alternative DS I considered was some sort of priority queue, because I could only add the next number in the queue, so some sort of sorted DS would be good for this objective. I decided against it for several reasons. PQ's have slower push + pop due to the bubble up algorithm O(logn). The convience of sorted order was unecessary since I more specifically could only add last_number+1, not just the most recent one. I am able to check for the existence of last_number+1 with an unordered_map with the same expected runtime as peak for a PQ, so the map seemed like the all around better choice here.
+An alternative approach I considered was 
+storing whole strings together (using a unordered_map<int, string> instead of unordered_map<int, char>), 
+and I could just reattempt to add all strings when I needed to using some sort of complex indexing math. I initially thought
+about this approach to save storage space (some of the test cases store alot of data), but I soon realized that storing the chars
+individually vs storing a string does not actually save that much overhead. I guess it would have reduced the number of collisions
+in my unordered_map, but worst case get()/set() time would be O(logn), which isn't too bad. I decided the simplicity was more worth the 
+potentially slower runtime. Generally, it is my understanding that I would not have to deal with collisions in my map much unless I was storing
+thousands of thousands of keys.
+
+An alternative DS I considered was some sort of priority queue, because I could only add the next number in the queue, 
+so some sort of sorted DS would be good for this objective. I decided against it for several reasons: PQ's have slower 
+push + pop due to the bubble up algorithm O(logn) expected time. Furthermore, the convience of sorted order was unecessary since I more specifically 
+could only add the index last_number+1, not the most recent index in general. Using an unordered_map I am able to check for the existence of last_number+1 with an 
+unordered_map with the same expected runtime as peak for a PQ, so the map seemed like the all around better choice here - in terms of runtime, and simplicity. I do 
+believe a PQ could have been simpler when implementing some parts of the reassembler (such as restoring the Bytestream from my saved state). Instead of saving indexes
+I could simply peek and pop on a loop to readd. One challenge it would pose is it would not do well with duplicates, so I would need to find a quick way of 
+checking if a item already exists. An unordered_map excels at this O(1) runtime.
 
 
 Implementation Challenges:
-[Mac UTM default compiler made it so I couldnt pass reassembler_win for a while. Ed post #251 helped alot, thanks Keith!!]
+[Mac UTM default compiler made it so I couldnt pass reassembler_win for a while. Ed post #251 helped alot, thanks Keith!!
+I struggled also in understanding when the Reassembler could close the connection. I felt that the assignment handout was vague in this (as was the header file),
+and the way I went about this was really just running the test cases and studying them to derive what correct behavior would be.]
 
 Remaining Bugs:
 [None (hopefully)]

--- a/writeups/check1.md
+++ b/writeups/check1.md
@@ -61,6 +61,12 @@ believe a PQ could have been simpler when implementing some parts of the reassem
 I could simply peek and pop on a loop to readd. One challenge it would pose is it would not do well with duplicates, so I would need to find a quick way of 
 checking if a item already exists. An unordered_map excels at this O(1) runtime.
 
+17/18 Test #39: byte_stream_speed_test ...........   Passed    0.53 sec
+      Start 40: reassembler_speed_test
+        Reassembler throughput (no overlap):   2.23 Gbit/s
+        Reassembler throughput (10x overlap):  0.35 Gbit/s
+18/18 Test #40: reassembler_speed_test ...........   Passed    0.99 sec
+
 
 Implementation Challenges:
 [Mac UTM default compiler made it so I couldnt pass reassembler_win for a while. Ed post #251 helped alot, thanks Keith!!

--- a/writeups/check1.md
+++ b/writeups/check1.md
@@ -74,7 +74,9 @@ I struggled also in understanding when the Reassembler could close the connectio
 and the way I went about this was really just running the test cases and studying them to derive what correct behavior would be.]
 
 Remaining Bugs:
-[None (hopefully)]
+One bug this reassembler could have is with bytes that have been corrupted. The Reassembler only stores/enqueues the first byte receieved -- this means that if the first byte recieved has been corrupted, the Reassembler would not be able to fix this. One method to fix this would implement a byte-updating protocol; in storage, only the most recent copy of each byte is stored. However, most the test cases seem to imply we will recieve well formatted data.
+
+Another bug would be if the reassembler is passed a string that exceeds max storage capacity, and has a end_of_string flag attatched; since the last byte exceeds capacity it would not be stored/pushed, and the bytestream would never be closed. For well formatted data, this is not an issue, but if this is not a valid assumption, the Reassembler will leave the stream open in this case.
 
 - Optional: I had unexpected difficulty with: [describe]
 

--- a/writeups/check2.md
+++ b/writeups/check2.md
@@ -1,0 +1,36 @@
+Checkpoint 2 Writeup
+====================
+
+My name: [your name here]
+
+My SUNet ID: [your sunetid here]
+
+I collaborated with: [list sunetids here]
+
+I would like to thank/reward these classmates for their help: [list sunetids here]
+
+This lab took me about [n] hours to do. I [did/did not] attend the lab session.
+
+Describe Wrap32 and TCPReceiver structure and design. [Describe data
+structures and approach taken. Describe alternative designs considered
+or tested.  Describe benefits and weaknesses of your design compared
+with alternatives -- perhaps in terms of simplicity/complexity, risk
+of bugs, asymptotic performance, empirical performance, required
+implementation time and difficulty, and other factors. Include any
+measurements if applicable.]
+
+Implementation Challenges:
+[]
+
+Remaining Bugs:
+[]
+
+- Optional: I had unexpected difficulty with: [describe]
+
+- Optional: I think you could make this lab better by: [describe]
+
+- Optional: I was surprised by: [describe]
+
+- Optional: I'm not sure about: [describe]
+
+- Optional: I made an extra test I think will be helpful in catching bugs: [describe where to find]

--- a/writeups/check2.md
+++ b/writeups/check2.md
@@ -40,6 +40,73 @@ I felt like this class was fairly straightforward, and there was not much need f
 Implementation Challenges:
 [I found some of the edge cases to not be well discussed in the Lab Handout/Lecture so I had to spend alot of time reading through test cases to derive the proper functionality.]
 
+Test project /home/cs144/checkpoint0/minnow/build
+      Start  1: compile with bug-checkers
+ 1/30 Test  #1: compile with bug-checkers ........   Passed    2.06 sec
+      Start  3: byte_stream_basics
+ 2/30 Test  #3: byte_stream_basics ...............   Passed    0.01 sec
+      Start  4: byte_stream_capacity
+ 3/30 Test  #4: byte_stream_capacity .............   Passed    0.01 sec
+      Start  5: byte_stream_one_write
+ 4/30 Test  #5: byte_stream_one_write ............   Passed    0.01 sec
+      Start  6: byte_stream_two_writes
+ 5/30 Test  #6: byte_stream_two_writes ...........   Passed    0.01 sec
+      Start  7: byte_stream_many_writes
+ 6/30 Test  #7: byte_stream_many_writes ..........   Passed    0.06 sec
+      Start  8: byte_stream_stress_test
+ 7/30 Test  #8: byte_stream_stress_test ..........   Passed    0.02 sec
+      Start  9: reassembler_single
+ 8/30 Test  #9: reassembler_single ...............   Passed    0.01 sec
+      Start 10: reassembler_cap
+ 9/30 Test #10: reassembler_cap ..................   Passed    0.01 sec
+      Start 11: reassembler_seq
+10/30 Test #11: reassembler_seq ..................   Passed    0.01 sec
+      Start 12: reassembler_dup
+11/30 Test #12: reassembler_dup ..................   Passed    0.03 sec
+      Start 13: reassembler_holes
+12/30 Test #13: reassembler_holes ................   Passed    0.01 sec
+      Start 14: reassembler_overlapping
+13/30 Test #14: reassembler_overlapping ..........   Passed    0.01 sec
+      Start 15: reassembler_win
+14/30 Test #15: reassembler_win ..................   Passed    6.63 sec
+      Start 16: wrapping_integers_cmp
+15/30 Test #16: wrapping_integers_cmp ............   Passed    0.01 sec
+      Start 17: wrapping_integers_wrap
+16/30 Test #17: wrapping_integers_wrap ...........   Passed    0.00 sec
+      Start 18: wrapping_integers_unwrap
+17/30 Test #18: wrapping_integers_unwrap .........   Passed    0.01 sec
+      Start 19: wrapping_integers_roundtrip
+18/30 Test #19: wrapping_integers_roundtrip ......   Passed    0.28 sec
+      Start 20: wrapping_integers_extra
+19/30 Test #20: wrapping_integers_extra ..........   Passed    0.22 sec
+      Start 21: recv_connect
+20/30 Test #21: recv_connect .....................   Passed    0.01 sec
+      Start 22: recv_transmit
+21/30 Test #22: recv_transmit ....................   Passed    0.25 sec
+      Start 23: recv_window
+22/30 Test #23: recv_window ......................   Passed    0.01 sec
+      Start 24: recv_reorder
+23/30 Test #24: recv_reorder .....................   Passed    0.01 sec
+      Start 25: recv_reorder_more
+24/30 Test #25: recv_reorder_more ................   Passed   12.83 sec
+      Start 26: recv_close
+25/30 Test #26: recv_close .......................   Passed    0.01 sec
+      Start 27: recv_special
+26/30 Test #27: recv_special .....................   Passed    0.04 sec
+      Start 37: no_skip
+27/30 Test #37: no_skip ..........................   Passed    0.00 sec
+      Start 38: compile with optimization
+28/30 Test #38: compile with optimization ........   Passed    2.41 sec
+      Start 39: byte_stream_speed_test
+        ByteStream throughput (pop length 4096):  2.29 Gbit/s
+        ByteStream throughput (pop length 128):   0.97 Gbit/s
+        ByteStream throughput (pop length 32):    0.37 Gbit/s
+29/30 Test #39: byte_stream_speed_test ...........   Passed    0.52 sec
+      Start 40: reassembler_speed_test
+        Reassembler throughput (no overlap):   2.22 Gbit/s
+        Reassembler throughput (10x overlap):  0.28 Gbit/s
+30/30 Test #40: reassembler_speed_test ...........   Passed    1.20 sec
+
 Remaining Bugs:
 [None, I hope.]
 

--- a/writeups/check2.md
+++ b/writeups/check2.md
@@ -1,15 +1,15 @@
 Checkpoint 2 Writeup
 ====================
 
-My name: [your name here]
+My name: Raymond Llata
 
-My SUNet ID: [your sunetid here]
+My SUNet ID: rllata
 
 I collaborated with: [list sunetids here]
 
 I would like to thank/reward these classmates for their help: [list sunetids here]
 
-This lab took me about [n] hours to do. I [did/did not] attend the lab session.
+This lab took me about [5] hours to do. I [did not] attend the lab session.
 
 Describe Wrap32 and TCPReceiver structure and design. [Describe data
 structures and approach taken. Describe alternative designs considered
@@ -19,11 +19,29 @@ of bugs, asymptotic performance, empirical performance, required
 implementation time and difficulty, and other factors. Include any
 measurements if applicable.]
 
+Wrap32:
+
+For wrap, I simply implement the formula ISN + zero_point % 2^32. This took one line, and runs in 0(1). I do not think there is a better approach.
+
+I begin by converting the checkpoint uint64_t into a Wrap32, so that I may take advantage of the principle that the offset between checkpoint and actual the actual index is preserved. Then, I calculated the minimum distance from the curr index to checkpoint index and store it in the diff var. Next, I add and subtract diff from the index, to derive two potential locations that our index could be at, and check convert each of those locations to Wrap32's. Next, I compare the new Wrap32's to the initial Wrap to see if they are the same, and return the corresponding element. 
+
+One design I considered and initially went with was calculating the absolute value of the difference. This passed many of the test cases, but would fail when I was subtracting a larger number from a smaller number (ie 0 - 1). Due to the overflow, I would get an inaccurate value that would result in picking the wrong Absolute Index for unwrap. 
+
+In terms of simplicity, I do believe it would be hard to come up with a much simpler approach; My function is quite succinct, and makes sense intuitively once you understand offset is preserved. In terms of complexity, it runs in constant time and uses contant space. I do believe there are some marginal improvements that could be made (ie. create less variables), but nothing that would have a substantial impact on my code. This took me <2 hours, and most of the time was spent understanding the assignment handout.
+
+TCPReceiver:
+
+In terms of time/storage complexity, my TCPReciever also runs in constant time, I do not think there is a substantially better solution for this class then the one I have coded. My overall approach for receive() was to process each part of the message individually, and update the corresponding member variables. One problem I ran into was the behavior when the RST flag has been raised; I thought initially I could just return and not add to the Bytestream, but the test cases seemed like the correct behavior was to raise an error in the bytestream itself, which I ended up doing.
+
+An alternate approach I considered was storing the Window Size in a local variable. I implemented this for a while, before I noticed that the window size was the same as the Reassmebler capacity, just with an upper limit. So, I removed all the logic I had updating my window_ variable, and used the min() standard function to return window_size in send.
+
+I felt like this class was fairly straightforward, and there was not much need for a complex data structure that would heavily influence performance. This took me ~3 hours, much of which was parsing through test cases and stepping through the debugger to figure out what proper behavior was.
+
 Implementation Challenges:
-[]
+[I found some of the edge cases to not be well discussed in the Lab Handout/Lecture so I had to spend alot of time reading through test cases to derive the proper functionality.]
 
 Remaining Bugs:
-[]
+[None, I hope.]
 
 - Optional: I had unexpected difficulty with: [describe]
 

--- a/writeups/check3.md
+++ b/writeups/check3.md
@@ -1,0 +1,38 @@
+Checkpoint 3 Writeup
+====================
+
+My name: [your name here]
+
+My SUNet ID: [your sunetid here]
+
+I collaborated with: [list sunetids here]
+
+I would like to thank/reward these classmates for their help: [list sunetids here]
+
+This checkpoint took me about [n] hours to do. I [did/did not] attend the lab session.
+
+Program Structure and Design of the TCPSender [Describe data
+structures and approach taken. Describe alternative designs considered
+or tested.  Describe benefits and weaknesses of your design compared
+with alternatives -- perhaps in terms of simplicity/complexity, risk
+of bugs, asymptotic performance, empirical performance, required
+implementation time and difficulty, and other factors. Include any
+measurements if applicable.]: []
+
+Report from the hands-on component: []
+
+Implementation Challenges:
+[]
+
+Remaining Bugs:
+[]
+
+- Optional: I had unexpected difficulty with: [describe]
+
+- Optional: I think you could make this lab better by: [describe]
+
+- Optional: I was surprised by: [describe]
+
+- Optional: I'm not sure about: [describe]
+
+- Optional: I made an extra test I think will be helpful in catching bugs: [describe where to find]

--- a/writeups/check3.md
+++ b/writeups/check3.md
@@ -1,9 +1,9 @@
 Checkpoint 3 Writeup
 ====================
 
-My name: [your name here]
+My name: Raymond Llata
 
-My SUNet ID: [your sunetid here]
+My SUNet ID: rllata
 
 I collaborated with: [list sunetids here]
 
@@ -17,7 +17,13 @@ or tested.  Describe benefits and weaknesses of your design compared
 with alternatives -- perhaps in terms of simplicity/complexity, risk
 of bugs, asymptotic performance, empirical performance, required
 implementation time and difficulty, and other factors. Include any
-measurements if applicable.]: []
+measurements if applicable.]: 
+
+I used a standard cpp map class to store outstanding bytes for the TCPSender. The other state variables I used for the assignment were constant space. The main benefit for this data structure was simplicity for my code. Insert/Get/Erase operations all take runtime O(logn), which I deemed fairly efficient. I picked this data structure when laying out the framework for processing messages. I wanted a quick way to loop through outstanding_segments, and remove the smallest elements first. Given that a standard map is implicitly sorted, this worked well for me. However, this was not the fast solution that I considered.
+
+The alternate approach I had in mind was using two data structures; a Queue and a Unordered_Map. A stand alone unordered_map would not work primarily due to my looping through the keys -- when looping in an unordered_map the keys would iterate in a seemingly random order. So, the solution to this that I considered was including a queue of segment keys; This way instead of looping through the unordered_map, I could iterate through the queue, and recieve elements in order that way. This method would have faster average case runtime. Unordered_maps have O(1) average case Insert/Get/Erase. However, they also have worst case O(n) Insert/Get/Erase, which would have been substantially worse then my standard cpp map implementation. Furthermore, maintaining two data structures would have added alot more complexity to my code, especially in the recieve and push functions where I make alot of changes to my global state. Given the simplicity of my initial approach, and the fact that the complex approach did not necessairly provide better results, I decided to implement my TCPSender using a standard map.
+
+My class functions were fairly straightfoward. For Tick() I simply coded the algorithm straight from the Assignment Spec. For Recieve() I added a helper function to update outstanding_segments_, and other global state variables. The logic gates in Recieve() were more or less taken straight from the assignment spec. Push() was my most complicated function. My approach was to create a helper, push_packet(), that when given the proper information, would be able to push every type of packet required. The logic in Push() mainly looks at the input_, and global state variables, and makes a decision as to what kind of packet to push. It will pass this information to push_packet(), which will create a Message and transmit it. I created many intermediate state variables for clarity and a better debugging experience.
 
 Report from the hands-on component: []
 

--- a/writeups/check3.md
+++ b/writeups/check3.md
@@ -9,7 +9,7 @@ I collaborated with: [list sunetids here]
 
 I would like to thank/reward these classmates for their help: [list sunetids here]
 
-This checkpoint took me about [n] hours to do. I [did/did not] attend the lab session.
+This checkpoint took me about [n] hours to do. I [did not] attend the lab session.
 
 Program Structure and Design of the TCPSender [Describe data
 structures and approach taken. Describe alternative designs considered
@@ -25,7 +25,10 @@ The alternate approach I had in mind was using two data structures; a Queue and 
 
 My class functions were fairly straightfoward. For Tick() I simply coded the algorithm straight from the Assignment Spec. For Recieve() I added a helper function to update outstanding_segments_, and other global state variables. The logic gates in Recieve() were more or less taken straight from the assignment spec. Push() was my most complicated function. My approach was to create a helper, push_packet(), that when given the proper information, would be able to push every type of packet required. The logic in Push() mainly looks at the input_, and global state variables, and makes a decision as to what kind of packet to push. It will pass this information to push_packet(), which will create a Message and transmit it. I created many intermediate state variables for clarity and a better debugging experience.
 
-Report from the hands-on component: []
+Report from the hands-on component: [
+
+
+]
 
 Implementation Challenges:
 []

--- a/writeups/check3.md
+++ b/writeups/check3.md
@@ -39,6 +39,8 @@ My ls -l output:
 -rw-rw-r-- 1 cs144 cs144 100000000 Feb 12 02:49 /tmp/big-received.txt
 Their ls -l output:
 -rw-rw-r-- 1 owlyfeather6 owlyfeather6 100000000 Feb 12 02:44 /tmp/biggest.txt
+
+One thing I found interesting was the time sending larger files took. I was under the impression that the time it took to send larger files would increase linearly. (As it seemed to me that link speeds were always constant, data rate was always constant, and queue sizes / paths did not change). However, in practice it seemed that the larger files we tried to send, the longer the time would take. For example, the one Megabyte challenge took around a second, but 10 Megabytes took us around 35 seconds (as opposed to 10 seconds like I thought), and 100 Megabytes took us over five minutes (I did not keep track of exactly how long). My hypothesis for why this is is that as for larger file sizes the queues potentially fill up faster and we end up losing more bytes, but even then, as per the data rate graphs we have seen in class I do not understand why this results in a non-linear time increase.
 ]
 
 Implementation Challenges:

--- a/writeups/check3.md
+++ b/writeups/check3.md
@@ -5,11 +5,11 @@ My name: Raymond Llata
 
 My SUNet ID: rllata
 
-I collaborated with: [list sunetids here]
+I collaborated with: [janlrudo]
 
 I would like to thank/reward these classmates for their help: [list sunetids here]
 
-This checkpoint took me about [n] hours to do. I [did not] attend the lab session.
+This checkpoint took me about [10-13] hours to do. I [did not] attend the lab session.
 
 Program Structure and Design of the TCPSender [Describe data
 structures and approach taken. Describe alternative designs considered
@@ -23,22 +23,33 @@ I used a standard cpp map class to store outstanding bytes for the TCPSender. Th
 
 The alternate approach I had in mind was using two data structures; a Queue and a Unordered_Map. A stand alone unordered_map would not work primarily due to my looping through the keys -- when looping in an unordered_map the keys would iterate in a seemingly random order. So, the solution to this that I considered was including a queue of segment keys; This way instead of looping through the unordered_map, I could iterate through the queue, and recieve elements in order that way. This method would have faster average case runtime. Unordered_maps have O(1) average case Insert/Get/Erase. However, they also have worst case O(n) Insert/Get/Erase, which would have been substantially worse then my standard cpp map implementation. Furthermore, maintaining two data structures would have added alot more complexity to my code, especially in the recieve and push functions where I make alot of changes to my global state. Given the simplicity of my initial approach, and the fact that the complex approach did not necessairly provide better results, I decided to implement my TCPSender using a standard map.
 
+Edit: I have now realized I could have just used a single Queue since I was leveraging the sorted order of a map. This approach would have added quicker runtimes and greater simplicity, and does not have much downside, as far as I can tell.
+
 My class functions were fairly straightfoward. For Tick() I simply coded the algorithm straight from the Assignment Spec. For Recieve() I added a helper function to update outstanding_segments_, and other global state variables. The logic gates in Recieve() were more or less taken straight from the assignment spec. Push() was my most complicated function. My approach was to create a helper, push_packet(), that when given the proper information, would be able to push every type of packet required. The logic in Push() mainly looks at the input_, and global state variables, and makes a decision as to what kind of packet to push. It will pass this information to push_packet(), which will create a Message and transmit it. I created many intermediate state variables for clarity and a better debugging experience.
 
 Report from the hands-on component: [
 
+I was able to send bytes to and forth my lab partner, as well as pass the one-megabyte challenge. Our SHA256 Checksum's matched, and we found similar success vice versa. The largest amount of bytes we had the patience to wait for was 100 Megabytes (or 100000000 Bytes). For this, I was the client, and janlrudo was the server. We did not attempt any higher because of time constraints. I have included the output from ls -l and sha-256 below.
 
+My SHA256 Checksum:
+2cb457f7c3aa3e1e031b0012673de0d6fa78631f1b9d9a86c81d2f74bd8960e4
+Their SHA256 Checksum:
+2cb457f7c3aa3e1e031b0012673de0d6fa78631f1b9d9a86c81d2f74bd8960e4
+My ls -l output:
+-rw-rw-r-- 1 cs144 cs144 100000000 Feb 12 02:49 /tmp/big-received.txt
+Their ls -l output:
+-rw-rw-r-- 1 owlyfeather6 owlyfeather6 100000000 Feb 12 02:44 /tmp/biggest.txt
 ]
 
 Implementation Challenges:
-[]
+[I struggled with understanding the behavior of the TCP Sender. I think that alot of the functionality was supposed to be intuitively understood without being listed on the Assignment Spec, so it was difficult for me to deduce how to implement it. I also struggled with the hands-on component, as I forgot to run commands to link my computer to the webserver / make ipv4 properly.]
 
 Remaining Bugs:
-[]
+[N/A]
 
 - Optional: I had unexpected difficulty with: [describe]
 
-- Optional: I think you could make this lab better by: [describe]
+- Optional: I think you could make this lab better by: [I think it would be good to direct us to possible relevant commands that are preventing us from succesfully running ipv4. (ie. ensure we are running make properly / reminding us to reconnect to the webserver)]
 
 - Optional: I was surprised by: [describe]
 

--- a/writeups/check3.md
+++ b/writeups/check3.md
@@ -42,7 +42,11 @@ Their ls -l output:
 ]
 
 Implementation Challenges:
-[I struggled with understanding the behavior of the TCP Sender. I think that alot of the functionality was supposed to be intuitively understood without being listed on the Assignment Spec, so it was difficult for me to deduce how to implement it. I also struggled with the hands-on component, as I forgot to run commands to link my computer to the webserver / make ipv4 properly.]
+[I struggled with understanding the behavior of the TCP Sender. I think that alot of the functionality was supposed to be intuitively understood without being listed on the Assignment Spec, so it was difficult for me to deduce how to implement it. 
+
+For example, behavior with a RST Flag was not really discussed in the handout. Intuitively, I gleaned that it would be a good idea to communicate a RST Flag from Sender/Reciever ASAP, but it was unclear if it was supposed to be in a packet by itself. Another example was the SYN Flag. In class, we covered that a SYN Flag can be sent by itself or with a larger packet, but on the Assignment Handout it only explicitly mentions how to handle a SYN Flag-only packet, with no payload. This led me to believe the TCP Sender I was implementing was always initializing it's link with a reciever first. And so I proceeded like this through the first few test cases, debugging as I needed, until I found a test case were the Reciever was reaching out first, which my code did not handle. I think, for me, these were the greatest challenges. The Retransmit Timer logic was simple enough, and most of the remaining difficulty for the assignment was figuring out how to implement the functionality I want with as little state-keeping as possible.
+
+I also struggled with the hands-on component, as I forgot to run commands to link my computer to the webserver / make ipv4 properly.]
 
 Remaining Bugs:
 [N/A]

--- a/writeups/check5.md
+++ b/writeups/check5.md
@@ -1,0 +1,35 @@
+Checkpoint 5 Writeup
+====================
+
+My name: [your name here]
+
+My SUNet ID: [your sunetid here]
+
+I collaborated with: [list sunetids here]
+
+I would like to thank/reward these classmates for their help: [list sunetids here]
+
+This checkpoint took me about [n] hours to do. I [did/did not] attend the lab session.
+
+Program Structure and Design of the NetworkInterface [Describe data
+structures and approach taken. Describe alternative designs considered
+or tested.  Describe benefits and weaknesses of your design compared
+with alternatives -- perhaps in terms of simplicity/complexity, risk
+of bugs, asymptotic performance, empirical performance, required
+implementation time and difficulty, and other factors. Include any
+measurements if applicable.]:
+[]
+
+Implementation Challenges:
+[]
+
+Remaining Bugs:
+[]
+
+- Optional: I had unexpected difficulty with: [describe]
+
+- Optional: I think you could make this lab better by: [describe]
+
+- Optional: I was surprised by: [describe]
+
+- Optional: I'm not sure about: [describe]

--- a/writeups/check5.md
+++ b/writeups/check5.md
@@ -9,7 +9,7 @@ I collaborated with: [list sunetids here]
 
 I would like to thank/reward these classmates for their help: [list sunetids here]
 
-This checkpoint took me about [n] hours to do. I [did/did not] attend the lab session.
+This checkpoint took me about [5] hours to do. I [did not] attend the lab session.
 
 Program Structure and Design of the NetworkInterface [Describe data
 structures and approach taken. Describe alternative designs considered
@@ -18,10 +18,14 @@ with alternatives -- perhaps in terms of simplicity/complexity, risk
 of bugs, asymptotic performance, empirical performance, required
 implementation time and difficulty, and other factors. Include any
 measurements if applicable.]:
-[]
+[To implement the Network Interface I used a combination of a Map & a Queue. I had a master queue to store the order of key insertions into my Map. I used the queue to determine whether or not a address-Ethernet pair had expired, and if it had, I would remove it from the dictionary. Otherwise, I used a dictionary to map "IP DST Addresses" to "Ethernet Addresses". I did so using a struct to store releveant information (ie. if this was a pending ARP request, if the ARP had been send, and the messages queued waiting for an ARP Reply). An alternative approach I considered was only using a Map. Doing this, when I wanted to remove old elements I would need to loop through the entire map, and check each key individually. This would imply O(nlogn) work where "n" is the number of entries in the Map. My approach would use O(mlogn) where "m" is the number of entries to be removed and "n" is the number of entries in the map. Since the implementation changes to use two data structures was not that high, I just decided to use a queue as well, to minimize the extra work my code is doing.
+
+One thing I did to increase the simplicity of my code was using a struct. Initially, I had even more data structures since for every key/addr it was either a known IP or a pending ARP message, and there was alot of state to keep track of. THis resulted in multiple Datastructures, which was initially a bit confusing. In order reduce the complexity I bundled all the parallel data values into a struct, and added some additional housekeeping variables like "isArp" to it to make things simpler.]
 
 Implementation Challenges:
-[]
+[I think for me the biggest challenge was keeping track of the state-keeping. I think one conceptual misunderstanding I had that caused alot of this was not updating the knownIP timer when the IP was used again. In alot of other cache systems I have seen, (LRU Cache), the deletion timer is generally restarted whenever a value was used, and I thought the same metric would apply to this system. If an Addresses' Ethernet IP is being requested multiple times, maybe it should not be deleted. I built alot of my implementation around this initially, only to find out this was not the case, would caused some refactoring challenges.
+
+Another instance of challenging statekeeping would be when deciding when to add to my IP Queue. Initially, my intent was to add every time something was transmitted, but this raised errors when an Ethernet IP had been transmitted to many times, then deleted and re-recieved, but some of the trasmits persisted in my queue, thus prompting my code to delete the new ARP entry when it should not be deleted. To solve this I added the "last_ARP_sent" var to my struct, as a final check before deletion to decide if this was really recent enough.]
 
 Remaining Bugs:
 []

--- a/writeups/check5.md
+++ b/writeups/check5.md
@@ -1,9 +1,9 @@
 Checkpoint 5 Writeup
 ====================
 
-My name: [your name here]
+My name: [Raymond Llata]
 
-My SUNet ID: [your sunetid here]
+My SUNet ID: [rllata]
 
 I collaborated with: [list sunetids here]
 

--- a/writeups/check6.md
+++ b/writeups/check6.md
@@ -1,0 +1,34 @@
+Checkpoint 6 Writeup
+====================
+
+My name: [your name here]
+
+My SUNet ID: [your sunetid here]
+
+I collaborated with: [list sunetids here]
+
+I would like to thank/reward these classmates for their help: [list sunetids here]
+
+This checkpoint took me about [n] hours to do. I [did/did not] attend the lab session.
+
+Program Structure and Design of the Router [Describe data
+structures and approach taken. Describe alternative designs considered
+or tested.  Describe benefits and weaknesses of your design compared
+with alternatives -- perhaps in terms of simplicity/complexity, risk
+of bugs, asymptotic performance, empirical performance, required
+implementation time and difficulty, and other factors. Include any
+measurements if applicable.]: []
+
+Implementation Challenges:
+[]
+
+Remaining Bugs:
+[]
+
+- Optional: I had unexpected difficulty with: [describe]
+
+- Optional: I think you could make this lab better by: [describe]
+
+- Optional: I was surprised by: [describe]
+
+- Optional: I'm not sure about: [describe]


### PR DESCRIPTION
If the Network Interface is waiting on an ARP Reply from a given IP, and then they receive a ARP Request (not reply) from said IP, the Network Interface should still send the queued messages, since they now know the IP/Eth Addresses. Right now, this case is not tested. 

The test case is included in the commit: "CUSTOM_TEST", and the code for the correct/incorrect version of the implementation is included in "network_interface.cc" at line 136, and is marked by comments.

Even if the aforementioned behavior is wrong, and the opposite should happen, that is still not tested in the current test suite.