### PR TITLE
Checkpoint 5: Added 2 new test cases for ARP broadcasts

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -22,4 +22,5 @@ endmacro(add_app)
 
 add_app(webget)
 add_app(tcp_native)
+add_app(tcp_ipv4)
 add_app(ip_raw)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -22,3 +22,4 @@ endmacro(add_app)
 
 add_app(webget)
 add_app(tcp_native)
+add_app(ip_raw)

--- a/apps/ip_raw.cc
+++ b/apps/ip_raw.cc
@@ -1,0 +1,16 @@
+#include "socket.hh"
+
+using namespace std;
+
+class RawSocket : public DatagramSocket
+{
+public:
+  RawSocket() : DatagramSocket( AF_INET, SOCK_RAW, IPPROTO_RAW ) {}
+};
+
+int main()
+{
+  // construct an Internet or user datagram here, and send using the RawSocket as in the Jan. 10 lecture
+
+  return 0;
+}

--- a/apps/tcp_ipv4.cc
+++ b/apps/tcp_ipv4.cc
@@ -1,0 +1,178 @@
+#include "bidirectional_stream_copy.hh"
+#include "tcp_config.hh"
+#include "tcp_minnow_socket.hh"
+#include "tun.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <random>
+#include <span>
+#include <string>
+#include <tuple>
+
+using namespace std;
+
+constexpr const char* TUN_DFLT = "tun144";
+constexpr const char* LOCAL_ADDRESS_DFLT = "169.254.144.9";
+
+namespace {
+void show_usage( const char* argv0, const char* msg )
+{
+  cout << "Usage: " << argv0 << " [options] <host> <port>\n\n"
+       << "   Option                                                          Default\n"
+       << "   --                                                              --\n\n"
+
+       << "   -l              Server (listen) mode.                           (client mode)\n"
+       << "                   In server mode, <host>:<port> is the address to bind.\n\n"
+
+       << "   -a <addr>       Set source address (client mode only)           " << LOCAL_ADDRESS_DFLT << "\n"
+       << "   -s <port>       Set source port (client mode only)              (random)\n\n"
+
+       << "   -w <winsz>      Use a window of <winsz> bytes                   " << TCPConfig::MAX_PAYLOAD_SIZE
+       << "\n\n"
+
+       << "   -t <tmout>      Set rt_timeout to tmout                         " << TCPConfig::TIMEOUT_DFLT << "\n\n"
+
+       << "   -d <tundev>     Connect to tun <tundev>                         " << TUN_DFLT << "\n\n"
+
+       << "   -Lu <loss>      Set uplink loss to <rate> (float in 0..1)       (no loss)\n"
+       << "   -Ld <loss>      Set downlink loss to <rate> (float in 0..1)     (no loss)\n\n"
+
+       << "   -h              Show this message.\n\n";
+
+  if ( msg != nullptr ) {
+    cout << msg;
+  }
+  cout << "\n";
+}
+
+void check_argc( const span<char*>& args, size_t curr, const char* err )
+{
+  if ( curr + 3 >= args.size() ) {
+    show_usage( args.front(), err );
+    exit( 1 );
+  }
+}
+
+tuple<TCPConfig, FdAdapterConfig, bool, const char*> get_config( const span<char*>& args )
+{
+  TCPConfig c_fsm {};
+  c_fsm.isn = Wrap32 { random_device()() };
+
+  FdAdapterConfig c_filt {};
+  const char* tundev = nullptr;
+
+  size_t curr = 1;
+  bool listen = false;
+  const size_t argc = args.size();
+
+  string source_address = LOCAL_ADDRESS_DFLT;
+  string source_port = to_string( static_cast<uint16_t>( random_device()() ) );
+
+  while ( argc - curr > 2 ) {
+    if ( strncmp( "-l", args[curr], 3 ) == 0 ) {
+      listen = true;
+      curr += 1;
+
+    } else if ( strncmp( "-a", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -a requires one argument." );
+      source_address = args[curr + 1];
+      curr += 2;
+
+    } else if ( strncmp( "-s", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -s requires one argument." );
+      source_port = args[curr + 1];
+      curr += 2;
+
+    } else if ( strncmp( "-w", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -w requires one argument." );
+      c_fsm.recv_capacity = strtol( args[curr + 1], nullptr, 0 );
+      curr += 2;
+
+    } else if ( strncmp( "-t", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -t requires one argument." );
+      c_fsm.rt_timeout = strtol( args[curr + 1], nullptr, 0 );
+      curr += 2;
+
+    } else if ( strncmp( "-d", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -t requires one argument." );
+      tundev = args[curr + 1];
+      curr += 2;
+
+    } else if ( strncmp( "-Lu", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -Lu requires one argument." );
+      const float lossrate = strtof( args[curr + 1], nullptr );
+      using LossRateUpT = decltype( c_filt.loss_rate_up );
+      c_filt.loss_rate_up
+        = static_cast<LossRateUpT>( static_cast<float>( numeric_limits<LossRateUpT>::max() ) * lossrate );
+      curr += 2;
+
+    } else if ( strncmp( "-Ld", args[curr], 3 ) == 0 ) {
+      check_argc( args, curr, "ERROR: -Lu requires one argument." );
+      const float lossrate = strtof( args[curr + 1], nullptr );
+      using LossRateDnT = decltype( c_filt.loss_rate_dn );
+      c_filt.loss_rate_dn
+        = static_cast<LossRateDnT>( static_cast<float>( numeric_limits<LossRateDnT>::max() ) * lossrate );
+      curr += 2;
+
+    } else if ( strncmp( "-h", args[curr], 3 ) == 0 ) {
+      show_usage( args[0], nullptr );
+      exit( 0 );
+
+    } else {
+      show_usage( args[0], string( "ERROR: unrecognized option " + string( args[curr] ) ).c_str() );
+      exit( 1 );
+    }
+  }
+
+  // parse positional command-line arguments
+  if ( listen ) {
+    c_filt.source = { "0", args[curr + 1] };
+    if ( c_filt.source.port() == 0 ) {
+      show_usage( args[0], "ERROR: listen port cannot be zero in server mode." );
+      exit( 1 );
+    }
+  } else {
+    c_filt.destination = { args[curr], args[curr + 1] };
+    c_filt.source = { source_address, source_port };
+  }
+
+  return make_tuple( c_fsm, c_filt, listen, tundev );
+}
+} // namespace
+
+int main( int argc, char** argv )
+{
+  try {
+    if ( argc <= 0 ) {
+      abort(); // For sticklers: don't try to access argv[0] if argc <= 0.
+    }
+
+    auto args = span( argv, argc );
+
+    if ( argc < 3 ) {
+      show_usage( args.front(), "ERROR: required arguments are missing." );
+      return EXIT_FAILURE;
+    }
+
+    auto [c_fsm, c_filt, listen, tun_dev_name] = get_config( args );
+    LossyTCPOverIPv4MinnowSocket tcp_socket( LossyFdAdapter<TCPOverIPv4OverTunFdAdapter>(
+      TCPOverIPv4OverTunFdAdapter( TunFD( tun_dev_name == nullptr ? TUN_DFLT : tun_dev_name ) ) ) );
+
+    if ( listen ) {
+      tcp_socket.listen_and_accept( c_fsm, c_filt );
+    } else {
+      tcp_socket.connect( c_fsm, c_filt );
+    }
+
+    bidirectional_stream_copy( tcp_socket, tcp_socket.peer_address().to_string() );
+    tcp_socket.wait_until_closed();
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -62,6 +62,8 @@ ttest(no_skip)
 
 add_custom_target (check0 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R 'webget|^byte_stream_|^no_skip')
 
+add_custom_target (check_byte_stream COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^byte_stream_|^no_skip')
+
 add_custom_target (check_webget COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --timeout 15 -R 'webget')
 
 add_custom_target (check1 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^byte_stream_|^reassembler_|^no_skip')
@@ -70,9 +72,9 @@ add_custom_target (check2 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --s
 
 add_custom_target (check3 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^byte_stream_|^reassembler_|^wrapping|^recv|^send|^no_skip')
 
-add_custom_target (check4 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^net_interface|^no_skip')
+add_custom_target (check5 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^net_interface|^no_skip')
 
-add_custom_target (check5 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^net_interface|^router|^no_skip')
+add_custom_target (check6 COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --stop-on-failure --timeout 15 -R '^net_interface|^router|^no_skip')
 
 ###
 

--- a/scripts/lines-of-code
+++ b/scripts/lines-of-code
@@ -8,8 +8,8 @@ import sys
 base = sys.argv[1] if len(sys.argv) > 1 else '.'
 modules = [['byte_stream', 'ByteStream'],
            ['reassembler', 'Reassembler'],
-#           ['tcp_receiver', 'TCPReceiver'],
-#           ['wrapping_integers', 'Wrap32'],
+           ['tcp_receiver', 'TCPReceiver'],
+           ['wrapping_integers', 'Wrap32'],
 #           ['tcp_sender', 'TCPSender'],
 #           ['network_interface', 'NetworkInterface'],
 #           ['router', 'Router']

--- a/scripts/lines-of-code
+++ b/scripts/lines-of-code
@@ -8,11 +8,12 @@ import sys
 base = sys.argv[1] if len(sys.argv) > 1 else '.'
 modules = [['byte_stream', 'ByteStream'],
            ['reassembler', 'Reassembler'],
-           ['tcp_receiver', 'TCPReceiver'],
-           ['wrapping_integers', 'Wrap32'],
-           ['tcp_sender', 'TCPSender'],
-           ['network_interface', 'NetworkInterface'],
-           ['router', 'Router']]
+#           ['tcp_receiver', 'TCPReceiver'],
+#           ['wrapping_integers', 'Wrap32'],
+#           ['tcp_sender', 'TCPSender'],
+#           ['network_interface', 'NetworkInterface'],
+#           ['router', 'Router']
+           ]
 longest_module_length = max([len(x[1]) for x in modules])
 
 

--- a/scripts/lines-of-code
+++ b/scripts/lines-of-code
@@ -10,7 +10,7 @@ modules = [['byte_stream', 'ByteStream'],
            ['reassembler', 'Reassembler'],
            ['tcp_receiver', 'TCPReceiver'],
            ['wrapping_integers', 'Wrap32'],
-#           ['tcp_sender', 'TCPSender'],
+           ['tcp_sender', 'TCPSender'],
 #           ['network_interface', 'NetworkInterface'],
 #           ['router', 'Router']
            ]

--- a/src/network_interface.cc
+++ b/src/network_interface.cc
@@ -1,0 +1,49 @@
+#include <iostream>
+
+#include "arp_message.hh"
+#include "debug.hh"
+#include "ethernet_frame.hh"
+#include "exception.hh"
+#include "helpers.hh"
+#include "network_interface.hh"
+
+using namespace std;
+
+//! \param[in] ethernet_address Ethernet (what ARP calls "hardware") address of the interface
+//! \param[in] ip_address IP (what ARP calls "protocol") address of the interface
+NetworkInterface::NetworkInterface( string_view name,
+                                    shared_ptr<OutputPort> port,
+                                    const EthernetAddress& ethernet_address,
+                                    const Address& ip_address )
+  : name_( name )
+  , port_( notnull( "OutputPort", move( port ) ) )
+  , ethernet_address_( ethernet_address )
+  , ip_address_( ip_address )
+{
+  cerr << "DEBUG: Network interface has Ethernet address " << to_string( ethernet_address_ ) << " and IP address "
+       << ip_address.ip() << "\n";
+}
+
+//! \param[in] dgram the IPv4 datagram to be sent
+//! \param[in] next_hop the IP address of the interface to send it to (typically a router or default gateway, but
+//! may also be another host if directly connected to the same network as the destination) Note: the Address type
+//! can be converted to a uint32_t (raw 32-bit IP address) by using the Address::ipv4_numeric() method.
+void NetworkInterface::send_datagram( const InternetDatagram& dgram, const Address& next_hop )
+{
+  debug( "unimplemented send_datagram called" );
+  (void)dgram;
+  (void)next_hop;
+}
+
+//! \param[in] frame the incoming Ethernet frame
+void NetworkInterface::recv_frame( EthernetFrame frame )
+{
+  debug( "unimplemented recv_frame called" );
+  (void)frame;
+}
+
+//! \param[in] ms_since_last_tick the number of milliseconds since the last call to this method
+void NetworkInterface::tick( const size_t ms_since_last_tick )
+{
+  debug( "unimplemented tick({}) called", ms_since_last_tick );
+}

--- a/src/network_interface.hh
+++ b/src/network_interface.hh
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "address.hh"
+#include "ethernet_frame.hh"
+#include "ipv4_datagram.hh"
+
+#include <memory>
+#include <queue>
+
+// A "network interface" that connects IP (the internet layer, or network layer)
+// with Ethernet (the network access layer, or link layer).
+
+// This module is the lowest layer of a TCP/IP stack
+// (connecting IP with the lower-layer network protocol,
+// e.g. Ethernet). But the same module is also used repeatedly
+// as part of a router: a router generally has many network
+// interfaces, and the router's job is to route Internet datagrams
+// between the different interfaces.
+
+// The network interface translates datagrams (coming from the
+// "customer," e.g. a TCP/IP stack or router) into Ethernet
+// frames. To fill in the Ethernet destination address, it looks up
+// the Ethernet address of the next IP hop of each datagram, making
+// requests with the [Address Resolution Protocol](\ref rfc::rfc826).
+// In the opposite direction, the network interface accepts Ethernet
+// frames, checks if they are intended for it, and if so, processes
+// the the payload depending on its type. If it's an IPv4 datagram,
+// the network interface passes it up the stack. If it's an ARP
+// request or reply, the network interface processes the frame
+// and learns or replies as necessary.
+class NetworkInterface
+{
+public:
+  // An abstraction for the physical output port where the NetworkInterface sends Ethernet frames
+  class OutputPort
+  {
+  public:
+    virtual void transmit( const NetworkInterface& sender, const EthernetFrame& frame ) = 0;
+    virtual ~OutputPort() = default;
+  };
+
+  // Construct a network interface with given Ethernet (network-access-layer) and IP (internet-layer)
+  // addresses
+  NetworkInterface( std::string_view name,
+                    std::shared_ptr<OutputPort> port,
+                    const EthernetAddress& ethernet_address,
+                    const Address& ip_address );
+
+  // Sends an Internet datagram, encapsulated in an Ethernet frame (if it knows the Ethernet destination
+  // address). Will need to use [ARP](\ref rfc::rfc826) to look up the Ethernet destination address for the next
+  // hop. Sending is accomplished by calling `transmit()` (a member variable) on the frame.
+  void send_datagram( const InternetDatagram& dgram, const Address& next_hop );
+
+  // Receives an Ethernet frame and responds appropriately.
+  // If type is IPv4, pushes the datagram to the datagrams_in queue.
+  // If type is ARP request, learn a mapping from the "sender" fields, and send an ARP reply.
+  // If type is ARP reply, learn a mapping from the "sender" fields.
+  void recv_frame( EthernetFrame frame );
+
+  // Called periodically when time elapses
+  void tick( size_t ms_since_last_tick );
+
+  // Accessors
+  const std::string& name() const { return name_; }
+  const OutputPort& output() const { return *port_; }
+  OutputPort& output() { return *port_; }
+  std::queue<InternetDatagram>& datagrams_received() { return datagrams_received_; }
+
+private:
+  // Human-readable name of the interface
+  std::string name_;
+
+  // The physical output port (+ a helper function `transmit` that uses it to send an Ethernet frame)
+  std::shared_ptr<OutputPort> port_;
+  void transmit( const EthernetFrame& frame ) const { port_->transmit( *this, frame ); }
+
+  // Ethernet (known as hardware, network-access-layer, or link-layer) address of the interface
+  EthernetAddress ethernet_address_;
+
+  // IP (known as internet-layer or network-layer) address of the interface
+  Address ip_address_;
+
+  // Datagrams that have been received
+  std::queue<InternetDatagram> datagrams_received_ {};
+};

--- a/src/reassembler.cc
+++ b/src/reassembler.cc
@@ -1,0 +1,17 @@
+#include "reassembler.hh"
+#include "debug.hh"
+
+using namespace std;
+
+void Reassembler::insert( uint64_t first_index, string data, bool is_last_substring )
+{
+  debug( "unimplemented insert({}, {}, {}) called", first_index, data, is_last_substring );
+}
+
+// How many bytes are stored in the Reassembler itself?
+// This function is for testing only; don't add extra state to support it.
+uint64_t Reassembler::count_bytes_pending() const
+{
+  debug( "unimplemented count_bytes_pending() called" );
+  return {};
+}

--- a/src/reassembler.hh
+++ b/src/reassembler.hh
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "byte_stream.hh"
+
+class Reassembler
+{
+public:
+  // Construct Reassembler to write into given ByteStream.
+  explicit Reassembler( ByteStream&& output ) : output_( std::move( output ) ) {}
+
+  /*
+   * Insert a new substring to be reassembled into a ByteStream.
+   *   `first_index`: the index of the first byte of the substring
+   *   `data`: the substring itself
+   *   `is_last_substring`: this substring represents the end of the stream
+   *   `output`: a mutable reference to the Writer
+   *
+   * The Reassembler's job is to reassemble the indexed substrings (possibly out-of-order
+   * and possibly overlapping) back into the original ByteStream. As soon as the Reassembler
+   * learns the next byte in the stream, it should write it to the output.
+   *
+   * If the Reassembler learns about bytes that fit within the stream's available capacity
+   * but can't yet be written (because earlier bytes remain unknown), it should store them
+   * internally until the gaps are filled in.
+   *
+   * The Reassembler should discard any bytes that lie beyond the stream's available capacity
+   * (i.e., bytes that couldn't be written even if earlier gaps get filled in).
+   *
+   * The Reassembler should close the stream after writing the last byte.
+   */
+  void insert( uint64_t first_index, std::string data, bool is_last_substring );
+
+  // How many bytes are stored in the Reassembler itself?
+  // This function is for testing only; don't add extra state to support it.
+  uint64_t count_bytes_pending() const;
+
+  // Access output stream reader
+  Reader& reader() { return output_.reader(); }
+  const Reader& reader() const { return output_.reader(); }
+
+  // Access output stream writer, but const-only (can't write from outside)
+  const Writer& writer() const { return output_.writer(); }
+
+private:
+  ByteStream output_;
+};

--- a/src/tcp_minnow_socket.cc
+++ b/src/tcp_minnow_socket.cc
@@ -1,0 +1,5 @@
+#include "tcp_minnow_socket_impl.hh"
+
+//! Specializations of TCPMinnowSocket for TCPOverIPv4OverTunFdAdapter and its lossy version
+template class TCPMinnowSocket<TCPOverIPv4OverTunFdAdapter>;
+template class TCPMinnowSocket<LossyFdAdapter<TCPOverIPv4OverTunFdAdapter>>;

--- a/src/tcp_receiver.cc
+++ b/src/tcp_receiver.cc
@@ -1,0 +1,18 @@
+#include "tcp_receiver.hh"
+#include "debug.hh"
+
+using namespace std;
+
+void TCPReceiver::receive( TCPSenderMessage message )
+{
+  // Your code here.
+  debug( "unimplemented receive() called" );
+  (void)message;
+}
+
+TCPReceiverMessage TCPReceiver::send() const
+{
+  // Your code here.
+  debug( "unimplemented send() called" );
+  return {};
+}

--- a/src/tcp_receiver.hh
+++ b/src/tcp_receiver.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "reassembler.hh"
+#include "tcp_receiver_message.hh"
+#include "tcp_sender_message.hh"
+
+class TCPReceiver
+{
+public:
+  // Construct with given Reassembler
+  explicit TCPReceiver( Reassembler&& reassembler ) : reassembler_( std::move( reassembler ) ) {}
+
+  /*
+   * The TCPReceiver receives TCPSenderMessages, inserting their payload into the Reassembler
+   * at the correct stream index.
+   */
+  void receive( TCPSenderMessage message );
+
+  // The TCPReceiver sends TCPReceiverMessages to the peer's TCPSender.
+  TCPReceiverMessage send() const;
+
+  // Access the output
+  const Reassembler& reassembler() const { return reassembler_; }
+  Reader& reader() { return reassembler_.reader(); }
+  const Reader& reader() const { return reassembler_.reader(); }
+  const Writer& writer() const { return reassembler_.writer(); }
+
+private:
+  Reassembler reassembler_;
+};

--- a/src/tcp_sender.cc
+++ b/src/tcp_sender.cc
@@ -1,0 +1,43 @@
+#include "tcp_sender.hh"
+#include "debug.hh"
+#include "tcp_config.hh"
+
+using namespace std;
+
+// This function is for testing only; don't add extra state to support it.
+uint64_t TCPSender::sequence_numbers_in_flight() const
+{
+  debug( "unimplemented sequence_numbers_in_flight() called" );
+  return {};
+}
+
+// This function is for testing only; don't add extra state to support it.
+uint64_t TCPSender::consecutive_retransmissions() const
+{
+  debug( "unimplemented consecutive_retransmissions() called" );
+  return {};
+}
+
+void TCPSender::push( const TransmitFunction& transmit )
+{
+  debug( "unimplemented push() called" );
+  (void)transmit;
+}
+
+TCPSenderMessage TCPSender::make_empty_message() const
+{
+  debug( "unimplemented make_empty_message() called" );
+  return {};
+}
+
+void TCPSender::receive( const TCPReceiverMessage& msg )
+{
+  debug( "unimplemented receive() called" );
+  (void)msg;
+}
+
+void TCPSender::tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit )
+{
+  debug( "unimplemented tick({}, ...) called", ms_since_last_tick );
+  (void)transmit;
+}

--- a/src/tcp_sender.hh
+++ b/src/tcp_sender.hh
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "byte_stream.hh"
+#include "tcp_receiver_message.hh"
+#include "tcp_sender_message.hh"
+
+#include <functional>
+
+class TCPSender
+{
+public:
+  /* Construct TCP sender with given default Retransmission Timeout and possible ISN */
+  TCPSender( ByteStream&& input, Wrap32 isn, uint64_t initial_RTO_ms )
+    : input_( std::move( input ) ), isn_( isn ), initial_RTO_ms_( initial_RTO_ms )
+  {}
+
+  /* Generate an empty TCPSenderMessage */
+  TCPSenderMessage make_empty_message() const;
+
+  /* Receive and process a TCPReceiverMessage from the peer's receiver */
+  void receive( const TCPReceiverMessage& msg );
+
+  /* Type of the `transmit` function that the push and tick methods can use to send messages */
+  using TransmitFunction = std::function<void( const TCPSenderMessage& )>;
+
+  /* Push bytes from the outbound stream */
+  void push( const TransmitFunction& transmit );
+
+  /* Time has passed by the given # of milliseconds since the last time the tick() method was called */
+  void tick( uint64_t ms_since_last_tick, const TransmitFunction& transmit );
+
+  // Accessors
+  uint64_t sequence_numbers_in_flight() const;  // For testing: how many sequence numbers are outstanding?
+  uint64_t consecutive_retransmissions() const; // For testing: how many consecutive retransmissions have happened?
+  const Writer& writer() const { return input_.writer(); }
+  const Reader& reader() const { return input_.reader(); }
+  Writer& writer() { return input_.writer(); }
+
+private:
+  Reader& reader() { return input_.reader(); }
+
+  ByteStream input_;
+  Wrap32 isn_;
+  uint64_t initial_RTO_ms_;
+};

--- a/src/wrapping_integers.cc
+++ b/src/wrapping_integers.cc
@@ -1,0 +1,18 @@
+#include "wrapping_integers.hh"
+#include "debug.hh"
+
+using namespace std;
+
+Wrap32 Wrap32::wrap( uint64_t n, Wrap32 zero_point )
+{
+  // Your code here.
+  debug( "unimplemented wrap( {}, {} ) called", n, zero_point.raw_value_ );
+  return Wrap32 { 0 };
+}
+
+uint64_t Wrap32::unwrap( Wrap32 zero_point, uint64_t checkpoint ) const
+{
+  // Your code here.
+  debug( "unimplemented unwrap( {}, {} ) called", zero_point.raw_value_, checkpoint );
+  return {};
+}

--- a/src/wrapping_integers.hh
+++ b/src/wrapping_integers.hh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+
+/*
+ * The Wrap32 type represents a 32-bit unsigned integer that:
+ *    - starts at an arbitrary "zero point" (initial value), and
+ *    - wraps back to zero when it reaches 2^32 - 1.
+ */
+
+class Wrap32
+{
+public:
+  explicit Wrap32( uint32_t raw_value ) : raw_value_( raw_value ) {}
+
+  /* Construct a Wrap32 given an absolute sequence number n and the zero point. */
+  static Wrap32 wrap( uint64_t n, Wrap32 zero_point );
+
+  /*
+   * The unwrap method returns an absolute sequence number that wraps to this Wrap32, given the zero point
+   * and a "checkpoint": another absolute sequence number near the desired answer.
+   *
+   * There are many possible absolute sequence numbers that all wrap to the same Wrap32.
+   * The unwrap method should return the one that is closest to the checkpoint.
+   */
+  uint64_t unwrap( Wrap32 zero_point, uint64_t checkpoint ) const;
+
+  Wrap32 operator+( uint32_t n ) const { return Wrap32 { raw_value_ + n }; }
+  bool operator==( const Wrap32& other ) const { return raw_value_ == other.raw_value_; }
+
+protected:
+  uint32_t raw_value_ {};
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,14 @@ add_test_exec(recv_reorder_more)
 add_test_exec(recv_close)
 add_test_exec(recv_special)
 
+add_test_exec(send_connect)
+add_test_exec(send_transmit)
+add_test_exec(send_window)
+add_test_exec(send_ack)
+add_test_exec(send_close)
+add_test_exec(send_retx)
+add_test_exec(send_extra)
+
 add_test_exec(no_skip)
 
 add_speed_test(byte_stream_speed_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,20 @@ add_test_exec(reassembler_holes)
 add_test_exec(reassembler_overlapping)
 add_test_exec(reassembler_win)
 
+add_test_exec(wrapping_integers_cmp)
+add_test_exec(wrapping_integers_wrap)
+add_test_exec(wrapping_integers_unwrap)
+add_test_exec(wrapping_integers_roundtrip)
+add_test_exec(wrapping_integers_extra)
+
+add_test_exec(recv_connect)
+add_test_exec(recv_transmit)
+add_test_exec(recv_window)
+add_test_exec(recv_reorder)
+add_test_exec(recv_reorder_more)
+add_test_exec(recv_close)
+add_test_exec(recv_special)
+
 add_test_exec(no_skip)
 
 add_speed_test(byte_stream_speed_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,15 @@ add_test_exec(byte_stream_two_writes)
 add_test_exec(byte_stream_many_writes)
 add_test_exec(byte_stream_stress_test)
 
+add_test_exec(reassembler_single)
+add_test_exec(reassembler_cap)
+add_test_exec(reassembler_seq)
+add_test_exec(reassembler_dup)
+add_test_exec(reassembler_holes)
+add_test_exec(reassembler_overlapping)
+add_test_exec(reassembler_win)
+
 add_test_exec(no_skip)
 
 add_speed_test(byte_stream_speed_test)
+add_speed_test(reassembler_speed_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,8 @@ add_test_exec(send_close)
 add_test_exec(send_retx)
 add_test_exec(send_extra)
 
+add_test_exec(net_interface)
+
 add_test_exec(no_skip)
 
 add_speed_test(byte_stream_speed_test)

--- a/tests/byte_stream_speed_test.cc
+++ b/tests/byte_stream_speed_test.cc
@@ -77,7 +77,7 @@ double speed_test( fstream& debug_output,
        << " reached " << fixed << setprecision( 2 ) << gigabits_per_second << " Gbit/s.\n";
 
   auto read_s = to_string( read_size );
-  string fill( 5 - read_s.size(), ' ' );
+  const string fill( 5 - read_s.size(), ' ' );
   debug_output << "        ByteStream throughput (pop length " << read_s << "):" << fill << fixed
                << setprecision( 2 ) << setw( 5 ) << gigabits_per_second << " Gbit/s\n";
 

--- a/tests/common.hh
+++ b/tests/common.hh
@@ -3,6 +3,7 @@
 #include "conversions.hh"
 #include "debug.hh"
 #include "exception.hh"
+#include "tcp_sender_message.hh"
 
 #include <iostream>
 #include <optional>
@@ -18,7 +19,7 @@ public:
   explicit ExpectationViolation( const std::string& msg ) : std::runtime_error( msg ) {}
 
   template<typename T>
-  inline ExpectationViolation( const std::string& property_name, const T& expected, const T& actual )
+  ExpectationViolation( const std::string& property_name, const T& expected, const T& actual )
     : ExpectationViolation { "should have had " + property_name + " = " + to_string( expected )
                              + ", but instead it was " + to_string( actual ) }
   {}
@@ -74,11 +75,21 @@ class Timeout
   public:
     Timer();
     ~Timer();
+
+    Timer( const Timer& other ) = delete;
+    Timer( Timer&& other ) = delete;
+    Timer& operator=( const Timer& other ) = delete;
+    Timer& operator=( Timer&& other ) = delete;
   };
 
 public:
   Timeout();
   ~Timeout();
+
+  Timeout( const Timeout& other ) = delete;
+  Timeout( Timeout&& other ) = delete;
+  Timeout& operator=( const Timeout& other ) = delete;
+  Timeout& operator=( Timeout&& other ) = delete;
 
   Timer make_timer();
 };
@@ -123,6 +134,9 @@ class TestHarness
 
   void finish_step( const std::string& str, int color )
   {
+    if ( not steps_executed_ ) {
+      throw std::runtime_error( "TestHarness in invalid state" );
+    }
     steps_executed_.value().emplace_back( str, color, std::move( debug_output_ ) );
     debug_output_.clear();
   }
@@ -235,3 +249,5 @@ struct ExpectBool : public ExpectNumber<T, bool>
 {
   using ExpectNumber<T, bool>::ExpectNumber;
 };
+
+std::string to_string( const TCPSenderMessage& msg );

--- a/tests/conversions.hh
+++ b/tests/conversions.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "helpers.hh"
+#include "wrapping_integers.hh"
 
 #include <optional>
 #include <string>
@@ -10,6 +11,17 @@
 
 namespace minnow_conversions {
 using std::to_string;
+
+class DebugWrap32 : public Wrap32
+{
+public:
+  uint32_t debug_get_raw_value() const { return raw_value_; }
+};
+
+inline std::string to_string( Wrap32 i )
+{
+  return "Wrap32<" + std::to_string( DebugWrap32 { i }.debug_get_raw_value() ) + ">";
+}
 
 template<typename T>
 std::string to_string( const std::optional<T>& v )
@@ -39,4 +51,14 @@ template<MinnowStringable T>
 std::string to_string( T&& t )
 {
   return minnow_conversions::to_string( std::forward<T>( t ) );
+}
+
+inline std::ostream& operator<<( std::ostream& os, Wrap32 a )
+{
+  return os << to_string( a );
+}
+
+inline bool operator!=( Wrap32 a, Wrap32 b )
+{
+  return not( a == b );
 }

--- a/tests/net_interface.cc
+++ b/tests/net_interface.cc
@@ -1,0 +1,625 @@
+#include "arp_message.hh"
+#include "ethernet_header.hh"
+#include "ipv4_datagram.hh"
+#include "network_interface_test_harness.hh"
+
+#include <cstdlib>
+#include <iostream>
+#include <random>
+
+using namespace std;
+
+EthernetAddress random_private_ethernet_address()
+{
+  EthernetAddress addr;
+  for ( auto& byte : addr ) {
+    byte = random_device()(); // use a random local Ethernet address
+  }
+  addr.at( 0 ) |= 0x02; // "10" in last two binary digits marks a private Ethernet address
+  addr.at( 0 ) &= 0xfe;
+
+  return addr;
+}
+
+InternetDatagram make_datagram( const string& src_ip, const string& dst_ip ) // NOLINT(*-swappable-*)
+{
+  InternetDatagram dgram;
+  dgram.header.src = Address( src_ip, 0 ).ipv4_numeric();
+  dgram.header.dst = Address( dst_ip, 0 ).ipv4_numeric();
+  dgram.payload.emplace_back( "hello" );
+  dgram.header.len = static_cast<uint64_t>( dgram.header.hlen ) * 4 + dgram.payload.front()->size();
+  dgram.header.compute_checksum();
+  return dgram;
+}
+
+ARPMessage make_arp( const uint16_t opcode,
+                     const EthernetAddress sender_ethernet_address,
+                     const string& sender_ip_address,
+                     const EthernetAddress target_ethernet_address,
+                     const string& target_ip_address )
+{
+  ARPMessage arp;
+  arp.opcode = opcode;
+  arp.sender_ethernet_address = sender_ethernet_address;
+  arp.sender_ip_address = Address( sender_ip_address, 0 ).ipv4_numeric();
+  arp.target_ethernet_address = target_ethernet_address;
+  arp.target_ip_address = Address( target_ip_address, 0 ).ipv4_numeric();
+  return arp;
+}
+
+EthernetFrame make_frame( const EthernetAddress& src,
+                          const EthernetAddress& dst,
+                          const uint16_t type,
+                          vector<Ref<string>> payload )
+{
+  EthernetFrame frame;
+  frame.header.src = src;
+  frame.header.dst = dst;
+  frame.header.type = type;
+  frame.payload = move( payload );
+  return frame;
+}
+
+int main()
+{
+  try {
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "typical ARP workflow", local_eth, Address( "4.3.2.1", 0 ) };
+
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+
+      // outgoing datagram should result in an ARP request
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      const EthernetAddress target_eth = random_private_ethernet_address();
+
+      test.execute( Tick { 800 } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP reply should result in the queued datagram getting sent
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // any IP reply directed for our Ethernet address should be passed up the stack
+      const auto reply_datagram = make_datagram( "13.12.11.10", "5.6.7.8" );
+      test.execute(
+        ReceiveFrame( make_frame( target_eth, local_eth, EthernetHeader::TYPE_IPv4, serialize( reply_datagram ) ),
+                      reply_datagram ) );
+      test.execute( ExpectNoFrame {} );
+
+      // incoming frames to another Ethernet address (not ours) should be ignored
+      const EthernetAddress another_eth = { 1, 1, 1, 1, 1, 1 };
+      test.execute( ReceiveFrame(
+        make_frame( target_eth, another_eth, EthernetHeader::TYPE_IPv4, serialize( reply_datagram ) ) ) );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress remote_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "reply to ARP request", local_eth, Address( "5.5.5.5", 0 ) };
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "10.0.1.1", {}, "7.7.7.7" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "10.0.1.1", {}, "5.5.5.5" ) ) ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        remote_eth,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, local_eth, "5.5.5.5", remote_eth, "10.0.1.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress remote_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "learn from ARP request", local_eth, Address( "5.5.5.5", 0 ) };
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "10.0.1.1", {}, "5.5.5.5" ) ) ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        remote_eth,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, local_eth, "5.5.5.5", remote_eth, "10.0.1.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "10.0.1.1", 0 ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "pending mappings last five seconds", local_eth, Address( "1.2.3.4", 0 ) };
+
+      test.execute( SendDatagram { make_datagram( "5.6.7.8", "13.12.11.10" ), Address( "10.0.0.1", 0 ) } );
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    ETHERNET_BROADCAST,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "1.2.3.4", {}, "10.0.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      test.execute( Tick { 4990 } );
+      test.execute( SendDatagram { make_datagram( "17.17.17.17", "18.18.18.18" ), Address( "10.0.0.1", 0 ) } );
+      test.execute( ExpectNoFrame {} );
+      test.execute( Tick { 20 } );
+      // pending mapping should now expire
+      test.execute( SendDatagram { make_datagram( "42.41.40.39", "13.12.11.10" ), Address( "10.0.0.1", 0 ) } );
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    ETHERNET_BROADCAST,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "1.2.3.4", {}, "10.0.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test { "active mappings last 30 seconds", local_eth, Address( "4.3.2.1", 0 ) };
+
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      const auto datagram2 = make_datagram( "5.6.7.8", "13.12.11.11" );
+      const auto datagram3 = make_datagram( "5.6.7.8", "13.12.11.12" );
+      const auto datagram4 = make_datagram( "5.6.7.8", "13.12.11.13" );
+      const auto datagram5 = make_datagram( "5.6.7.8", "13.12.11.14" );
+
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      const EthernetAddress target_eth = random_private_ethernet_address();
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // try after 10 seconds -- no ARP should be generated
+      test.execute( Tick { 10000 } );
+      test.execute( SendDatagram { datagram2, Address( "192.168.0.1", 0 ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram2 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // another 10 seconds -- no ARP should be generated
+      test.execute( Tick { 10000 } );
+      test.execute( SendDatagram { datagram3, Address( "192.168.0.1", 0 ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram3 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // after another 11 seconds, need to ARP again
+      test.execute( Tick { 11000 } );
+      test.execute( SendDatagram { datagram4, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // should not generate ARP message because original request still pending
+      // test credit: Matt Reed
+      test.execute( Tick { 4900 } );
+      test.execute( SendDatagram { datagram5, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP reply again
+      const EthernetAddress new_target_eth = random_private_ethernet_address();
+      test.execute( ReceiveFrame {
+        make_frame( new_target_eth,
+                    local_eth,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp(
+                      ARPMessage::OPCODE_REPLY, new_target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+      test.execute( ExpectFrame {
+        make_frame( local_eth, new_target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram4 ) ) } );
+      test.execute( ExpectFrame {
+        make_frame( local_eth, new_target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram5 ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress remote_eth1 = random_private_ethernet_address();
+      const EthernetAddress remote_eth2 = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "different ARP mappings are independent", local_eth, Address( "10.0.0.1", 0 ) };
+
+      // first ARP mapping
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth1,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth1, "10.0.0.5", {}, "10.0.0.1" ) ) ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        remote_eth1,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, local_eth, "10.0.0.1", remote_eth1, "10.0.0.5" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      test.execute( Tick { 15000 } );
+
+      // second ARP mapping
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth2,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth2, "10.0.0.19", {}, "10.0.0.1" ) ) ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        remote_eth2,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, local_eth, "10.0.0.1", remote_eth2, "10.0.0.19" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      test.execute( Tick { 10000 } );
+
+      // outgoing datagram to first destination
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "10.0.0.5", 0 ) } );
+
+      // outgoing datagram to second destination
+      const auto datagram2 = make_datagram( "100.99.98.97", "4.10.4.10" );
+      test.execute( SendDatagram { datagram2, Address( "10.0.0.19", 0 ) } );
+
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth1, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth2, EthernetHeader::TYPE_IPv4, serialize( datagram2 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      test.execute( Tick { 5010 } );
+
+      // outgoing datagram to second destination (mapping still alive)
+      const auto datagram3 = make_datagram( "150.140.130.120", "144.144.144.144" );
+      test.execute( SendDatagram { datagram3, Address( "10.0.0.19", 0 ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth2, EthernetHeader::TYPE_IPv4, serialize( datagram3 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // outgoing datagram to second destination (mapping has expired)
+      const auto datagram4 = make_datagram( "244.244.244.244", "3.3.3.3" );
+      test.execute( SendDatagram { datagram4, Address( "10.0.0.5", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "10.0.0.1", {}, "10.0.0.5" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // test credit: Matthew Harvill
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress target_eth1 = random_private_ethernet_address();
+      const EthernetAddress target_eth2 = random_private_ethernet_address();
+
+      NetworkInterfaceTestHarness test {
+        "pending datagrams sent to correct dst when ARP replies received out-of-order",
+        local_eth,
+        Address( "4.3.2.1", 0 ) };
+
+      const auto datagram1 = make_datagram( "5.6.7.8", "13.12.11.10" );
+      const auto datagram2 = make_datagram( "5.6.7.8", "13.12.11.11" );
+
+      // Try to send datagram1, but we don't know target_eth1 yet, so send ARP request to get it
+      test.execute( SendDatagram { datagram1, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+
+      // Try to send datagram2, but we don't know target_eth2 yet, so send ARP request to get it
+      test.execute( SendDatagram { datagram2, Address( "192.168.0.2", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.2" ) ) ) } );
+
+      // Receive ARP reply from target_eth2 first; make sure to send datagram2, not datagram1
+      test.execute( ReceiveFrame { make_frame(
+        target_eth2,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth2, "192.168.0.2", local_eth, "4.3.2.1" ) ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth2, EthernetHeader::TYPE_IPv4, serialize( datagram2 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // Receive ARP reply from target_eth1 next, make sure we send datagram1
+      test.execute( ReceiveFrame { make_frame(
+        target_eth1,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth1, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth1, EthernetHeader::TYPE_IPv4, serialize( datagram1 ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // test credit: Matthew Harvill
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress target_eth = random_private_ethernet_address();
+
+      NetworkInterfaceTestHarness test {
+        "multiple pending datagrams sent when ARP reply received", local_eth, Address( "4.3.2.1", 0 ) };
+
+      const auto datagram1 = make_datagram( "5.6.7.8", "13.12.11.10" );
+      const auto datagram2 = make_datagram( "5.6.7.8", "13.12.11.11" );
+      const auto datagram3 = make_datagram( "5.6.7.8", "13.12.11.12" );
+
+      // Try to send all datagrams, but we don't know target_eth yet, so should send ARP request to get it
+      test.execute( SendDatagram { datagram1, Address( "192.168.0.1", 0 ) } );
+      test.execute( SendDatagram { datagram2, Address( "192.168.0.1", 0 ) } );
+      test.execute( SendDatagram { datagram3, Address( "192.168.0.1", 0 ) } );
+
+      // Should have sent an ARP request to get target_eth
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // Receive ARP reply from target_eth next, and make sure we respond by sending all datagrams
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram1 ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram2 ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram3 ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // test credit: Tanmay Garg
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      const EthernetAddress remote_eth = random_private_ethernet_address();
+      const auto datagram1 = make_datagram( "5.6.7.8", "13.12.11.10" );
+      const auto datagram2 = make_datagram( "5.6.7.8", "13.12.11.11" );
+
+      NetworkInterfaceTestHarness test {
+        "update timestamp for ARP mapping if in map already", local_eth, Address( "100.5.100.5", 0 ) };
+
+      // receive ARP request
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "144.144.144.144", {}, "100.5.100.5" ) ) ) } );
+
+      // send ARP reply which does not reach destination
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    remote_eth,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp(
+                      ARPMessage::OPCODE_REPLY, local_eth, "100.5.100.5", remote_eth, "144.144.144.144" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // just more than 5 seconds pass
+      test.execute( Tick { 5001 } );
+
+      // receive same ARP request and update mapping timestamp
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "144.144.144.144", {}, "100.5.100.5" ) ) ) } );
+
+      // send same arp reply again
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    remote_eth,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp(
+                      ARPMessage::OPCODE_REPLY, local_eth, "100.5.100.5", remote_eth, "144.144.144.144" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // 25 seconds pass
+      test.execute( Tick { 25000 } );
+
+      // expect mapping to not be expired (25 sec since updated timestamp)
+      test.execute( SendDatagram { datagram1, Address( "144.144.144.144", 0 ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth, EthernetHeader::TYPE_IPv4, serialize( datagram1 ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // just more than 5 seconds pass
+      test.execute( Tick { 5001 } );
+
+      // expect mapping to be expired now (30.001 sec since updated timestamp)
+      test.execute( SendDatagram { datagram2, Address( "144.144.144.144", 0 ) } );
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "100.5.100.5", {}, "144.144.144.144" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // test credit: Josselin Somerville Roberts
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "Two datagrams sent before ARP response", local_eth, Address( "4.3.2.1", 0 ) };
+
+      // Send first datagram
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+
+      // outgoing datagram should result in an ARP request
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      const EthernetAddress target_eth = random_private_ethernet_address();
+
+      // Resend a second time a datagram
+      // This should not result in an ARP request
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP reply should result in the queued datagram getting sent
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+
+      // Should receive the two queued datagrams
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // test credit: Josselin Somerville Roberts
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "Pending datagrams dropped when pending request expires", local_eth, Address( "4.3.2.1", 0 ) };
+
+      // Send first datagram
+      const auto datagram = make_datagram( "5.6.7.8", "13.12.11.10" );
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+
+      // outgoing datagram should result in an ARP request
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+      const EthernetAddress target_eth = random_private_ethernet_address();
+
+      // Send another datagram after some delay
+      test.execute( Tick { 5100 } );
+      test.execute( SendDatagram { datagram, Address( "192.168.0.1", 0 ) } );
+
+      // outgoing datagram should result in a new ARP request
+      test.execute( ExpectFrame { make_frame(
+        local_eth,
+        ETHERNET_BROADCAST,
+        EthernetHeader::TYPE_ARP,
+        serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "4.3.2.1", {}, "192.168.0.1" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // ARP reply should result in the queued datagram getting sent
+      test.execute( ReceiveFrame { make_frame(
+        target_eth,
+        local_eth,
+        EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+        serialize( make_arp( ARPMessage::OPCODE_REPLY, target_eth, "192.168.0.1", local_eth, "4.3.2.1" ) ) ) } );
+
+      // We should receive only the second queued datagram
+      test.execute(
+        ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram ) ) } );
+      test.execute( ExpectNoFrame {} );
+    }
+
+    // Test credit: Shiva Khanna Yamamoto
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "ARP replies trigger correct Ethernet frame", local_eth, Address( "5.5.5.5", 0 ) };
+
+      int dst_suffix = 1;
+      int dst_suffix_2 = 1;
+      int dst_suffix_3 = 1;
+
+      for ( int i = 0; i < 50; i++ ) {
+        // call send_datagram expecting two ARP requests
+        const auto datagram_1 = make_datagram( "5.6.7.8", "14.12.11." + to_string( dst_suffix_2 ) );
+        const auto datagram_2 = make_datagram( "5.6.7.8", "14.12.11." + to_string( dst_suffix_2 + 1 ) );
+        test.execute( SendDatagram { datagram_1, Address( "192.168.0." + to_string( dst_suffix_3 ), 0 ) } );
+        test.execute( SendDatagram { datagram_2, Address( "192.168.0." + to_string( dst_suffix_3 + 1 ), 0 ) } );
+        test.execute(
+          ExpectFrame { make_frame( local_eth,
+                                    ETHERNET_BROADCAST,
+                                    EthernetHeader::TYPE_ARP,
+                                    serialize( make_arp( ARPMessage::OPCODE_REQUEST,
+                                                         local_eth,
+                                                         "5.5.5.5",
+                                                         {},
+                                                         "192.168.0." + to_string( dst_suffix_3 ) ) ) ) } );
+        test.execute(
+          ExpectFrame { make_frame( local_eth,
+                                    ETHERNET_BROADCAST,
+                                    EthernetHeader::TYPE_ARP,
+                                    serialize( make_arp( ARPMessage::OPCODE_REQUEST,
+                                                         local_eth,
+                                                         "5.5.5.5",
+                                                         {},
+                                                         "192.168.0." + to_string( dst_suffix_3 + 1 ) ) ) ) } );
+
+        // call recv_frame once, expecting only one ARP Reply followed by transmission of the correct Ethernet Frame
+        const EthernetAddress target_eth = random_private_ethernet_address();
+        test.execute( ReceiveFrame { make_frame( target_eth,
+                                                 local_eth,
+                                                 EthernetHeader::TYPE_ARP, // NOLINTNEXTLINE(*-suspicious-*)
+                                                 serialize( make_arp( ARPMessage::OPCODE_REPLY,
+                                                                      target_eth,
+                                                                      "192.168.0." + to_string( dst_suffix_3 + 1 ),
+                                                                      local_eth,
+                                                                      "5.5.5.5" ) ) ) } );
+        test.execute(
+          ExpectFrame { make_frame( local_eth, target_eth, EthernetHeader::TYPE_IPv4, serialize( datagram_2 ) ) } );
+        test.execute( ExpectNoFrame {} );
+
+        // change destination addrs
+        dst_suffix = dst_suffix + 2;
+        dst_suffix_2 = dst_suffix_2 + 2;
+        dst_suffix_3 = dst_suffix_3 + 2;
+      }
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/net_interface.cc
+++ b/tests/net_interface.cc
@@ -616,6 +616,45 @@ int main()
         dst_suffix_3 = dst_suffix_3 + 2;
       }
     }
+
+    {
+      const EthernetAddress local_eth = random_private_ethernet_address();
+      NetworkInterfaceTestHarness test {
+        "Learn from broadcast ARP request not for our IP", local_eth, Address( "5.5.5.5", 0 ) };
+
+      // Send a datagram to an unmapped address.
+      const auto queued_dgram = make_datagram( "5.5.5.5", "111.222.33.44" );
+      test.execute( SendDatagram { queued_dgram, Address( "10.0.1.2", 0 ) } );
+      // Expect an ARP request.
+      test.execute( ExpectFrame {
+        make_frame( local_eth,
+                    ETHERNET_BROADCAST,
+                    EthernetHeader::TYPE_ARP,
+                    serialize( make_arp( ARPMessage::OPCODE_REQUEST, local_eth, "5.5.5.5", {}, "10.0.1.2" ) ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // Receive an ARP request for an IP that isn't ours that contains a mapping we want to learn.
+      const EthernetAddress remote_eth = random_private_ethernet_address();
+      ARPMessage request_for_someone_else
+        = make_arp( ARPMessage::OPCODE_REQUEST, remote_eth, "10.0.1.2", {}, "10.0.1.3" );
+      test.execute( ReceiveFrame { make_frame(
+        remote_eth, ETHERNET_BROADCAST, EthernetHeader::TYPE_ARP, serialize( request_for_someone_else ) ) } );
+
+      // We expect the queued datagram to be sent.
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth, EthernetHeader::TYPE_IPv4, serialize( queued_dgram ) ) } );
+      test.execute( ExpectNoFrame {} );
+
+      // Send a datagram to the IP of the ARP request.
+      const auto dgram = make_datagram( "5.5.5.5", "99.99.99.99" );
+      test.execute( SendDatagram { dgram, Address( "10.0.1.2", 0 ) } );
+
+      // Expect that we still have learned the mapping.
+      test.execute(
+        ExpectFrame { make_frame( local_eth, remote_eth, EthernetHeader::TYPE_IPv4, serialize( dgram ) ) } );
+
+      test.execute( ExpectNoFrame {} );
+    }
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return EXIT_FAILURE;

--- a/tests/net_interface.cc
+++ b/tests/net_interface.cc
@@ -617,6 +617,7 @@ int main()
       }
     }
 
+    // Test credit: Adam Lambert
     {
       const EthernetAddress local_eth = random_private_ethernet_address();
       NetworkInterfaceTestHarness test {
@@ -656,6 +657,7 @@ int main()
       test.execute( ExpectNoFrame {} );
     }
 
+    // Test credit: Adam Lambert
     {
       const EthernetAddress local_eth = random_private_ethernet_address();
       NetworkInterfaceTestHarness test { "Learn from broadcast ARP reply", local_eth, Address( "5.5.5.5", 0 ) };

--- a/tests/network_interface_test_harness.hh
+++ b/tests/network_interface_test_harness.hh
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include "common.hh"
+#include "helpers.hh"
+#include "network_interface.hh"
+
+class FramesOut : public NetworkInterface::OutputPort
+{
+public:
+  std::queue<EthernetFrame> frames {};
+  void transmit( const NetworkInterface& n [[maybe_unused]], const EthernetFrame& x ) override
+  {
+    frames.push( clone( x ) );
+  }
+
+  EthernetFrame expect_frame() const
+  {
+    if ( frames.empty() ) {
+      throw ExpectationViolation( "should have sent an Ethernet frame" );
+    }
+    auto& mutable_output = const_cast<decltype( frames )&>( frames ); // NOLINT(*-const-cast)
+    EthernetFrame ret { std::move( mutable_output.front() ) };
+    mutable_output.pop();
+    return ret;
+  }
+};
+
+using Output = std::shared_ptr<FramesOut>;
+using InterfaceAndOutput = std::pair<NetworkInterface, Output>;
+
+class NetworkInterfaceTestHarness : public TestHarness<InterfaceAndOutput>
+{
+public:
+  NetworkInterfaceTestHarness( std::string test_name,
+                               const EthernetAddress& ethernet_address,
+                               const Address& ip_address )
+    : TestHarness( move( test_name ), "eth=" + to_string( ethernet_address ) + ", ip=" + ip_address.ip(), [&] {
+      Output output { std::make_shared<FramesOut>() };
+      NetworkInterface iface { "test", output, ethernet_address, ip_address };
+      return InterfaceAndOutput { std::move( iface ), std::move( output ) };
+    }() )
+  {}
+};
+
+struct SendDatagram : public Action<InterfaceAndOutput>
+{
+  InternetDatagram dgram;
+  Address next_hop;
+
+  std::string description() const override
+  {
+    return "request to send datagram (to next hop " + next_hop.ip() + "): " + dgram.header.to_string()
+           + " payload=\"" + pretty_print( concat( dgram.payload ) ) + "\"";
+  }
+
+  void execute( InterfaceAndOutput& interface ) const override { interface.first.send_datagram( dgram, next_hop ); }
+
+  SendDatagram( const InternetDatagram& d, Address n ) : dgram( clone( d ) ), next_hop( n ) {}
+};
+
+template<class T>
+bool equal( const T& t1, const T& t2 )
+{
+  const auto t1s = serialize( t1 );
+  const auto t2s = serialize( t2 );
+
+  return concat( t1s ) == concat( t2s );
+}
+
+struct ReceiveFrame : public Action<InterfaceAndOutput>
+{
+  EthernetFrame frame;
+  std::optional<InternetDatagram> expected {};
+
+  std::string description() const override { return "receive frame (" + summary( frame ) + ")"; }
+  void execute( InterfaceAndOutput& interface ) const override
+  {
+    interface.first.recv_frame( clone( frame ) );
+
+    auto& inbound = interface.first.datagrams_received();
+
+    if ( not expected.has_value() ) {
+      if ( inbound.empty() ) {
+        return;
+      }
+      throw ExpectationViolation(
+        "an arriving Ethernet frame was passed up the stack as an Internet datagram, but was not expected to be "
+        "(did destination address match our interface?)" );
+    }
+
+    if ( inbound.empty() ) {
+      throw ExpectationViolation(
+        "an arriving Ethernet frame was expected to be passed up the stack as an Internet datagram, but wasn't" );
+    }
+
+    if ( not equal( inbound.front(), expected.value() ) ) {
+      throw ExpectationViolation(
+        std::string( "NetworkInterface::recv_frame() produced a different Internet datagram than was expected: " )
+        + "actual={" + inbound.front().header.to_string() + "}" );
+    }
+
+    inbound.pop();
+  }
+
+  ReceiveFrame( const EthernetFrame& f, const InternetDatagram& e ) : frame( clone( f ) ), expected( clone( e ) ) {}
+
+  explicit ReceiveFrame( const EthernetFrame& f ) : frame( clone( f ) ) {}
+};
+
+struct ExpectFrame : public Expectation<InterfaceAndOutput>
+{
+  EthernetFrame expected;
+
+  std::string description() const override { return "frame transmitted (" + summary( expected ) + ")"; }
+  void execute( const InterfaceAndOutput& interface ) const override
+  {
+    const EthernetFrame frame = interface.second->expect_frame();
+
+    if ( not equal( frame, expected ) ) {
+      throw ExpectationViolation( "NetworkInterface sent a different Ethernet frame than was expected: actual={"
+                                  + summary( frame ) + "}" );
+    }
+  }
+
+  explicit ExpectFrame( const EthernetFrame& e ) : expected( clone( e ) ) {}
+};
+
+struct ExpectNoFrame : public Expectation<InterfaceAndOutput>
+{
+  std::string description() const override { return "no frame transmitted"; }
+  void execute( const InterfaceAndOutput& interface ) const override
+  {
+    if ( not interface.second->frames.empty() ) {
+      throw ExpectationViolation( "NetworkInterface sent an Ethernet frame although none was expected" );
+    }
+  }
+};
+
+struct Tick : public Action<InterfaceAndOutput>
+{
+  size_t _ms;
+
+  std::string description() const override { return to_string( _ms ) + " ms pass"; }
+  void execute( InterfaceAndOutput& interface ) const override { interface.first.tick( _ms ); }
+
+  explicit Tick( const size_t ms ) : _ms( ms ) {}
+};

--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -1,0 +1,155 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      ReassemblerTestHarness test { "all within capacity", 2 };
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( Insert { "cd", 2 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "cd" ) );
+
+      test.execute( Insert { "ef", 4 } );
+      test.execute( BytesPushed( 6 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ef" ) );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert beyond capacity", 2 };
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "cd", 2 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "ab" ) );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "cd", 2 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "cd" ) );
+    }
+
+    {
+      ReassemblerTestHarness test { "overlapping inserts", 1 };
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "a" ) );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "abc", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "b" ) );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert beyond capacity repeated with different data", 2 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "bX", 2 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( Insert { "bc", 1 } );
+      test.execute( BytesPushed( 3 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "c" ) );
+    }
+
+    // test credit: Cooper de Nicola
+    {
+      ReassemblerTestHarness test { "insert last beyond capacity", 2 };
+
+      test.execute( Insert { "bc", 1 }.is_last() );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "bc", 1 }.is_last() );
+      test.execute( BytesPushed( 3 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( ReadAll( "c" ) );
+
+      test.execute( IsFinished { true } );
+    }
+
+    // test credit: Tanmay Garg and Agam Mohan Singh Bhatia
+    {
+      ReassemblerTestHarness test { "insert last fully beyond capacity + empty string is last", 2 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "abc", 0 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "", 3 }.is_last() );
+      test.execute( IsFinished { false } );
+
+      test.execute( ReadAll( "ab" ) );
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( ReadAll( "c" ) );
+      test.execute( IsFinished { true } );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -146,6 +146,63 @@ int main()
       test.execute( ReadAll( "c" ) );
       test.execute( IsFinished { true } );
     }
+
+    // test credit: Parth Sarthi
+    {
+      ReassemblerTestHarness test { "last index exactly fills capacity", 2 };
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( ReadAll( "c" ) );
+
+      test.execute( Insert { "de", 3 }.is_last() );
+      test.execute( ReadAll( "de" ) );
+
+      test.execute( IsFinished { true } );
+    }
+
+    // test credit: Parth Sarthi
+    {
+      ReassemblerTestHarness test { "last index is unacceptable", 2 };
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "ab" ) );
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( ReadAll( "c" ) );
+
+      test.execute( Insert { "def", 3 }.is_last() );
+      test.execute( ReadAll( "de" ) );
+
+      test.execute( IsFinished { false } );
+    }
+
+    // test credit: Andy Wang
+    {
+      ReassemblerTestHarness test { "insert beyond capacity at colossally gigantic index", 3 };
+
+      test.execute( Insert { "b", 1 }.is_last() );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "z", UINT64_MAX } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "xyz", UINT64_MAX - 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished( true ) );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << "\n";
     return EXIT_FAILURE;

--- a/tests/reassembler_cap.cc
+++ b/tests/reassembler_cap.cc
@@ -203,6 +203,51 @@ int main()
       test.execute( ReadAll( "ab" ) );
       test.execute( IsFinished( true ) );
     }
+
+#if 0
+    // test credit: Riya Ranjan
+    {
+      ReassemblerTestHarness test { "insert beyond capacity at colossally gigantic index II", 4 };
+      test.execute( Insert { "", 0 } );
+      test.execute( Insert { "a", UINT64_MAX - 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+#endif
+
+    // test credit: Andy Wang with Jasraj Yogesh Kripalani
+    {
+      ReassemblerTestHarness test { "Use full reassembler storage", 10 };
+
+      test.execute( Insert { "bcde", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 5 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "abcde" ) );
+
+      test.execute( Insert { "ghijklmno", 6 } );
+      test.execute( BytesPushed( 5 ) );
+      test.execute( BytesPending( 9 ) );
+
+      test.execute( Insert { "f", 5 } );
+      test.execute( BytesPushed( 15 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "fghijklmno" ) );
+
+      test.execute( Insert { "rstuvwxy", 17 }.is_last() );
+      test.execute( BytesPushed( 15 ) );
+      test.execute( BytesPending( 8 ) );
+
+      test.execute( Insert { "pq", 15 } );
+      test.execute( BytesPushed( 25 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "pqrstuvwxy" ) );
+
+      test.execute( IsFinished( true ) );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << "\n";
     return EXIT_FAILURE;

--- a/tests/reassembler_dup.cc
+++ b/tests/reassembler_dup.cc
@@ -1,0 +1,98 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      ReassemblerTestHarness test { "dup 1", 65000 };
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "dup 2", 65000 };
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abcd", 4 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abcd", 4 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "dup 3", 65000 };
+
+      test.execute( Insert { "abcdefgh", 0 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( ReadAll( "abcdefgh" ) );
+      test.execute( IsFinished { false } );
+      string data = "abcdefgh";
+
+      for ( size_t i = 0; i < 1000; ++i ) {
+        const size_t start_i = uniform_int_distribution<size_t> { 0, 8 }( rd );
+        auto start = data.begin();
+        advance( start, start_i );
+
+        const size_t end_i = uniform_int_distribution<size_t> { start_i, 8 }( rd );
+        auto end = data.begin();
+        advance( end, end_i );
+
+        test.execute( Insert { string { start, end }, start_i } );
+        test.execute( BytesPushed( 8 ) );
+        test.execute( ReadAll( "" ) );
+        test.execute( IsFinished { false } );
+      }
+    }
+
+    {
+      ReassemblerTestHarness test { "dup 4", 65000 };
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abcdef", 0 } );
+      test.execute( BytesPushed( 6 ) );
+      test.execute( ReadAll( "ef" ) );
+      test.execute( IsFinished { false } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_holes.cc
+++ b/tests/reassembler_holes.cc
@@ -1,0 +1,139 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      ReassemblerTestHarness test { "holes 1", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 2", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( Insert { "a", 0 } );
+
+      test.execute( BytesPushed( 2 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 3", 65000 };
+
+      test.execute( Insert { "b", 1 }.is_last() );
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "a", 0 } );
+
+      test.execute( BytesPushed( 2 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished { true } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 4", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( Insert { "ab", 0 } );
+
+      test.execute( BytesPushed( 2 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 5", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "d", 3 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "a", 0 } );
+
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 6", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "d", 3 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abc", 0 } );
+
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "holes 7", 65000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "d", 3 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "cd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "", 4 }.is_last() );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { true } );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_overlapping.cc
+++ b/tests/reassembler_overlapping.cc
@@ -1,0 +1,296 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      // Overlapping assembled (unread) section
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping assembled/unread section", cap };
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( Insert { "ab", 0 } );
+
+      test.execute( BytesPushed( 2 ) );
+      test.execute( ReadAll( "ab" ) );
+    }
+
+    {
+      // Overlapping assembled (read) section
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping assembled/read section", cap };
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "a" ) );
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( ReadAll( "b" ) );
+      test.execute( BytesPushed( 2 ) );
+    }
+
+    {
+      // Overlapping unassembled section, resulting in assembly
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping unassembled section to fill hole", cap };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "" ) );
+
+      test.execute( Insert { "ab", 0 } );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed( 2 ) );
+    }
+    {
+      // Overlapping unassembled section, not resulting in assembly
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping unassembled section", cap };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "" ) );
+
+      test.execute( Insert { "bc", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPending { 2 } );
+      test.execute( BytesPushed( 0 ) );
+    }
+    {
+      // Overlapping unassembled section, not resulting in assembly
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping unassembled section 2", cap };
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( ReadAll( "" ) );
+
+      test.execute( Insert { "bcd", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPending { 3 } );
+      test.execute( BytesPushed( 0 ) );
+    }
+
+    {
+      // Overlapping multiple unassembled sections
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping multiple unassembled sections", cap };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( Insert { "d", 3 } );
+      test.execute( ReadAll( "" ) );
+
+      test.execute( Insert { "bcde", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+    }
+
+    {
+      // Submission over existing
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "insert over existing section", cap };
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( Insert { "bcd", 1 } );
+
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 3 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Submission within existing
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "insert within existing section", cap };
+
+      test.execute( Insert { "bcd", 1 } );
+      test.execute( Insert { "c", 2 } );
+
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 3 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Hole filled progressively and with overlap. Credit: Sarah McCarthy
+
+      ReassemblerTestHarness test { "hole filled with overlap", 20 };
+
+      test.execute( Insert { "fgh", 5 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "abc", 0 } );
+      test.execute( BytesPushed( 3 ) );
+
+      test.execute( Insert { "abcdef", 0 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll( "abcdefgh" ) );
+    }
+
+    {
+      // Multiple overlap. Credit: Sebastian Ingino
+      ReassemblerTestHarness test { "multiple overlaps", 1000 };
+
+      test.execute( Insert { "c", 2 } );
+      test.execute( Insert { "e", 4 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 2 ) );
+
+      test.execute( Insert { "bcdef", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 5 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcdef" ) );
+      test.execute( BytesPushed( 6 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Overlap between two pending. Credit: Sebastian Ingino.
+      ReassemblerTestHarness test { "overlap between two pending", 1000 };
+
+      test.execute( Insert { "bc", 1 } );
+      test.execute( Insert { "ef", 4 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+
+      test.execute( Insert { "cde", 2 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 5 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcdef" ) );
+      test.execute( BytesPushed( 6 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Add exact copy. Credit: Sebastian Ingino.
+      ReassemblerTestHarness test { "exact copy", 1000 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Credit: Anonymous (2023)
+      ReassemblerTestHarness test { "yet another overlap test", 150 };
+
+      test.execute( Insert { "efgh", 4 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+
+      test.execute( Insert { "op", 14 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 6 ) );
+
+      test.execute( Insert { "s", 18 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 7 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( BytesPending( 7 ) );
+
+      test.execute( Insert { "abcde", 0 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( BytesPending( 3 ) );
+
+      test.execute( Insert { "opqrst", 14 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( BytesPending( 6 ) );
+
+      test.execute( Insert { "op", 14 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( BytesPending( 6 ) );
+
+      test.execute( Insert { "ijklmn", 8 } );
+      test.execute( BytesPushed( 20 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Credit: Eli Wald
+      ReassemblerTestHarness test { "small capacity with overlapping insert", 2 };
+      test.execute( Insert { "bc", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "ab" ) );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Credit: Chenhao Li
+      const size_t cap = { 1000 };
+      ReassemblerTestHarness test { "overlapping multiple unassembled sections 2", cap };
+
+      test.execute( Insert { "bcd", 1 } );
+      test.execute( Insert { "cde", 2 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 4 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcde" ) );
+      test.execute( BytesPushed( 5 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Credit: Tanmay Garg
+      ReassemblerTestHarness test { "overlapping multiple unassembled sections 3", 30 };
+
+      test.execute( Insert { "hello", 15 } );
+      test.execute( Insert { "world!", 21 } );
+      test.execute( Insert { "I am sentient", 0 } );
+      test.execute( Insert { "sentient, hello world", 5 } );
+
+      test.execute( BytesPending( 0 ) );
+      test.execute( BytesPushed( 27 ) );
+      test.execute( ReadAll( "I am sentient, hello world!" ) );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_seq.cc
+++ b/tests/reassembler_seq.cc
@@ -1,0 +1,89 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      ReassemblerTestHarness test { "seq 1", 65000 };
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { "efgh", 4 } );
+      test.execute( BytesPushed( 8 ) );
+      test.execute( ReadAll( "efgh" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "seq 2", 65000 };
+
+      test.execute( Insert { "abcd", 0 } );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "efgh", 4 } );
+      test.execute( BytesPushed( 8 ) );
+
+      test.execute( ReadAll( "abcdefgh" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "seq 3", 65000 };
+      ostringstream ss;
+
+      for ( size_t i = 0; i < 100; ++i ) {
+        test.execute( BytesPushed( 4 * i ) );
+        test.execute( Insert { "abcd", 4 * i } );
+        test.execute( IsFinished { false } );
+
+        ss << "abcd";
+      }
+
+      test.execute( ReadAll( ss.str() ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "seq 4", 65000 };
+      for ( size_t i = 0; i < 100; ++i ) {
+        test.execute( BytesPushed( 4 * i ) );
+        test.execute( Insert { "abcd", 4 * i } );
+        test.execute( IsFinished { false } );
+
+        test.execute( ReadAll( "abcd" ) );
+      }
+    }
+
+    {
+      ReassemblerTestHarness test { "zero-valued byte in substring", 16 };
+
+      test.execute( Insert { { 0x30, 0x0d, 0x62, 0x00, 0x61, 0x00, 0x00 }, 9 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( ReadAll( "" ) );
+      test.execute( IsFinished { false } );
+
+      test.execute( Insert { { 0x0d, 0x0a, 0x63, 0x61, 0x0a, 0x66 }, 0 } );
+      test.execute( BytesPushed( 6 ) );
+
+      test.execute( Insert { { 0x0d, 0x0a, 0x63, 0x61, 0x0a, 0x66, 0x65, 0x20, 0x62, 0x30 }, 0 } );
+      test.execute( BytesPushed( 16 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( ReadAll(
+        { 0x0d, 0x0a, 0x63, 0x61, 0x0a, 0x66, 0x65, 0x20, 0x62, 0x30, 0x0d, 0x62, 0x00, 0x61, 0x00, 0x00 } ) );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_single.cc
+++ b/tests/reassembler_single.cc
@@ -1,0 +1,93 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      ReassemblerTestHarness test { "construction", 65000 };
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert a @ 0", 65000 };
+
+      test.execute( Insert { "a", 0 } );
+
+      test.execute( BytesPushed( 1 ) );
+      test.execute( ReadAll( "a" ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert a @ 0 [last]", 65000 };
+
+      test.execute( Insert { "a", 0 }.is_last() );
+
+      test.execute( BytesPushed( 1 ) );
+      test.execute( ReadAll( "a" ) );
+      test.execute( IsFinished { true } );
+    }
+
+    {
+      ReassemblerTestHarness test { "empty stream", 65000 };
+
+      test.execute( Insert { "", 0 }.is_last() );
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( IsFinished { true } );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert b @ 0 [last]", 65000 };
+
+      test.execute( Insert { "b", 0 }.is_last() );
+
+      test.execute( BytesPushed( 1 ) );
+      test.execute( ReadAll( "b" ) );
+      test.execute( IsFinished { true } );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert empty string @ 0", 65000 };
+
+      test.execute( Insert { "", 0 } );
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( IsFinished { false } );
+    }
+
+    // credit: Joshua Dong
+    {
+      ReassemblerTestHarness test { "insert a after 'first unacceptable'", 1 };
+
+      test.execute( Insert { "g", 3 } );
+
+      test.execute( BytesPushed( 0 ) );
+      test.execute( IsFinished { false } );
+    }
+
+    {
+      ReassemblerTestHarness test { "insert b before 'first unassembled'", 1 };
+
+      test.execute( Insert { "b", 0 } );
+      test.execute( ReadAll( "b" ) );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( Insert { "b", 0 } );
+      test.execute( BytesPushed( 1 ) );
+      test.execute( IsFinished { false } );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_single.cc
+++ b/tests/reassembler_single.cc
@@ -84,6 +84,29 @@ int main()
       test.execute( BytesPushed( 1 ) );
       test.execute( IsFinished { false } );
     }
+
+    // credit: iberny
+    {
+      ReassemblerTestHarness test { "stream ends first I", 1000 };
+
+      test.execute( Insert { "", 4 }.is_last() );
+      test.execute( Insert { "abc", 0 } );
+
+      test.execute( BytesPushed( 3 ) );
+      test.execute( ReadAll( "abc" ) );
+      test.execute( IsFinished( false ) );
+    }
+
+    {
+      ReassemblerTestHarness test { "stream ends first II", 1000 };
+
+      test.execute( Insert { "", 3 }.is_last() );
+      test.execute( Insert { "abc", 0 } );
+
+      test.execute( BytesPushed( 3 ) );
+      test.execute( ReadAll( "abc" ) );
+      test.execute( IsFinished( true ) );
+    }
   } catch ( const exception& e ) {
     cerr << "Exception: " << e.what() << "\n";
     return EXIT_FAILURE;

--- a/tests/reassembler_speed_test.cc
+++ b/tests/reassembler_speed_test.cc
@@ -1,0 +1,111 @@
+#include "reassembler.hh"
+
+#include <chrono>
+#include <cstddef>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <queue>
+#include <random>
+#include <tuple>
+
+using namespace std;
+using namespace std::chrono;
+
+void speed_test( const size_t num_chunks,  // NOLINT(bugprone-easily-swappable-parameters)
+                 const size_t chunk_size,  // NOLINT(bugprone-easily-swappable-parameters)
+                 const size_t overlap,     // NOLINT(bugprone-easily-swappable-parameters)
+                 const size_t capacity,    // NOLINT(bugprone-easily-swappable-parameters)
+                 const size_t random_seed, // NOLINT(bugprone-easily-swappable-parameters)
+                 string_view scenario )
+{
+  // Generate the data to be written
+  const string data = [&] {
+    default_random_engine rd { random_seed };
+    uniform_int_distribution<char> ud;
+    string ret;
+    for ( size_t i = 0; i < num_chunks * chunk_size; ++i ) {
+      ret += ud( rd );
+    }
+    return ret;
+  }();
+
+  // Split the data into segments before writing
+  queue<tuple<uint64_t, string, bool>> split_data;
+  for ( size_t i = 0; i < data.size(); i += capacity ) {
+    size_t chunk_begin = min( i + capacity - 1, data.size() - 1 );
+    while ( true ) {
+      split_data.emplace(
+        chunk_begin, data.substr( chunk_begin, chunk_size ), chunk_begin + chunk_size >= data.size() );
+      if ( chunk_begin >= overlap ) {
+        chunk_begin -= overlap;
+      } else {
+        split_data.emplace( 0, data.substr( 0, chunk_size ), 0 + chunk_size >= data.size() );
+        break;
+      }
+    }
+  }
+
+  Reassembler reassembler { ByteStream { capacity } };
+
+  string output_data;
+  output_data.reserve( data.size() );
+
+  const auto start_time = steady_clock::now();
+  while ( not split_data.empty() ) {
+    auto& next = split_data.front();
+    reassembler.insert( get<uint64_t>( next ), move( get<string>( next ) ), get<bool>( next ) );
+    split_data.pop();
+
+    while ( reassembler.reader().bytes_buffered() ) {
+      output_data += reassembler.reader().peek();
+      reassembler.reader().pop( output_data.size() - reassembler.reader().bytes_popped() );
+    }
+  }
+
+  const auto stop_time = steady_clock::now();
+
+  if ( not reassembler.reader().is_finished() ) {
+    throw runtime_error( "Reassembler did not close ByteStream when finished" );
+  }
+
+  if ( data != output_data ) {
+    throw runtime_error( "Mismatch between data written and read" );
+  }
+
+  auto test_duration = duration_cast<duration<double>>( stop_time - start_time );
+  auto bytes_per_second = static_cast<double>( num_chunks * capacity ) / test_duration.count();
+  auto bits_per_second = 8 * bytes_per_second;
+  auto gigabits_per_second = bits_per_second / 1e9;
+
+  fstream debug_output;
+  debug_output.open( "/dev/tty" );
+
+  cout << "Reassembler to ByteStream with capacity=" << capacity << " reached " << fixed << setprecision( 2 )
+       << gigabits_per_second << " Gbit/s.\n";
+
+  debug_output << "        Reassembler throughput " << scenario << fixed << setprecision( 2 ) << setw( 5 )
+               << gigabits_per_second << " Gbit/s\n";
+
+  if ( gigabits_per_second < 0.1 ) {
+    throw runtime_error( "Reassembler did not meet minimum speed of 0.1 Gbit/s." );
+  }
+}
+
+void program_body()
+{
+  speed_test( 1000, 1500, 1500, 32768, 1370, "(no overlap):  " );
+  speed_test( 1000, 1500, 150, 32768, 6163, "(10x overlap): " );
+}
+
+int main()
+{
+  try {
+    program_body();
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/reassembler_test_harness.hh
+++ b/tests/reassembler_test_harness.hh
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "common.hh"
+#include "helpers.hh"
+#include "reassembler.hh"
+
+#include <sstream>
+#include <utility>
+
+template<std::derived_from<TestStep<ByteStream>> T>
+struct ReassemblerTestStep : public TestStep<Reassembler>
+{
+  T step_;
+
+  explicit ReassemblerTestStep( T byte_stream_test_step )
+    : TestStep<Reassembler>(), step_( std::move( byte_stream_test_step ) )
+  {}
+
+  std::string str() const override { return step_.str(); }
+  uint8_t color() const override { return step_.color(); }
+  void execute( Reassembler& r ) const override { step_.execute( r.reader() ); }
+  constexpr std::string obj() const override { return step_.obj(); }
+};
+
+class ReassemblerTestHarness : public TestHarness<Reassembler>
+{
+public:
+  ReassemblerTestHarness( std::string test_name, uint64_t capacity )
+    : TestHarness( move( test_name ),
+                   "capacity=" + std::to_string( capacity ),
+                   { Reassembler { ByteStream { capacity } } } )
+  {}
+
+  template<std::derived_from<TestStep<ByteStream>> T>
+  void execute( const T& test )
+  {
+    TestHarness<Reassembler>::execute( ReassemblerTestStep { test } );
+  }
+
+  using TestHarness<Reassembler>::execute;
+};
+
+struct BytesPending : public ExpectNumber<Reassembler, uint64_t>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "count_bytes_pending"; }
+  uint64_t value( const Reassembler& r ) const override { return r.count_bytes_pending(); }
+};
+
+struct Insert : public Action<Reassembler>
+{
+  std::string data_;
+  uint64_t first_index_;
+  bool is_last_substring_ {};
+
+  Insert( std::string data, uint64_t first_index ) : data_( move( data ) ), first_index_( first_index ) {}
+
+  Insert& is_last( bool status = true )
+  {
+    is_last_substring_ = status;
+    return *this;
+  }
+
+  std::string description() const override
+  {
+    std::ostringstream ss;
+    ss << "insert \"" << pretty_print( data_ ) << "\" @ index " << first_index_;
+    if ( is_last_substring_ ) {
+      ss << " [last substring]";
+    }
+    return ss.str();
+  }
+
+  void execute( Reassembler& r ) const override { r.insert( first_index_, data_, is_last_substring_ ); }
+};

--- a/tests/reassembler_win.cc
+++ b/tests/reassembler_win.cc
@@ -1,0 +1,51 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+
+#include <algorithm>
+#include <exception>
+#include <iostream>
+#include <tuple>
+#include <vector>
+
+using namespace std;
+
+static constexpr size_t NREPS = 32;
+static constexpr size_t NSEGS = 128;
+static constexpr size_t MAX_SEG_LEN = 2048;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    // overlapping segments
+    for ( unsigned rep_no = 0; rep_no < NREPS; ++rep_no ) {
+      ReassemblerTestHarness sr { "win test " + to_string( rep_no ), NSEGS * MAX_SEG_LEN };
+
+      vector<tuple<size_t, size_t>> seq_size;
+      size_t offset = 0;
+      for ( unsigned i = 0; i < NSEGS; ++i ) {
+        const size_t size = 1 + ( rd() % ( MAX_SEG_LEN - 1 ) );
+        const size_t offs = min( offset, 1 + ( static_cast<size_t>( rd() ) % 1023 ) );
+        seq_size.emplace_back( offset - offs, size + offs );
+        offset += size;
+      }
+      shuffle( seq_size.begin(), seq_size.end(), rd );
+
+      string d( offset, 0 );
+      generate( d.begin(), d.end(), [&] { return rd(); } );
+
+      for ( auto [off, sz] : seq_size ) {
+        sr.execute( Insert { d.substr( off, sz ), off }.is_last( off + sz == offset ) );
+      }
+
+      sr.execute( ReadAll { d } );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/receiver_test_harness.hh
+++ b/tests/receiver_test_harness.hh
@@ -1,0 +1,179 @@
+#pragma once
+
+#include "common.hh"
+#include "tcp_receiver.hh"
+#include "tcp_receiver_message.hh"
+
+#include <optional>
+#include <sstream>
+#include <utility>
+
+template<std::derived_from<TestStep<Reassembler>> T>
+struct DirectReassemblerTest : public TestStep<TCPReceiver>
+{
+  T step_;
+
+  explicit DirectReassemblerTest( T sr_test_step ) : TestStep<TCPReceiver>(), step_( std::move( sr_test_step ) ) {}
+
+  std::string str() const override { return step_.str(); }
+  uint8_t color() const override { return step_.color(); }
+  void execute( TCPReceiver& sr ) const override { step_.execute( sr.reassembler() ); }
+  constexpr std::string obj() const override { return step_.obj(); }
+};
+
+template<std::derived_from<TestStep<ByteStream>> T>
+struct DirectByteStreamTest : public TestStep<TCPReceiver>
+{
+  T step_;
+
+  explicit DirectByteStreamTest( T sr_test_step ) : TestStep<TCPReceiver>(), step_( std::move( sr_test_step ) ) {}
+
+  std::string str() const override { return step_.str(); }
+  uint8_t color() const override { return step_.color(); }
+  void execute( TCPReceiver& sr ) const override { step_.execute( sr.reader() ); }
+  constexpr std::string obj() const override { return step_.obj(); }
+};
+
+class TCPReceiverTestHarness : public TestHarness<TCPReceiver>
+{
+public:
+  TCPReceiverTestHarness( std::string test_name, uint64_t capacity )
+    : TestHarness( move( test_name ),
+                   "capacity=" + std::to_string( capacity ),
+                   { TCPReceiver { Reassembler { ByteStream { capacity } } } } )
+  {}
+
+  template<std::derived_from<TestStep<Reassembler>> T>
+  void execute( const T& test )
+  {
+    TestHarness<TCPReceiver>::execute( DirectReassemblerTest { test } );
+  }
+
+  template<std::derived_from<TestStep<ByteStream>> T>
+  void execute( const T& test )
+  {
+    TestHarness<TCPReceiver>::execute( DirectByteStreamTest { test } );
+  }
+
+  using TestHarness<TCPReceiver>::execute;
+};
+
+struct ExpectWindow : public ExpectNumber<TCPReceiver, uint16_t>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "window_size"; }
+  uint16_t value( const TCPReceiver& rs ) const override { return rs.send().window_size; }
+};
+
+struct ExpectAckno : public ExpectNumber<TCPReceiver, std::optional<Wrap32>>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "ackno"; }
+  std::optional<Wrap32> value( const TCPReceiver& rs ) const override { return rs.send().ackno; }
+};
+
+struct ExpectReset : public ExpectBool<TCPReceiver>
+{
+  using ExpectBool::ExpectBool;
+  std::string name() const override { return "RST"; }
+
+  bool value( const TCPReceiver& rs ) const override { return rs.send().RST; }
+};
+
+struct ExpectAcknoBetween : public Expectation<TCPReceiver>
+{
+  Wrap32 isn_;
+  uint64_t checkpoint_;
+  uint64_t min_, max_;
+  ExpectAcknoBetween( Wrap32 isn, uint64_t checkpoint, uint64_t min, uint64_t max ) // NOLINT(*-swappable-*)
+    : isn_( isn ), checkpoint_( checkpoint ), min_( min ), max_( max )
+  {}
+
+  std::string description() const override
+  {
+    return "ackno unwraps to between " + to_string( min_ ) + " and " + to_string( max_ );
+  }
+
+  void execute( const TCPReceiver& rs ) const override
+  {
+    auto ackno = rs.send().ackno;
+    if ( not ackno.has_value() ) {
+      throw ExpectationViolation( "ackno did not have value" );
+    }
+    const uint64_t ackno_absolute = ackno.value().unwrap( isn_, checkpoint_ );
+
+    if ( ackno_absolute < min_ or ackno_absolute > max_ ) {
+      throw ExpectationViolation( "ackno outside expected range" );
+    }
+  }
+};
+
+struct HasAckno : public ExpectBool<TCPReceiver>
+{
+  using ExpectBool::ExpectBool;
+  std::string name() const override { return "ackno.has_value()"; }
+  bool value( const TCPReceiver& rs ) const override { return rs.send().ackno.has_value(); }
+};
+
+struct SegmentArrives : public Action<TCPReceiver>
+{
+  TCPSenderMessage msg_ {};
+  HasAckno ackno_expected_ { true };
+
+  SegmentArrives& with_syn()
+  {
+    msg_.SYN = true;
+    return *this;
+  }
+
+  SegmentArrives& with_fin()
+  {
+    msg_.FIN = true;
+    return *this;
+  }
+
+  SegmentArrives& with_rst()
+  {
+    msg_.RST = true;
+    return *this;
+  }
+
+  SegmentArrives& with_seqno( Wrap32 seqno_ )
+  {
+    msg_.seqno = seqno_;
+    return *this;
+  }
+
+  SegmentArrives& with_seqno( uint32_t seqno_ ) { return with_seqno( Wrap32 { seqno_ } ); }
+
+  SegmentArrives& with_data( std::string data )
+  {
+    msg_.payload = move( data );
+    return *this;
+  }
+
+  SegmentArrives& without_ackno()
+  {
+    ackno_expected_ = HasAckno { false };
+    return *this;
+  }
+
+  void execute( TCPReceiver& rs ) const override
+  {
+    rs.receive( msg_ );
+    ackno_expected_.execute( rs );
+  }
+
+  std::string description() const override
+  {
+    std::ostringstream ss;
+    ss << "receive message: " << to_string( msg_ );
+
+    if ( ackno_expected_.value_ ) {
+      ss << " with ackno expected";
+    } else {
+      ss << " with ackno not expected";
+    }
+    return ss.str();
+  }
+};

--- a/tests/recv_close.cc
+++ b/tests/recv_close.cc
@@ -1,0 +1,54 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "close 1", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn + 0 ) );
+      test.execute( IsClosed { false } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( isn + 1 ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 2 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( Peek { "" } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( IsClosed { true } );
+    }
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "close 2", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn + 0 ) );
+      test.execute( IsClosed { false } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( isn + 1 ).with_data( "a" ) );
+      test.execute( IsClosed { true } );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( ReadAll { "a" } );
+      test.execute( BytesPushed { 1 } );
+      test.execute( IsClosed { true } );
+      test.execute( IsFinished { true } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_close.cc
+++ b/tests/recv_close.cc
@@ -45,6 +45,21 @@ int main()
       test.execute( IsFinished { true } );
     }
 
+    // test credit: Derek Askaryar
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "close 3", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abc" ) );
+      test.execute( ReadAll { "abc" } );
+      test.execute( BytesPushed { 3 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 4 ).with_fin() );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( IsClosed { true } );
+      test.execute( IsFinished { true } );
+    }
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return 1;

--- a/tests/recv_connect.cc
+++ b/tests/recv_connect.cc
@@ -1,0 +1,121 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <optional>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      TCPReceiverTestHarness test { "connect 1", 4000 };
+      test.execute( ExpectWindow { 4000 } );
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( 0 ) );
+      test.execute( ExpectAckno { Wrap32 { 1 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "connect 2", 5435 };
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( 89347598 ) );
+      test.execute( ExpectAckno { Wrap32 { 89347599 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "connect 3", 5435 };
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( 893475 ).without_ackno() );
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "connect 4", 5435 };
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( 893475 ).without_ackno() );
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "connect 5", 5435 };
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( 893475 ).without_ackno() );
+      test.execute( ExpectAckno { optional<Wrap32> {} } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( 89347598 ) );
+      test.execute( ExpectAckno { Wrap32 { 89347599 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "connect 6", 4000 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( 5 ).with_fin() );
+      test.execute( IsClosed { true } );
+      test.execute( ExpectAckno { Wrap32 { 7 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size zero", 0 };
+      test.execute( ExpectWindow { 0 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size 50", 50 };
+      test.execute( ExpectWindow { 50 } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size at max", UINT16_MAX };
+      test.execute( ExpectWindow { UINT16_MAX } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size at max+1", UINT16_MAX + 1 };
+      test.execute( ExpectWindow { UINT16_MAX } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size at max+5", UINT16_MAX + 5 };
+      test.execute( ExpectWindow { UINT16_MAX } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "window size at 10M", 10'000'000 };
+      test.execute( ExpectWindow { UINT16_MAX } );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_reorder.cc
+++ b/tests/recv_reorder.cc
@@ -1,0 +1,137 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "in-window, later segment", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 10 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 4 } );
+      test.execute( BytesPushed { 0 } );
+    }
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "in-window, later segment, then hole filled", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "efgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 4 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 9 } } );
+      test.execute( ReadAll { "abcdefgh" } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 8 } );
+    }
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "hole filled bit-by-bit", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "efgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 4 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "ab" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+      test.execute( ReadAll { "ab" } );
+      test.execute( BytesPending { 4 } );
+      test.execute( BytesPushed { 2 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 3 ).with_data( "cd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 9 } } );
+      test.execute( ReadAll { "cdefgh" } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 8 } );
+    }
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "many gaps, filled bit-by-bit", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "e" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 1 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 7 ).with_data( "g" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 2 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 3 ).with_data( "c" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 3 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "ab" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 4 } } );
+      test.execute( ReadAll { "abc" } );
+      test.execute( BytesPending { 2 } );
+      test.execute( BytesPushed { 3 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 6 ).with_data( "f" ) );
+      test.execute( BytesPending { 3 } );
+      test.execute( BytesPushed { 3 } );
+      test.execute( ReadAll { "" } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 4 ).with_data( "d" ) );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 7 } );
+      test.execute( ReadAll { "defg" } );
+    }
+
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "many gaps, then subsumed", 2358 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "e" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 1 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 7 ).with_data( "g" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 2 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 3 ).with_data( "c" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPending { 3 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcdefgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 9 } } );
+      test.execute( ReadAll { "abcdefgh" } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 8 } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_reorder_more.cc
+++ b/tests/recv_reorder_more.cc
@@ -1,0 +1,125 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+#include "tcp_config.hh"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+using namespace std;
+
+static constexpr unsigned NREPS = 64;
+
+void do_test_1( const TCPConfig& cfg, default_random_engine& rd )
+{
+  const Wrap32 rx_isn( rd() );
+  TCPReceiverTestHarness test_1 { "non-overlapping out-of-order segments", cfg.recv_capacity };
+  test_1.execute( SegmentArrives {}.with_seqno( rx_isn ).with_syn() );
+  vector<tuple<size_t, size_t>> seq_size;
+  size_t datalen = 0;
+  while ( datalen < cfg.recv_capacity ) {
+    const size_t size = min( 1 + ( static_cast<size_t>( rd() ) % ( TCPConfig::MAX_PAYLOAD_SIZE - 1 ) ),
+                             cfg.recv_capacity - datalen );
+    seq_size.emplace_back( datalen, size );
+    datalen += size;
+  }
+  shuffle( seq_size.begin(), seq_size.end(), rd );
+
+  string d( datalen, 0 );
+  generate( d.begin(), d.end(), [&] { return rd(); } );
+
+  uint64_t min_expect_ackno = 1;
+  uint64_t max_expect_ackno = 1;
+  for ( auto [off, sz] : seq_size ) {
+    test_1.execute( SegmentArrives {}.with_seqno( rx_isn + 1 + off ).with_data( d.substr( off, sz ) ) );
+    if ( off + 1 == min_expect_ackno ) {
+      min_expect_ackno = min_expect_ackno + sz;
+    }
+    max_expect_ackno = max_expect_ackno + sz;
+    test_1.execute( ExpectAcknoBetween { rx_isn, off, min_expect_ackno, max_expect_ackno } );
+  }
+
+  test_1.execute( BytesPending { 0 } );
+  test_1.execute( ReadAll { d } );
+}
+
+void do_test_2( const TCPConfig& cfg, default_random_engine& rd )
+{
+  const Wrap32 rx_isn( rd() );
+  TCPReceiverTestHarness test_2 { "overlapping out-of-order segments", cfg.recv_capacity };
+  test_2.execute( SegmentArrives {}.with_seqno( rx_isn ).with_syn() );
+  vector<tuple<size_t, size_t>> seq_size;
+  size_t datalen = 0;
+  while ( datalen < cfg.recv_capacity ) {
+    const size_t size = min( 1 + ( static_cast<size_t>( rd() ) % ( TCPConfig::MAX_PAYLOAD_SIZE - 1 ) ),
+                             cfg.recv_capacity - datalen );
+    const size_t rem = TCPConfig::MAX_PAYLOAD_SIZE - size;
+    size_t offs = 0;
+    if ( rem == 0 ) {
+      offs = 0;
+    } else if ( rem == 1 ) {
+      offs = min( static_cast<size_t>( 1 ), datalen );
+    } else {
+      offs = min( min( datalen, rem ), 1 + ( static_cast<size_t>( rd() ) % ( rem - 1 ) ) );
+    }
+
+    if ( size + offs > TCPConfig::MAX_PAYLOAD_SIZE ) {
+      throw runtime_error( "test 2 internal error: bad payload size" );
+    }
+    seq_size.emplace_back( datalen - offs, size + offs );
+    datalen += size;
+  }
+  if ( datalen > cfg.recv_capacity ) {
+    throw runtime_error( "test 2 internal error: bad offset sequence" );
+  }
+  shuffle( seq_size.begin(), seq_size.end(), rd );
+
+  string d( datalen, 0 );
+  generate( d.begin(), d.end(), [&] { return rd(); } );
+
+  uint64_t min_expect_ackno = 1;
+  uint64_t max_expect_ackno = 1;
+  for ( auto [off, sz] : seq_size ) {
+    test_2.execute( SegmentArrives {}.with_seqno( rx_isn + 1 + off ).with_data( d.substr( off, sz ) ) );
+    if ( off + 1 <= min_expect_ackno && off + sz + 1 > min_expect_ackno ) {
+      min_expect_ackno = sz + off;
+    }
+    max_expect_ackno = max_expect_ackno + sz; // really loose because of overlap
+    test_2.execute( ExpectAcknoBetween { rx_isn, off, min_expect_ackno, max_expect_ackno } );
+  }
+
+  test_2.execute( BytesPending { 0 } );
+  test_2.execute( ReadAll { d } );
+}
+
+int main()
+{
+  try {
+    TCPConfig cfg {};
+    cfg.recv_capacity = 65000;
+    auto rd = get_random_engine();
+
+    // non-overlapping out-of-order segments
+    for ( unsigned rep_no = 0; rep_no < NREPS; ++rep_no ) {
+      do_test_1( cfg, rd );
+    }
+
+    // overlapping out-of-order segments
+    for ( unsigned rep_no = 0; rep_no < NREPS; ++rep_no ) {
+      do_test_2( cfg, rd );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_special.cc
+++ b/tests/recv_special.cc
@@ -1,0 +1,287 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    /* segment before SYN */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment before SYN", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "hello" ).without_ackno() );
+      test.execute( HasAckno { false } );
+      test.execute( BytesPending { 0 } );
+      test.execute( ReadAll { "" } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( HasAckno { true } );
+      test.execute( IsClosed { false } );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+    }
+
+    /* segment with SYN + data */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment with SYN + data", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ).with_data( "Hello, CS144!" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 14 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( ReadAll { "Hello, CS144!" } );
+      test.execute( IsClosed { false } );
+    }
+
+    /* empty segment */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "empty segment", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ) );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( IsClosed { false } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ) );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( IsClosed { false } );
+    }
+
+    /* segment with null byte */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment with null byte", 4000 };
+      const string text = "Here's a null byte:"s + '\0' + "and it's gone."s;
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( text ) );
+      test.execute( ReadAll { string( text ) } );
+      test.execute( ExpectAckno { Wrap32 { isn + 35 } } );
+      test.execute( IsClosed { false } );
+    }
+
+    /* segment with data + FIN */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment with data + FIN", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_fin().with_data( "Goodbye, CS144!" ).with_seqno( isn + 1 ) );
+      test.execute( IsClosed { true } );
+      test.execute( ReadAll { "Goodbye, CS144!" } );
+      test.execute( ExpectAckno { Wrap32 { isn + 17 } } );
+      test.execute( IsFinished { true } );
+    }
+
+    /* segment with FIN (but can't be assembled yet) */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment with FIN (but can't be assembled yet)", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_fin().with_data( "oodbye, CS144!" ).with_seqno( isn + 2 ) );
+      test.execute( ReadAll { "" } );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( IsClosed { false } );
+      test.execute( SegmentArrives {}.with_data( "G" ).with_seqno( isn + 1 ) );
+      test.execute( IsClosed { true } );
+      test.execute( ReadAll { "Goodbye, CS144!" } );
+      test.execute( ExpectAckno { Wrap32 { isn + 17 } } );
+      test.execute( IsFinished { true } );
+    }
+
+    /* segment with SYN + data + FIN */
+    {
+      const uint32_t isn = uniform_int_distribution<uint32_t> { 0, UINT32_MAX }( rd );
+      TCPReceiverTestHarness test { "segment with SYN + payload + FIN", 4000 };
+      test.execute( HasAckno { false } );
+      test.execute(
+        SegmentArrives {}.with_syn().with_seqno( isn ).with_data( "Hello and goodbye, CS144!" ).with_fin() );
+      test.execute( IsClosed { true } );
+      test.execute( ExpectAckno { Wrap32 { isn + 27 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( ReadAll { "Hello and goodbye, CS144!" } );
+      test.execute( IsFinished { true } );
+    }
+
+    // credit: Mustafa Bayramov
+    {
+      const size_t cap = 10;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "buffer full, keep pushing", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ExpectWindow { cap } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcde" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 6 } } );
+      test.execute( ExpectWindow { cap - 5 } );
+      test.execute( BytesPushed { 5 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 6 ).with_data( "fghij" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 11 } } );
+      test.execute( ExpectWindow { 0 } );
+      test.execute( BytesPushed { 10 } );
+      // buffer we keep pushing
+      test.execute( SegmentArrives {}.with_seqno( isn + 11 ).with_data( "klmno" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 11 } } );
+      test.execute( ExpectWindow { 0 } );
+      test.execute( BytesPushed { 10 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 16 ).with_data( "pqrst" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 11 } } );
+      test.execute( ExpectWindow { 0 } );
+      test.execute( BytesPushed { 10 } );
+      test.execute( ReadAll { "abcdefghij" } );
+    }
+
+    {
+      const size_t cap = 10;
+      const uint32_t isn = 12345;
+      TCPReceiverTestHarness test { "missing first byte in the first segment", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 2 ).with_data( "a" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 4 ).with_data( "b" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 6 ).with_data( "c" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 8 ).with_data( "d" ) );
+      test.execute( BytesPushed { 0 } );
+      test.execute( ExpectWindow { 10 } );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+    }
+
+    {
+      const size_t cap = 10;
+      const uint32_t isn = 123456;
+      TCPReceiverTestHarness test { "pushing bytes in reverse order in initial SYN", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      string bytes = { 'j', 'i', 'h', 'g', 'f', 'e', 'd', 'c', 'b', 'a' };
+      for ( int i = cap - 1; i >= 1; --i ) {
+        test.execute( SegmentArrives {}.with_seqno( isn + i + 1 ).with_data( string( 1, bytes[cap - i - 1] ) ) );
+        test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+        test.execute( BytesPushed { 0 } );
+        test.execute( ExpectWindow { 10 } );
+      }
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( string( 1, bytes[cap - 1] ) ) );
+      test.execute( BytesPushed { bytes.size() } );
+      test.execute( ExpectWindow { 0 } );
+      test.execute( ExpectAckno { Wrap32 { static_cast<uint32_t>( isn + bytes.size() + 1 ) } } );
+      test.execute( ReadAll { "abcdefghij" } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "Stream error -> RST flag", 10 };
+      test.execute( SetError {} );
+      test.execute( ExpectReset { true } );
+    }
+
+    {
+      TCPReceiverTestHarness test { "No stream error -> no RST flag", 10 };
+      test.execute( ExpectReset { false } );
+    }
+
+    {
+      // The spec is more restrictive on RST acceptance; we use simpler logic in CS144.
+      TCPReceiverTestHarness test { "RST flag set -> stream error", 10 };
+      test.execute( SegmentArrives {}.with_seqno( rd() ).with_rst().without_ackno() );
+      test.execute( HasError { true } );
+    }
+
+    {
+      // test credit: Majd Nasra
+      ReassemblerTestHarness test { "segment already seen in full", 3 };
+
+      test.execute( Insert { "abc", 0 } );
+      test.execute( ReadAll( "abc" ) );
+      test.execute( BytesPushed( 3 ) );
+      test.execute( BytesPending( 0 ) );
+      test.execute( Insert { "ab", 0 } );
+      test.execute( ReadAll( "" ) ); // tests if the code double-pushes segments already seen in the stream.
+      test.execute( BytesPushed( 3 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    {
+      // Credit: Max Jardetzky
+      ReassemblerTestHarness test { "insert within capacity", 4 };
+
+      test.execute( Insert { "bc", 1 } );
+      test.execute( ReadAll( "" ) );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 2 ) );
+
+      test.execute( Insert { "bcd", 1 } );
+      test.execute( BytesPending( 3 ) );
+      test.execute( Insert { "a", 0 } );
+      test.execute( ReadAll( "abcd" ) );
+      test.execute( BytesPushed( 4 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+
+    // test credit: Tanmay Garg and Agam Mohan Singh Bhatia
+    {
+      ReassemblerTestHarness test { "insert last fully beyond capacity + empty string is last", 2 };
+
+      test.execute( Insert { "b", 1 } );
+      test.execute( BytesPushed( 0 ) );
+      test.execute( BytesPending( 1 ) );
+
+      test.execute( Insert { "a", 0 } );
+      test.execute( BytesPushed( 2 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "abc", 0 }.is_last() );
+      test.execute( IsFinished { false } );
+      test.execute( Insert { "", 3 }.is_last() );
+      test.execute( IsFinished { false } );
+
+      test.execute( ReadAll( "ab" ) );
+      test.execute( Insert { "c", 2 }.is_last() );
+      test.execute( ReadAll( "c" ) );
+      test.execute( IsFinished { true } );
+    }
+
+    // test credit: Noah Schechter
+    // More than 2^16 bytes sent in sets of 1000
+    {
+      TCPReceiverTestHarness test { "proper wrapping when sending more than 2^16bytes", 4000 };
+      const uint32_t block_size = 1000;
+      const uint32_t n_rounds = 67;
+      const uint32_t isn = 0;
+      size_t bytes_sent = 0;
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      for ( uint32_t i = 0; i < n_rounds; ++i ) {
+        string data;
+        for ( uint32_t j = 0; j < block_size; ++j ) {
+          const uint8_t c = 'a' + ( ( i + j ) % 26 );
+          data.push_back( static_cast<char>( c ) );
+        }
+        test.execute( ExpectAckno { make_optional<Wrap32>( isn + bytes_sent + 1 ) } );
+        test.execute( BytesPushed { bytes_sent } );
+        test.execute( SegmentArrives {}.with_seqno( isn + bytes_sent + 1 ).with_data( data ) );
+        bytes_sent += block_size;
+        test.execute( ReadAll { move( data ) } );
+      }
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_special.cc
+++ b/tests/recv_special.cc
@@ -278,6 +278,19 @@ int main()
         test.execute( ReadAll { move( data ) } );
       }
     }
+
+    // credit for test: Danica Xiong
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "retransmission of FIN", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "a" ) );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( isn + 2 ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+      test.execute( SegmentArrives {}.with_fin().with_seqno( isn + 2 ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+    }
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return 1;

--- a/tests/recv_transmit.cc
+++ b/tests/recv_transmit.cc
@@ -1,0 +1,115 @@
+#include "byte_stream_test_harness.hh"
+#include "random.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPReceiverTestHarness test { "transmit 1", 4000 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( 0 ) );
+      test.execute( SegmentArrives {}.with_seqno( 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { 5 } } );
+      test.execute( ReadAll { "abcd" } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 4 } );
+    }
+
+    {
+      const uint32_t isn = 384678;
+      TCPReceiverTestHarness test { "transmit 2", 4000 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 4 } );
+      test.execute( ReadAll { "abcd" } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "efgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 9 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 8 } );
+      test.execute( ReadAll { "efgh" } );
+    }
+
+    {
+      const uint32_t isn = 5;
+      TCPReceiverTestHarness test { "transmit 3", 4000 };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 4 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "efgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 9 } } );
+      test.execute( BytesPending { 0 } );
+      test.execute( BytesPushed { 8 } );
+      test.execute( ReadAll { "abcdefgh" } );
+    }
+
+    // Many (arrive/read)s
+    {
+      TCPReceiverTestHarness test { "transmit 4", 4000 };
+      const uint32_t max_block_size = 10;
+      const uint32_t n_rounds = 10000;
+      const uint32_t isn = 893472;
+      size_t bytes_sent = 0;
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      for ( uint32_t i = 0; i < n_rounds; ++i ) {
+        string data;
+        const uint32_t block_size = uniform_int_distribution<uint32_t> { 1, max_block_size }( rd );
+        for ( uint32_t j = 0; j < block_size; ++j ) {
+          const uint8_t c = 'a' + ( ( i + j ) % 26 );
+          data.push_back( static_cast<char>( c ) );
+        }
+        test.execute( ExpectAckno { make_optional<Wrap32>( isn + bytes_sent + 1 ) } );
+        test.execute( BytesPushed { bytes_sent } );
+        test.execute( SegmentArrives {}.with_seqno( isn + bytes_sent + 1 ).with_data( data ) );
+        bytes_sent += block_size;
+        test.execute( ReadAll { move( data ) } );
+      }
+    }
+
+    // Many arrives, one read
+    {
+      const uint64_t max_block_size = 10;
+      const uint64_t n_rounds = 100;
+      TCPReceiverTestHarness test { "transmit 5", max_block_size * n_rounds };
+      const uint32_t isn = 238;
+      size_t bytes_sent = 0;
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      string all_data;
+      for ( uint32_t i = 0; i < n_rounds; ++i ) {
+        string data;
+        const uint32_t block_size = uniform_int_distribution<uint32_t> { 1, max_block_size }( rd );
+        for ( uint32_t j = 0; j < block_size; ++j ) {
+          const uint8_t c = 'a' + ( ( i + j ) % 26 );
+          const char ch = static_cast<char>( c );
+          data.push_back( ch );
+          all_data.push_back( ch );
+        }
+        test.execute( ExpectAckno { make_optional<Wrap32>( isn + bytes_sent + 1 ) } );
+        test.execute( BytesPushed { bytes_sent } );
+        test.execute( SegmentArrives {}.with_seqno( isn + bytes_sent + 1 ).with_data( data ) );
+        bytes_sent += block_size;
+      }
+      test.execute( ReadAll { move( all_data ) } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/recv_window.cc
+++ b/tests/recv_window.cc
@@ -1,0 +1,115 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+#include "receiver_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      const size_t cap = 4000;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "window size decreases appropriately", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ExpectWindow { cap } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( ExpectWindow { cap - 4 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 9 ).with_data( "ijkl" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( ExpectWindow { cap - 4 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 5 ).with_data( "efgh" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 13 } } );
+      test.execute( ExpectWindow { cap - 12 } );
+    }
+
+    {
+      const size_t cap = 4000;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "window size expands after pop", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( ExpectWindow { cap } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "abcd" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( ExpectWindow { cap - 4 } );
+      test.execute( ReadAll { "abcd" } );
+      test.execute( ExpectAckno { Wrap32 { isn + 5 } } );
+      test.execute( ExpectWindow { cap } );
+    }
+
+    {
+      const size_t cap = 2;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "arriving segment with high seqno", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 2 ).with_data( "bc" ) );
+      test.execute( BytesPushed { 0 } );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "a" ) );
+      test.execute( ExpectAckno { Wrap32 { isn + 3 } } );
+      test.execute( ExpectWindow { 0 } );
+      test.execute( BytesPushed { 2 } );
+      test.execute( ReadAll { "ab" } );
+      test.execute( ExpectWindow { 2 } );
+    }
+
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 294058;
+      TCPReceiverTestHarness test { "arriving segment with low seqno", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_data( "ab" ).with_seqno( isn + 1 ) );
+      test.execute( BytesPushed { 2 } );
+      test.execute( ExpectWindow { cap - 2 } );
+      test.execute( SegmentArrives {}.with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( BytesPushed { 3 } );
+      test.execute( ExpectWindow { cap - 3 } );
+      test.execute( ReadAll { "abc" } );
+    }
+
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "segment overflowing window on left side", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "ab" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 3 ).with_data( "cdef" ) );
+      test.execute( ReadAll { "abcd" } );
+    }
+
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "segment matching window", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 1 ).with_data( "ab" ) );
+      test.execute( SegmentArrives {}.with_seqno( isn + 3 ).with_data( "cd" ) );
+      test.execute( ReadAll { "abcd" } );
+    }
+
+    // credit for test: Jared Wasserman + Anonymous
+    {
+      const size_t cap = 4;
+      const uint32_t isn = 23452;
+      TCPReceiverTestHarness test { "byte with invalid stream index should be ignored", cap };
+      test.execute( SegmentArrives {}.with_syn().with_seqno( isn ) );
+      test.execute( SegmentArrives {}.with_seqno( isn ).with_data( "a" ) );
+      test.execute( BytesPushed { 0 } );
+      test.execute( ExpectAckno { Wrap32 { isn + 1 } } );
+      test.execute( BytesPending( 0 ) );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_ack.cc
+++ b/tests/send_ack.cc
@@ -1,0 +1,77 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Repeat ACK is ignored", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( Push { "a" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "a" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Old ACK is ignored", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( Push { "a" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "a" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 2 } } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "b" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "b" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    // credit for test: Jared Wasserman (2020)
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Impossible ackno (beyond next seqno) is ignored", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 2 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( HasError { false } );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_close.cc
+++ b/tests/send_close.cc
@@ -1,0 +1,155 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN sent test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN with data", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "hello" }.with_close() );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ).with_data( "hello" ) );
+      test.execute( ExpectSeqno { isn + 7 } );
+      test.execute( ExpectSeqnosInFlight { 6 } );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "SYN + FIN", cfg };
+      test.execute( Receive { { {}, 1024 } }.without_push() );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_syn( true ).with_payload_size( 0 ).with_seqno( isn ).with_fin( true ) );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN acked test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 2 } } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN not acked test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN retx test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { TCPConfig::TIMEOUT_DFLT - 1 } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectMessage {}.with_fin( true ).with_seqno( isn + 1 ) );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 2 } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_connect.cc
+++ b/tests/send_connect.cc
@@ -1,0 +1,91 @@
+#include "sender_test_harness.hh"
+
+#include "random.hh"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "SYN sent after first push", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "SYN acked test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { isn + 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "SYN -> wrong ack test", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { isn } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "SYN acked, data", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { isn + 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "abcdefgh" } );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectMessage {}.with_seqno( isn + 1 ).with_data( "abcdefgh" ) );
+      test.execute( ExpectSeqno { isn + 9 } );
+      test.execute( ExpectSeqnosInFlight { 8 } );
+      test.execute( AckReceived { isn + 9 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectSeqno { isn + 9 } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_extra.cc
+++ b/tests/send_extra.cc
@@ -1,0 +1,717 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "If already running, timer stays running when new segment sent", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( Tick { rto - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push( "def" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ) );
+      test.execute( Tick { 6 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Retransmission still happens when expiration time not hit exactly", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( Tick { rto - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push( "def" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ) );
+      test.execute( Tick { 200 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Timer restarts on ACK of new data", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( Tick { rto - 5 } );
+      test.execute( Push( "def" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ).with_seqno( isn + 4 ) );
+      test.execute( AckReceived { Wrap32 { isn + 4 } }.with_win( 1000 ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 2 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ).with_seqno( isn + 4 ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Timer doesn't restart without ACK of new data", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( Tick { rto - 5 } );
+      test.execute( Push( "def" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ).with_seqno( isn + 4 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( Tick { 6 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { rto * 2 - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 8 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "RTO resets on ACK of new data", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( Tick { rto - 5 } );
+      test.execute( Push( "def" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ).with_seqno( isn + 4 ) );
+      test.execute( Push( "ghi" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "ghi" ).with_seqno( isn + 7 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( Tick { 6 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { rto * 2 - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 5 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { rto * 4 - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 4 } }.with_win( 1000 ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 2 } );
+      test.execute( ExpectMessage {}.with_payload_size( 3 ).with_data( "def" ).with_seqno( isn + 4 ) );
+      test.execute( ExpectNoSegment {} );
+    }
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      const string nicechars = "abcdefghijklmnopqrstuvwxyz";
+      string bigstring;
+      for ( unsigned int i = 0; i < TCPConfig::DEFAULT_CAPACITY; i++ ) {
+        bigstring.push_back( nicechars.at( rd() % nicechars.size() ) );
+      }
+
+      const size_t window_size = uniform_int_distribution<uint16_t> { 50000, 63000 }( rd );
+
+      TCPSenderTestHarness test { "fill_window() correctly fills a big window", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( window_size ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { bigstring } );
+
+      for ( unsigned int i = 0; i + TCPConfig::MAX_PAYLOAD_SIZE < min( bigstring.size(), window_size );
+            i += TCPConfig::MAX_PAYLOAD_SIZE ) {
+        const size_t expected_size = min( TCPConfig::MAX_PAYLOAD_SIZE, min( bigstring.size(), window_size ) - i );
+        test.execute( ExpectMessage {}
+                        .with_no_flags()
+                        .with_payload_size( expected_size )
+                        .with_data( bigstring.substr( i, expected_size ) )
+                        .with_seqno( isn + 1 + i ) );
+      }
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Retransmit a FIN-containing segment same as any other", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "abc" }.with_close() );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ).with_fin( true ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 2 } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ).with_fin( true ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Retransmit a FIN-only segment same as any other", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "abc" } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ).with_no_flags() );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_payload_size( 0 ).with_seqno( isn + 4 ).with_fin( true ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { isn + 4 }.with_win( 1000 ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 2 } );
+      test.execute( ExpectMessage {}.with_payload_size( 0 ).with_seqno( isn + 4 ).with_fin( true ) );
+      test.execute( Tick { 2 * rto - 5 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 10 } );
+      test.execute( ExpectMessage {}.with_payload_size( 0 ).with_seqno( isn + 4 ).with_fin( true ) );
+      test.execute( ExpectSeqno { isn + 5 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Don't add FIN if this would make the segment exceed the receiver's window",
+                                  cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( Push( "abc" ).with_close() );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 3 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ).with_no_flags() );
+      test.execute( ExpectSeqno { isn + 4 } );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( AckReceived { Wrap32 { isn + 2 } }.with_win( 2 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 3 } }.with_win( 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 4 } }.with_win( 1 ) );
+      test.execute( ExpectMessage {}.with_payload_size( 0 ).with_seqno( isn + 4 ).with_fin( true ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Don't send FIN by itself if the window is full", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 3 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 3 ).with_data( "abc" ).with_seqno( isn + 1 ).with_no_flags() );
+      test.execute( ExpectSeqno { isn + 4 } );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( Close {} );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 2 } }.with_win( 2 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 3 } }.with_win( 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 4 } }.with_win( 1 ) );
+      test.execute( ExpectMessage {}.with_payload_size( 0 ).with_seqno( isn + 4 ).with_fin( true ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      const string nicechars = "abcdefghijklmnopqrstuvwxyz";
+      string bigstring;
+      for ( unsigned int i = 0; i < TCPConfig::MAX_PAYLOAD_SIZE; i++ ) {
+        bigstring.push_back( nicechars.at( rd() % nicechars.size() ) );
+      }
+
+      TCPSenderTestHarness test { "MAX_PAYLOAD_SIZE limits payload only", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( Push { string( bigstring ) }.with_close() );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 40000 ) );
+      test.execute( ExpectMessage {}
+                      .with_payload_size( TCPConfig::MAX_PAYLOAD_SIZE )
+                      .with_data( string( bigstring ) )
+                      .with_seqno( isn + 1 )
+                      .with_fin( true ) );
+      test.execute( ExpectSeqno { isn + 2 + TCPConfig::MAX_PAYLOAD_SIZE } );
+      test.execute( ExpectSeqnosInFlight { 1 + TCPConfig::MAX_PAYLOAD_SIZE } );
+      test.execute( AckReceived( isn + 2 + TCPConfig::MAX_PAYLOAD_SIZE ) );
+      test.execute( ExpectSeqno { isn + 2 + TCPConfig::MAX_PAYLOAD_SIZE } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test {
+        "When filling window, treat a '0' window size as equal to '1' but don't back off RTO", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 0 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( Close {} );
+      test.execute( ExpectNoSegment {} );
+
+      for ( unsigned int i = 0; i < 5; i++ ) {
+        test.execute( Tick { rto - 1 } );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 } );
+        test.execute(
+          ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+      }
+
+      test.execute( AckReceived { isn + 2 }.with_win( 0 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "b" ).with_seqno( isn + 2 ).with_no_flags() );
+
+      for ( unsigned int i = 0; i < 5; i++ ) {
+        test.execute( Tick { rto - 1 } );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 } );
+        test.execute(
+          ExpectMessage {}.with_payload_size( 1 ).with_data( "b" ).with_seqno( isn + 2 ).with_no_flags() );
+      }
+
+      test.execute( AckReceived { isn + 3 }.with_win( 0 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "c" ).with_seqno( isn + 3 ).with_no_flags() );
+
+      for ( unsigned int i = 0; i < 5; i++ ) {
+        test.execute( Tick { rto - 1 } );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 } );
+        test.execute(
+          ExpectMessage {}.with_payload_size( 1 ).with_data( "c" ).with_seqno( isn + 3 ).with_no_flags() );
+      }
+
+      test.execute( AckReceived { isn + 4 }.with_win( 0 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 0 ).with_data( "" ).with_seqno( isn + 4 ).with_fin( true ) );
+
+      for ( unsigned int i = 0; i < 5; i++ ) {
+        test.execute( Tick { rto - 1 } );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 } );
+        test.execute(
+          ExpectMessage {}.with_payload_size( 0 ).with_data( "" ).with_seqno( isn + 4 ).with_fin( true ) );
+      }
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Unlike a zero-size window, a full window of nonzero size should be respected",
+                                  cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+      test.execute( ExpectSeqno { isn + 2 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+
+      test.execute( Close {} );
+
+      test.execute( Tick { 2 * rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+
+      test.execute( Tick { 4 * rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 1 ).with_data( "a" ).with_seqno( isn + 1 ).with_no_flags() );
+
+      test.execute( AckReceived { Wrap32 { isn + 2 } }.with_win( 3 ) );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 2 ).with_data( "bc" ).with_seqno( isn + 2 ).with_fin( true ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "Repeated ACKs and outdated ACKs are harmless", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "abcdefg" ) );
+      test.execute( ExpectMessage {}.with_payload_size( 7 ).with_data( "abcdefg" ).with_seqno( isn + 1 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push( "ijkl" ).with_close() );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 4 ).with_data( "ijkl" ).with_seqno( isn + 8 ).with_fin( true ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 12 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 12 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 12 } }.with_win( 1000 ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 1000 ) );
+      test.execute( Tick { 5 * rto } );
+      test.execute(
+        ExpectMessage {}.with_payload_size( 4 ).with_data( "ijkl" ).with_seqno( isn + 8 ).with_fin( true ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived( Wrap32 { isn + 13 } ).with_win( 1000 ) );
+      test.execute( AckReceived( Wrap32 { isn + 1 } ).with_win( 1000 ) );
+      test.execute( Tick { 5 * rto } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+    }
+
+    // test credit: DD152
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+      const string nicechars = "abcdefghijklmnopqrstuvwxyz";
+      string bigstring;
+      for ( unsigned int i = 0; i < TCPConfig::DEFAULT_CAPACITY; i++ ) {
+        bigstring.push_back( nicechars.at( rd() % nicechars.size() ) );
+      }
+      // max window size
+      const size_t window_size = 65535;
+      TCPSenderTestHarness test { "Only the last segment has FIN", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( window_size ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { bigstring }.with_close() );
+      unsigned int i = 0;
+      while ( ( i + TCPConfig::MAX_PAYLOAD_SIZE ) < bigstring.size() ) {
+        test.execute( ExpectMessage {}
+                        .with_no_flags()
+                        .with_payload_size( TCPConfig::MAX_PAYLOAD_SIZE )
+                        .with_data( bigstring.substr( i, TCPConfig::MAX_PAYLOAD_SIZE ) )
+                        .with_seqno( isn + 1 + i ) );
+        i += TCPConfig::MAX_PAYLOAD_SIZE;
+      }
+      test.execute( ExpectMessage {}
+                      .with_fin( true )
+                      .with_payload_size( bigstring.size() - i )
+                      .with_data( bigstring.substr( i, bigstring.size() - 1 ) )
+                      .with_seqno( isn + 1 + i ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 2 + bigstring.size() } );
+      test.execute( ExpectSeqnosInFlight { bigstring.size() + 1 } );
+      test.execute( AckReceived { isn + 2 + bigstring.size() } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectSeqno { isn + 2 + bigstring.size() } );
+    }
+
+    // Sender must set RST iff stream has suffered an error
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+      TCPSenderTestHarness test { "Stream error -> RST flag", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ) );
+      test.execute( SetError {} );
+      test.execute( ExpectReset { true } );
+    }
+
+    // Sender must set RST iff stream has suffered an error
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+      TCPSenderTestHarness test { "Stream error -> RST flag (non-empty segment)", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 100 ) );
+      test.execute( SetError {} );
+      test.execute( Push { "hello" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_rst( true ).with_seqno( isn + 1 ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "RST flag -> stream error", cfg };
+      test.execute( Receive { TCPReceiverMessage { .RST = true } } );
+      test.execute( HasError { true } );
+    }
+
+    // Newly added test: check RTO timer on invalid ackno
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+      cfg.rt_timeout = 10;
+      TCPSenderTestHarness test { "invalid ackno -> should not reset RTO timer", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 4 ) );
+      test.execute( Push { "abcd" } );
+      test.execute( ExpectMessage {}.with_payload_size( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 10 }.with_max_retx_exceeded( false ) ); // RTO timer should double here
+      test.execute( ExpectMessage {}.with_payload_size( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1000 } } );       // invalid ackno received here, should not reset
+      test.execute( Tick { 10 }.with_max_retx_exceeded( false ) ); // RTO timer should still be double
+      test.execute( ExpectNoSegment {} );
+    }
+
+    // test credit: Ava Jih-Schiff
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Receiving before transmit I", cfg };
+      test.execute(
+        AckReceived { Wrap32 { cfg.isn } }.with_win( 3 ).without_push() ); // invalid ack but window is set
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "abc" }.with_close() );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 2 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 3 } );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( AckReceived { Wrap32 { isn + 3 } }.with_win( 1 ) );
+      test.execute( ExpectMessage {}.with_no_flags().with_payload_size( 1 ).with_seqno( isn + 3 ) );
+      test.execute( AckReceived { Wrap32 { isn + 4 } }.with_win( 1 ) );
+      test.execute(
+        ExpectMessage {}.with_no_flags().with_fin( true ).with_payload_size( 0 ).with_seqno( isn + 4 ) );
+    }
+
+    // test credit: Majd Nasra
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const size_t rto = uniform_int_distribution<uint16_t> { 30, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = rto;
+
+      TCPSenderTestHarness test { "When queue is empty, timer is stopped", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( Tick { rto - 1 } );
+      test.execute( Push( "abc" ) );
+      test.execute( ExpectMessage {}.with_data( "abc" ) );
+      test.execute( Tick { rto - 1 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectMessage {}.with_data( "abc" ) );
+    }
+
+    // test credit: Majd Nasra
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Receiving before transmit II", cfg };
+      test.execute( Receive { { {}, 1024 } }.without_push() );
+      test.execute( Push( "01234567" ).with_close() );
+      test.execute( ExpectMessage {}.with_data( "01234567" ).with_syn( true ).with_seqno( isn ).with_fin( true ) );
+      test.execute( ExpectSeqno { isn + 10 } );
+      test.execute( ExpectSeqnosInFlight { 10 } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( HasError { false } );
+    }
+
+    // test credit: Sasha Moore
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Receiving before transmit III", cfg };
+      //  Set window size without having sent an acknowledgment
+      test.execute( Receive { { {}, 1024 } }.without_push() );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_syn( true ).with_fin( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    // test credit: Chuyi Zhang
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+      const string nicechars = "abcdefghijklmnopqrstuvwxyz";
+      string bigstring;
+      for ( unsigned int i = 0; i < TCPConfig::DEFAULT_CAPACITY; i++ ) {
+        bigstring.push_back( nicechars.at( rd() % nicechars.size() ) );
+      }
+      // const size_t window_size = uniform_int_distribution<uint16_t> { 50000, 63000 }( rd );
+      const size_t window_size = 63999;
+      TCPSenderTestHarness test { "Large payload and FIN", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( window_size ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { bigstring }.with_close() );
+      unsigned int i = 0;
+      while ( ( i + TCPConfig::MAX_PAYLOAD_SIZE ) < window_size ) {
+        test.execute( ExpectMessage {}
+                        .with_no_flags()
+                        .with_payload_size( TCPConfig::MAX_PAYLOAD_SIZE )
+                        .with_data( bigstring.substr( i, TCPConfig::MAX_PAYLOAD_SIZE ) )
+                        .with_seqno( isn + 1 + i ) );
+        i += TCPConfig::MAX_PAYLOAD_SIZE;
+      }
+
+      test.execute( ExpectMessage {}
+                      .with_payload_size( window_size - i )
+                      .with_data( bigstring.substr( i, 999 ) )
+                      .with_no_flags() );
+      test.execute( ExpectSeqnosInFlight { window_size } );
+      test.execute( AckReceived { isn + window_size + 1 }.with_win( window_size ) );
+      test.execute( ExpectMessage {}
+                      .with_payload_size( 1 )
+                      .with_data( bigstring.substr( bigstring.size() - 1, 1 ) )
+                      .with_fin( true ) );
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( AckReceived { isn + bigstring.size() + 2 }.with_win( window_size ) );
+      test.execute( ExpectSeqno { isn + bigstring.size() + 2 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_retx.cc
+++ b/tests/send_retx.cc
@@ -1,0 +1,207 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const uint16_t retx_timeout = uniform_int_distribution<uint16_t> { 10, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = retx_timeout;
+
+      TCPSenderTestHarness test { "Retx SYN twice at the right times, then ack", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( Tick { retx_timeout - 1U } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      // Wait twice as long b/c exponential back-off
+      test.execute( Tick { 2 * retx_timeout - 1U } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { 1 } );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( HasError { false } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const uint16_t retx_timeout = uniform_int_distribution<uint16_t> { 10, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = retx_timeout;
+
+      TCPSenderTestHarness test { "Retx SYN until too many retransmissions", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      for ( size_t attempt_no = 0; attempt_no < TCPConfig::MAX_RETX_ATTEMPTS; attempt_no++ ) {
+        test.execute( Tick { ( retx_timeout << attempt_no ) - 1U }.with_max_retx_exceeded( false ) );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 }.with_max_retx_exceeded( false ) );
+        test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+        test.execute( ExpectSeqno { isn + 1 } );
+        test.execute( ExpectSeqnosInFlight { 1 } );
+      }
+      test.execute(
+        Tick { ( retx_timeout << TCPConfig::MAX_RETX_ATTEMPTS ) - 1U }.with_max_retx_exceeded( false ) );
+      test.execute( Tick { 1 }.with_max_retx_exceeded( true ) );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const uint16_t retx_timeout = uniform_int_distribution<uint16_t> { 10, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = retx_timeout;
+
+      TCPSenderTestHarness test { "Send some data, the retx and succeed, then retx till limit", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( Push { "abcd" } );
+      test.execute( ExpectMessage {}.with_payload_size( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 5 } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "efgh" } );
+      test.execute( ExpectMessage {}.with_payload_size( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Tick { retx_timeout }.with_max_retx_exceeded( false ) );
+      test.execute( ExpectMessage {}.with_payload_size( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( AckReceived { Wrap32 { isn + 9 } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "ijkl" } );
+      test.execute( ExpectMessage {}.with_payload_size( 4 ).with_seqno( isn + 9 ) );
+      for ( size_t attempt_no = 0; attempt_no < TCPConfig::MAX_RETX_ATTEMPTS; attempt_no++ ) {
+        test.execute( Tick { ( retx_timeout << attempt_no ) - 1U }.with_max_retx_exceeded( false ) );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Tick { 1 }.with_max_retx_exceeded( false ) );
+        test.execute( ExpectMessage {}.with_payload_size( 4 ).with_seqno( isn + 9 ) );
+        test.execute( ExpectSeqnosInFlight { 4 } );
+      }
+      test.execute(
+        Tick { ( retx_timeout << TCPConfig::MAX_RETX_ATTEMPTS ) - 1U }.with_max_retx_exceeded( false ) );
+      test.execute( Tick { 1 }.with_max_retx_exceeded( true ) );
+    }
+
+    // test credit: Cooper de Nicola
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const uint16_t retx_timeout = uniform_int_distribution<uint16_t> { 10, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = retx_timeout;
+
+      // test that lowest seqno is sent on consecutive resends
+      TCPSenderTestHarness test { "Retx after multiple sends, retx earliest packet", cfg };
+      // syn + syn/ack to increase window size
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+
+      // segment A. Send
+      test.execute( Push { "A" } );
+      test.execute( ExpectMessage {}.with_payload_size( 1 ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+
+      // segment B. Queue.
+      test.execute( Push { "BB" } );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+
+      // timeout to queue A. Should send packet A and B, order does not matter
+      test.execute( Tick { retx_timeout }.with_max_retx_exceeded( false ) );
+      test.execute( ExpectMessage {} ); // either A or B
+      test.execute( ExpectMessage {} ); // either A or B
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( ExpectConsecutiveRetransmissions { 1 } );
+
+      // timeout. Should send segment A
+      test.execute( Tick { static_cast<uint64_t>( retx_timeout ) << 1 }.with_max_retx_exceeded( false ) );
+      test.execute( ExpectMessage {}.with_payload_size( 1 ).with_seqno( isn + 1 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( ExpectConsecutiveRetransmissions { 2 } );
+
+      // continue communications as expected
+      test.execute( AckReceived { Wrap32 { isn + 1 + 1 } } ); // ack A
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( ExpectConsecutiveRetransmissions { 0 } ); // B is still outstanding
+      test.execute( Tick { static_cast<uint64_t>( retx_timeout ) }.with_max_retx_exceeded( false ) );
+      test.execute( ExpectMessage {}.with_payload_size( 2 ).with_seqno( isn + 1 + 1 ) ); // packet B
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectConsecutiveRetransmissions { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 + 1 + 2 } } ); // ack B
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    // test credit: Kosthi
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      const uint16_t retx_timeout = uniform_int_distribution<uint16_t> { 10, 10000 }( rd );
+      cfg.isn = isn;
+      cfg.rt_timeout = retx_timeout;
+
+      TCPSenderTestHarness test { "timer correctness", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Tick( retx_timeout ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "a" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "a" ) );
+      test.execute( Tick( 1 ) ); // no timeout, no msg send
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( Tick( retx_timeout - 1U ) );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "a" ) );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 2 } } );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( HasError { false } );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_transmit.cc
+++ b/tests/send_transmit.cc
@@ -1,0 +1,174 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Three short writes", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push { "ab" } );
+      test.execute( ExpectMessage {}.with_data( "ab" ).with_seqno( isn + 1 ) );
+      test.execute( Push { "cd" } );
+      test.execute( ExpectMessage {}.with_data( "cd" ).with_seqno( isn + 3 ) );
+      test.execute( Push { "abcd" } );
+      test.execute( ExpectMessage {}.with_data( "abcd" ).with_seqno( isn + 5 ) );
+      test.execute( ExpectSeqno { isn + 9 } );
+      test.execute( ExpectSeqnosInFlight { 8 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Many short writes, continuous acks", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } } );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      constexpr uint32_t max_block_size = 10;
+      constexpr uint32_t n_rounds = 10000;
+      size_t bytes_sent = 0;
+      for ( uint32_t i = 0; i < n_rounds; ++i ) {
+        string data;
+        const uint32_t block_size = uniform_int_distribution<uint32_t> { 1, max_block_size }( rd );
+        for ( uint32_t j = 0; j < block_size; ++j ) {
+          const uint8_t c = 'a' + ( ( i + j ) % 26 );
+          data.push_back( static_cast<char>( c ) );
+        }
+        test.execute( ExpectSeqno { isn + static_cast<uint32_t>( bytes_sent ) + 1 } );
+        test.execute( Push { data } );
+        bytes_sent += block_size;
+        test.execute( ExpectSeqnosInFlight { block_size } );
+        test.execute( ExpectMessage {}
+                        .with_seqno( isn + 1 + static_cast<uint32_t>( bytes_sent - block_size ) )
+                        .with_data( move( data ) ) );
+        test.execute( ExpectNoSegment {} );
+        test.execute( AckReceived { Wrap32 { isn + 1 + static_cast<uint32_t>( bytes_sent ) } } );
+      }
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Many short writes, ack at end", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { isn + 1 }.with_win( 65000 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      constexpr uint32_t max_block_size = 10;
+      constexpr uint32_t n_rounds = 1000;
+      size_t bytes_sent = 0;
+      for ( uint32_t i = 0; i < n_rounds; ++i ) {
+        string data;
+        const uint32_t block_size = uniform_int_distribution<uint32_t> { 1, max_block_size }( rd );
+        for ( uint32_t j = 0; j < block_size; ++j ) {
+          const uint8_t c = 'a' + ( ( i + j ) % 26 );
+          data.push_back( static_cast<char>( c ) );
+        }
+        test.execute( ExpectSeqno { Wrap32 { isn + static_cast<uint32_t>( bytes_sent ) + 1 } } );
+        test.execute( Push( string( data ) ) );
+        bytes_sent += block_size;
+        test.execute( ExpectSeqnosInFlight { bytes_sent } );
+        test.execute( ExpectMessage {}
+                        .with_seqno( isn + 1 + static_cast<uint32_t>( bytes_sent - block_size ) )
+                        .with_data( move( data ) ) );
+        test.execute( ExpectNoSegment {} );
+      }
+      test.execute( ExpectSeqnosInFlight { bytes_sent } );
+      test.execute( AckReceived { Wrap32 { isn + 1 + static_cast<uint32_t>( bytes_sent ) } } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Window filling", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 3 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "01234567" ) );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( ExpectMessage {}.with_data( "012" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { Wrap32 { isn + 1 + 3 } } );
+      test.execute( AckReceived { Wrap32 { isn + 1 + 3 } }.with_win( 3 ) );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( ExpectMessage {}.with_data( "345" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { Wrap32 { isn + 1 + 6 } } );
+      test.execute( AckReceived { Wrap32 { isn + 1 + 6 } }.with_win( 3 ) );
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( ExpectMessage {}.with_data( "67" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { Wrap32 { isn + 1 + 8 } } );
+      test.execute( AckReceived { Wrap32 { isn + 1 + 8 } }.with_win( 3 ) );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Immediate writes respect the window", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 1 } );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 3 ) );
+      test.execute( ExpectSeqno { isn + 1 } );
+      test.execute( ExpectSeqnosInFlight { 0 } );
+      test.execute( Push( "01" ) );
+      test.execute( ExpectSeqnosInFlight { 2 } );
+      test.execute( ExpectMessage {}.with_data( "01" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { Wrap32 { isn + 1 + 2 } } );
+      test.execute( Push( "23" ) );
+      test.execute( ExpectSeqnosInFlight { 3 } );
+      test.execute( ExpectMessage {}.with_data( "2" ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( ExpectSeqno { Wrap32 { isn + 1 + 3 } } );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/send_window.cc
+++ b/tests/send_window.cc
@@ -1,0 +1,146 @@
+#include "random.hh"
+#include "sender_test_harness.hh"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Initial receiver advertised window is respected", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "abcdefg" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "abcd" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Immediate window is respected", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 6 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "abcdefg" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "abcdef" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      const size_t MIN_WIN = 5;
+      const size_t MAX_WIN = 100;
+      const size_t N_REPS = 1000;
+      for ( size_t i = 0; i < N_REPS; ++i ) {
+        const size_t len = MIN_WIN + rd() % ( MAX_WIN - MIN_WIN );
+        TCPConfig cfg;
+        const Wrap32 isn( rd() );
+        cfg.isn = isn;
+
+        TCPSenderTestHarness test { "Window " + to_string( i ), cfg };
+        test.execute( Push {} );
+        test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+        test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( len ) );
+        test.execute( ExpectNoSegment {} );
+        test.execute( Push { string( 2 * N_REPS, 'a' ) } );
+        test.execute( ExpectMessage {}.with_no_flags().with_payload_size( len ) );
+        test.execute( ExpectNoSegment {} );
+      }
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Window growth is exploited", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 4 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "0123456789" } );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "0123" ) );
+      test.execute( AckReceived { Wrap32 { isn + 5 } }.with_win( 5 ) );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "45678" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN flag occupies space in window", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 7 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "1234567" } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "1234567" ) );
+      test.execute( ExpectNoSegment {} ); // window is full
+      test.execute( AckReceived { Wrap32 { isn + 8 } }.with_win( 1 ) );
+      test.execute( ExpectMessage {}.with_fin( true ).with_data( "" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "FIN flag occupies space in window (part II)", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 7 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "1234567" } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "1234567" ) );
+      test.execute( ExpectNoSegment {} ); // window is full
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 8 ) );
+      test.execute( ExpectMessage {}.with_fin( true ).with_data( "" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+
+    {
+      TCPConfig cfg;
+      const Wrap32 isn( rd() );
+      cfg.isn = isn;
+
+      TCPSenderTestHarness test { "Piggyback FIN in segment when space is available", cfg };
+      test.execute( Push {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_syn( true ).with_payload_size( 0 ).with_seqno( isn ) );
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 3 ) );
+      test.execute( ExpectNoSegment {} );
+      test.execute( Push { "1234567" } );
+      test.execute( Close {} );
+      test.execute( ExpectMessage {}.with_no_flags().with_data( "123" ) );
+      test.execute( ExpectNoSegment {} ); // window is full
+      test.execute( AckReceived { Wrap32 { isn + 1 } }.with_win( 8 ) );
+      test.execute( ExpectMessage {}.with_fin( true ).with_data( "4567" ) );
+      test.execute( ExpectNoSegment {} );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/sender_test_harness.hh
+++ b/tests/sender_test_harness.hh
@@ -1,0 +1,406 @@
+#pragma once
+
+#include "common.hh"
+#include "helpers.hh"
+#include "tcp_config.hh"
+#include "tcp_receiver_message.hh"
+#include "tcp_sender.hh"
+#include "wrapping_integers.hh"
+
+#include <optional>
+#include <queue>
+#include <sstream>
+#include <utility>
+
+const unsigned int DEFAULT_TEST_WINDOW = 137;
+
+struct SenderAndOutput
+{
+  TCPSender sender;
+  std::queue<TCPSenderMessage> output {};
+
+  auto make_transmit()
+  {
+    return [&]( const TCPSenderMessage& x ) { output.push( x ); };
+  }
+
+  TCPSenderMessage expect_message() const
+  {
+    if ( output.empty() ) {
+      throw ExpectationViolation( "should have sent a message" );
+    }
+    auto& mutable_output = const_cast<decltype( output )&>( output ); // NOLINT(*-const-cast)
+    TCPSenderMessage ret { std::move( mutable_output.front() ) };
+    mutable_output.pop();
+    return ret;
+  }
+};
+
+template<std::derived_from<TestStep<TCPSender>> T>
+struct SenderTestStep : public TestStep<SenderAndOutput>
+{
+  T step_;
+
+  explicit SenderTestStep( T inner ) : TestStep<SenderAndOutput>(), step_( std::move( inner ) ) {}
+
+  std::string str() const override { return step_.str(); }
+  uint8_t color() const override { return step_.color(); }
+  void execute( SenderAndOutput& so ) const override { step_.execute( so.sender ); }
+  constexpr std::string obj() const override { return step_.obj(); }
+};
+
+class TCPSenderTestHarness : public TestHarness<SenderAndOutput>
+{
+public:
+  TCPSenderTestHarness( std::string name, TCPConfig config )
+    : TestHarness( move( name ),
+                   "initial_RTO_ms=" + to_string( config.rt_timeout ) + " and ISN=" + to_string( config.isn ),
+                   { TCPSender { ByteStream { config.send_capacity }, config.isn, config.rt_timeout } } )
+  {}
+
+  template<std::derived_from<TestStep<TCPSender>> T>
+  void execute( const T& test )
+  {
+    TestHarness<SenderAndOutput>::execute( SenderTestStep { test } );
+  }
+
+  using TestHarness<SenderAndOutput>::execute;
+};
+
+struct ExpectSeqno : public ExpectNumber<TCPSender, Wrap32>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "make_empty_message().seqno"; }
+
+  Wrap32 value( const TCPSender& sender ) const override
+  {
+    auto seg = sender.make_empty_message();
+    if ( seg.sequence_length() ) {
+      throw ExpectationViolation( "make_empty_message() returned non-empty message" );
+    }
+    return seg.seqno;
+  }
+};
+
+struct ExpectReset : public ExpectBool<TCPSender>
+{
+  using ExpectBool::ExpectBool;
+  std::string name() const override { return "make_empty_message().RST"; }
+
+  bool value( const TCPSender& sender ) const override { return sender.make_empty_message().RST; }
+};
+
+struct ExpectSeqnosInFlight : public ExpectNumber<TCPSender, uint64_t>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "sequence_numbers_in_flight"; }
+  uint64_t value( const TCPSender& sender ) const override { return sender.sequence_numbers_in_flight(); }
+};
+
+struct ExpectConsecutiveRetransmissions : public ExpectNumber<TCPSender, uint64_t>
+{
+  using ExpectNumber::ExpectNumber;
+  std::string name() const override { return "consecutive_retransmissions"; }
+  uint64_t value( const TCPSender& sender ) const override { return sender.consecutive_retransmissions(); }
+};
+
+struct ExpectNoSegment : public Expectation<SenderAndOutput>
+{
+  std::string description() const override { return "nothing to send"; }
+  void execute( const SenderAndOutput& ss ) const override
+  {
+    if ( not ss.output.empty() ) {
+      throw ExpectationViolation { "sent unexpected message: " + to_string( ss.output.front() ) };
+    }
+  }
+  constexpr std::string obj() const override { return "TCPSender"; }
+};
+
+struct SetError : public Action<TCPSender>
+{
+  std::string description() const override { return "set_error"; }
+  void execute( TCPSender& sender ) const override { sender.writer().set_error(); }
+};
+
+struct HasError : public ExpectBool<TCPSender>
+{
+  using ExpectBool::ExpectBool;
+  std::string name() const override { return "has_error"; }
+  bool value( const TCPSender& sender ) const override { return sender.writer().has_error(); }
+};
+
+struct Push : public Action<SenderAndOutput>
+{
+  std::string data_;
+  bool close_ {};
+
+  explicit Push( std::string data = "" ) : data_( move( data ) ) {}
+  std::string description() const override
+  {
+    if ( data_.empty() and not close_ ) {
+      return "push";
+    }
+
+    if ( data_.empty() and close_ ) {
+      return "close stream, then push";
+    }
+
+    return "push \"" + pretty_print( data_ ) + "\" to stream" + ( close_ ? ", close it" : "" )
+           + ", then push to TCPSender";
+  }
+  void execute( SenderAndOutput& ss ) const override
+  {
+    if ( not data_.empty() ) {
+      ss.sender.writer().push( data_ );
+    }
+    if ( close_ ) {
+      ss.sender.writer().close();
+    }
+    ss.sender.push( ss.make_transmit() );
+  }
+
+  Push& with_close()
+  {
+    close_ = true;
+    return *this;
+  }
+
+  constexpr std::string obj() const override { return "TCPSender"; }
+};
+
+struct Tick : public Action<SenderAndOutput>
+{
+  uint64_t ms_;
+  std::optional<bool> max_retx_exceeded_ {};
+
+  explicit Tick( uint64_t ms ) : ms_( ms ) {}
+
+  Tick& with_max_retx_exceeded( bool val )
+  {
+    max_retx_exceeded_ = val;
+    return *this;
+  }
+
+  std::string description() const override
+  {
+    std::ostringstream desc;
+    desc << ms_ << " ms pass";
+    if ( max_retx_exceeded_.has_value() ) {
+      desc << ( max_retx_exceeded_.value() ? " (max # retransmissions exceeded)"
+                                           : " (max # retransmissions not exceeded)" );
+    }
+    return desc.str();
+  }
+
+  void execute( SenderAndOutput& ss ) const override
+  {
+    ss.sender.tick( ms_, ss.make_transmit() );
+    if ( max_retx_exceeded_.has_value()
+         and max_retx_exceeded_ != ( ss.sender.consecutive_retransmissions() > TCPConfig::MAX_RETX_ATTEMPTS ) ) {
+      std::ostringstream desc;
+      desc << "after " << ms_ << " ms passed the TCP Sender reported\n\tconsecutive_retransmissions = "
+           << ss.sender.consecutive_retransmissions() << "\nbut it should have been\n\t";
+      if ( max_retx_exceeded_.value() ) {
+        desc << "greater than ";
+      } else {
+        desc << "less than or equal to ";
+      }
+      desc << TCPConfig::MAX_RETX_ATTEMPTS << "\n";
+      throw ExpectationViolation( desc.str() );
+    }
+  }
+
+  constexpr std::string obj() const override { return "TCPSender"; }
+};
+
+struct Receive : public Action<SenderAndOutput>
+{
+  TCPReceiverMessage msg_;
+  bool push_ = true;
+
+  explicit Receive( TCPReceiverMessage msg ) : msg_( msg ) {}
+  std::string description() const override
+  {
+    std::ostringstream desc;
+    desc << "receive(ack=" << to_string( msg_.ackno ) << ", win=" << msg_.window_size << ")";
+    if ( push_ ) {
+      desc << ", then push";
+    }
+    return desc.str();
+  }
+
+  Receive& with_win( uint16_t win )
+  {
+    msg_.window_size = win;
+    return *this;
+  }
+
+  void execute( SenderAndOutput& ss ) const override
+  {
+    ss.sender.receive( msg_ );
+    if ( push_ ) {
+      ss.sender.push( ss.make_transmit() );
+    }
+  }
+
+  Receive& without_push()
+  {
+    push_ = false;
+    return *this;
+  }
+
+  constexpr std::string obj() const override { return "TCPSender"; }
+};
+
+struct AckReceived : public Receive
+{
+  explicit AckReceived( Wrap32 ackno ) : Receive( { ackno, DEFAULT_TEST_WINDOW } ) {}
+};
+
+struct Close : public Push
+{
+  Close() : Push( "" ) { with_close(); }
+};
+
+class MessageExpectationViolation : public ExpectationViolation
+{
+public:
+  template<typename T>
+  MessageExpectationViolation( const TCPSenderMessage& msg,
+                               const std::string& property_name,
+                               const T& expected,
+                               const T& actual )
+    : ExpectationViolation( "sent a message " + to_string( msg ) + " that should have had " + property_name + " = "
+                            + to_string( expected ) + ", but instead it was " + to_string( actual ) )
+  {}
+};
+
+struct ExpectMessage : public Expectation<SenderAndOutput>
+{
+  std::optional<bool> syn {};
+  std::optional<bool> fin {};
+  std::optional<bool> rst {};
+  std::optional<Wrap32> seqno {};
+  std::optional<std::string> data {};
+  std::optional<size_t> payload_size {};
+
+  bool empty() const { return not( syn or fin or rst or seqno or data or payload_size ); }
+
+  ExpectMessage& with_syn( bool syn_ )
+  {
+    syn = syn_;
+    return *this;
+  }
+
+  ExpectMessage& with_fin( bool fin_ )
+  {
+    fin = fin_;
+    return *this;
+  }
+
+  ExpectMessage& with_no_flags()
+  {
+    syn = fin = rst = false;
+    return *this;
+  }
+
+  ExpectMessage& with_rst( bool rst_ )
+  {
+    rst = rst_;
+    return *this;
+  }
+
+  ExpectMessage& with_seqno( Wrap32 seqno_ )
+  {
+    seqno = seqno_;
+    return *this;
+  }
+
+  ExpectMessage& with_seqno( uint32_t seqno_ ) { return with_seqno( Wrap32 { seqno_ } ); }
+
+  ExpectMessage& with_payload_size( size_t payload_size_ )
+  {
+    payload_size = payload_size_;
+    return *this;
+  }
+
+  ExpectMessage& with_data( std::string data_ )
+  {
+    data = std::move( data_ );
+    return *this;
+  }
+
+  std::string message_description() const
+  {
+    std::ostringstream o;
+    if ( seqno.has_value() ) {
+      o << " seqno=" << seqno.value();
+    }
+    if ( syn.has_value() ) {
+      o << ( syn.value() ? " +SYN" : " -SYN" );
+    }
+
+    if ( data.has_value() and data.value().size() <= 32 ) {
+      o << " payload=\"" << pretty_print( data.value(), 32 ) << "\"";
+    } else {
+      if ( payload_size.has_value() ) {
+        if ( payload_size.value() ) {
+          o << " payload_len=" << payload_size.value();
+        } else {
+          o << " (no payload)";
+        }
+      }
+      if ( data.has_value() ) {
+        o << " payload=\"" << pretty_print( data.value(), 32 ) << "\"";
+      }
+    }
+
+    if ( fin.has_value() ) {
+      o << ( fin.value() ? " +FIN" : " -FIN" );
+    }
+    if ( rst.has_value() ) {
+      o << ( rst.value() ? " +RST" : " -RST" );
+    }
+    return o.str();
+  }
+
+  std::string description() const override
+  {
+    return empty() ? "message sent" : "message sent with" + message_description();
+  }
+
+  void execute( const SenderAndOutput& ss ) const override
+  {
+    if ( payload_size.has_value() and data.has_value() and payload_size.value() != data.value().size() ) {
+      throw std::runtime_error( "inconsistent test: invalid ExpectMessage" );
+    }
+
+    const TCPSenderMessage seg = ss.expect_message();
+
+    if ( seg.payload.size() > TCPConfig::MAX_PAYLOAD_SIZE ) {
+      throw ExpectationViolation( "sent a message with a " + std::to_string( seg.payload.size() )
+                                  + "-byte payload, which is longer than the maximum ("
+                                  + std::to_string( TCPConfig::MAX_PAYLOAD_SIZE ) + ")" );
+    }
+    if ( syn.has_value() and seg.SYN != syn.value() ) {
+      throw MessageExpectationViolation( seg, "SYN flag", syn.value(), seg.SYN );
+    }
+    if ( fin.has_value() and seg.FIN != fin.value() ) {
+      throw MessageExpectationViolation( seg, "FIN flag", fin.value(), seg.FIN );
+    }
+    if ( rst.has_value() and seg.RST != rst.value() ) {
+      throw MessageExpectationViolation( seg, "RST flag", rst.value(), seg.RST );
+    }
+    if ( seqno.has_value() and seg.seqno != seqno.value() ) {
+      throw MessageExpectationViolation( seg, "sequence number", seqno.value(), seg.seqno );
+    }
+    if ( payload_size.has_value() and seg.payload.size() != payload_size.value() ) {
+      throw MessageExpectationViolation( seg, "payload size", payload_size.value(), seg.payload.size() );
+    }
+    if ( data.has_value() and data.value() != static_cast<std::string>( seg.payload ) ) {
+      throw MessageExpectationViolation( seg, "payload", data.value(), static_cast<std::string>( seg.payload ) );
+    }
+  }
+
+  constexpr std::string obj() const override { return "TCPSender"; }
+};

--- a/tests/test_should_be.hh
+++ b/tests/test_should_be.hh
@@ -52,10 +52,10 @@ inline std::string human_compare( uint64_t actual, uint64_t expected )
 {
   std::ostringstream ss;
   if ( actual > expected ) {
-    uint64_t diff = actual - expected;
+    const uint64_t diff = actual - expected;
     ss << "The actual value was too high by " << diff << human( diff ) << ".\n";
   } else {
-    uint64_t diff = expected - actual;
+    const uint64_t diff = expected - actual;
     ss << "The actual value was too low by " << diff << human( diff ) << ".\n";
   }
   return ss.str();
@@ -65,10 +65,10 @@ inline std::string human_compare( uint64_t actual, uint64_t expected )
 inline std::string human_compare( const Wrap32& actual, const Wrap32& expected )
 {
   std::ostringstream ss;
-  uint32_t actual_raw = minnow_conversions::DebugWrap32 { actual }.debug_get_raw_value();
-  uint32_t expected_raw = minnow_conversions::DebugWrap32 { expected }.debug_get_raw_value();
-  uint32_t diff_high = actual_raw - expected_raw;
-  uint32_t diff_low = expected_raw - actual_raw;
+  const uint32_t actual_raw = minnow_conversions::DebugWrap32 { actual }.debug_get_raw_value();
+  const uint32_t expected_raw = minnow_conversions::DebugWrap32 { expected }.debug_get_raw_value();
+  const uint32_t diff_high = actual_raw - expected_raw;
+  const uint32_t diff_low = expected_raw - actual_raw;
   if ( diff_high < diff_low ) {
     ss << "The Wrap32's raw value was too high by " << diff_high << human( diff_high ) << ".\n";
   } else {

--- a/tests/wrapping_integers_cmp.cc
+++ b/tests/wrapping_integers_cmp.cc
@@ -1,0 +1,36 @@
+#include "random.hh"
+#include "test_should_be.hh"
+#include "wrapping_integers.hh"
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    // Comparing low-number adjacent seqnos
+    test_should_be( Wrap32( 3 ) != Wrap32( 1 ), true );
+    test_should_be( Wrap32( 3 ) == Wrap32( 1 ), false );
+
+    constexpr size_t N_REPS = 32768;
+
+    auto rd = get_random_engine();
+
+    for ( size_t i = 0; i < N_REPS; i++ ) {
+      const uint32_t n = rd();
+      const uint8_t diff = rd();
+      const uint32_t m = n + diff;
+      test_should_be( Wrap32( n ) == Wrap32( m ), n == m );
+      test_should_be( Wrap32( n ) != Wrap32( m ), n != m );
+    }
+
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/wrapping_integers_extra.cc
+++ b/tests/wrapping_integers_extra.cc
@@ -1,0 +1,80 @@
+#include "test_should_be.hh"
+#include "wrapping_integers.hh"
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    for ( uint64_t checkpoint = 0; checkpoint < 100000; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 0UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ), 0UL );
+    }
+
+    for ( uint64_t checkpoint = 0; checkpoint < 100000; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 1UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ), 1UL );
+    }
+
+    for ( uint64_t checkpoint = UINT32_MAX - 100000UL; checkpoint < UINT32_MAX + 100000UL; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( UINT32_MAX - 1UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      UINT32_MAX - 1UL );
+    }
+
+    for ( uint64_t checkpoint = UINT32_MAX - 100000UL; checkpoint < UINT32_MAX + 100000UL; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( UINT32_MAX, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      uint64_t { UINT32_MAX } );
+    }
+
+    for ( uint64_t checkpoint = UINT32_MAX - 100000UL; checkpoint < UINT32_MAX + 100000UL; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( UINT32_MAX + 1UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      UINT32_MAX + 1UL );
+    }
+
+    for ( uint64_t checkpoint = UINT32_MAX - 100000UL; checkpoint < UINT32_MAX + 100000UL; ++checkpoint ) {
+      test_should_be( Wrap32::wrap( UINT32_MAX + 2UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      UINT32_MAX + 2UL );
+    }
+
+    for ( uint64_t checkpoint = 2UL * UINT32_MAX - 100000UL; checkpoint < 2UL * UINT32_MAX + 100000UL;
+          ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 2UL * UINT32_MAX - 1UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      2UL * UINT32_MAX - 1UL );
+    }
+
+    for ( uint64_t checkpoint = 2UL * UINT32_MAX - 100000UL; checkpoint < 2UL * UINT32_MAX + 100000UL;
+          ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 2UL * UINT32_MAX, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      2UL * UINT32_MAX );
+    }
+
+    for ( uint64_t checkpoint = 2UL * UINT32_MAX - 100000UL; checkpoint < 2UL * UINT32_MAX + 100000UL;
+          ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 2UL * UINT32_MAX + 1UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      2UL * UINT32_MAX + 1UL );
+    }
+
+    for ( uint64_t checkpoint = 2UL * UINT32_MAX - 100000UL; checkpoint < 2UL * UINT32_MAX + 100000UL;
+          ++checkpoint ) {
+      test_should_be( Wrap32::wrap( 2UL * UINT32_MAX + 2UL, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, checkpoint ),
+                      2UL * UINT32_MAX + 2UL );
+    }
+
+    for ( int64_t i = -100000; i < 100000; ++i ) {
+      test_should_be( Wrap32::wrap( UINT32_MAX + i, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, UINT32_MAX ),
+                      uint64_t( UINT32_MAX + i ) );
+    }
+
+    for ( int64_t i = -100000; i < 100000; ++i ) {
+      test_should_be( Wrap32::wrap( 2UL * UINT32_MAX + i, Wrap32 { 19 } ).unwrap( Wrap32 { 19 }, 2UL * UINT32_MAX ),
+                      2UL * UINT32_MAX + i );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/wrapping_integers_roundtrip.cc
+++ b/tests/wrapping_integers_roundtrip.cc
@@ -1,0 +1,54 @@
+#include "conversions.hh"
+#include "random.hh"
+#include "wrapping_integers.hh"
+
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+using namespace std;
+
+void check_roundtrip( const Wrap32 isn, const uint64_t value, const uint64_t checkpoint )
+{
+  if ( Wrap32::wrap( value, isn ).unwrap( isn, checkpoint ) != value ) {
+    ostringstream ss;
+
+    ss << "Expected unwrap(wrap()) to recover same value, and it didn't!\n";
+    ss << "  unwrap(wrap(value, isn), isn, checkpoint) did not equal value\n";
+    ss << "  where value = " << value << ", isn = " << isn << ", and checkpoint = " << checkpoint << "\n";
+    ss << "  (Difference between value and checkpoint is " << value - checkpoint << ".)\n";
+    throw runtime_error( ss.str() );
+  }
+}
+
+int main()
+{
+  try {
+    auto rd = get_random_engine();
+    uniform_int_distribution<uint32_t> dist31minus1 { 0, ( uint32_t { 1 } << 31 ) - 1 };
+    uniform_int_distribution<uint32_t> dist32 { 0, numeric_limits<uint32_t>::max() };
+    const uint64_t big_offset = ( uint64_t { 1 } << 31 ) - 1;
+    // credit: Ammar Ratnani
+    uniform_int_distribution<uint64_t> dist63 { big_offset, uint64_t { 1 } << 63 };
+
+    for ( unsigned int i = 0; i < 250000; i++ ) {
+      const Wrap32 isn { dist32( rd ) };
+      const uint64_t val { dist63( rd ) };
+      const uint64_t offset { dist31minus1( rd ) };
+
+      check_roundtrip( isn, val, val );
+      check_roundtrip( isn, val + 1, val );
+      check_roundtrip( isn, val - 1, val );
+      check_roundtrip( isn, val + offset, val );
+      check_roundtrip( isn, val - offset, val );
+      check_roundtrip( isn, val + big_offset, val );
+      check_roundtrip( isn, val - big_offset, val );
+    }
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/wrapping_integers_unwrap.cc
+++ b/tests/wrapping_integers_unwrap.cc
@@ -1,0 +1,43 @@
+#include "test_should_be.hh"
+#include "wrapping_integers.hh"
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    // Unwrap the first byte after ISN
+    test_should_be( Wrap32( 1 ).unwrap( Wrap32( 0 ), 0 ), 1UL );
+    // Unwrap the first byte after the first wrap
+    test_should_be( Wrap32( 1 ).unwrap( Wrap32( 0 ), UINT32_MAX ), ( 1UL << 32 ) + 1 );
+    // Unwrap the last byte before the third wrap
+    test_should_be( Wrap32( UINT32_MAX - 1 ).unwrap( Wrap32( 0 ), 3 * ( 1UL << 32 ) ), 3 * ( 1UL << 32 ) - 2 );
+    // Unwrap the 10th from last byte before the third wrap
+    test_should_be( Wrap32( UINT32_MAX - 10 ).unwrap( Wrap32( 0 ), 3 * ( 1UL << 32 ) ), 3 * ( 1UL << 32 ) - 11 );
+    // Non-zero ISN
+    test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( 10 ), 3 * ( 1UL << 32 ) ), 3 * ( 1UL << 32 ) - 11 );
+    // Big unwrap
+    test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( 0 ), 0 ), static_cast<uint64_t>( UINT32_MAX ) );
+    // Unwrap a non-zero ISN
+    test_should_be( Wrap32( 16 ).unwrap( Wrap32( 16 ), 0 ), 0UL );
+
+    // Big unwrap with non-zero ISN
+    test_should_be( Wrap32( 15 ).unwrap( Wrap32( 16 ), 0 ), static_cast<uint64_t>( UINT32_MAX ) );
+    // Big unwrap with non-zero ISN
+    test_should_be( Wrap32( 0 ).unwrap( Wrap32( INT32_MAX ), 0 ), static_cast<uint64_t>( INT32_MAX ) + 2 );
+    // Barely big unwrap with non-zero ISN
+    test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( INT32_MAX ), 0 ), static_cast<uint64_t>( 1 ) << 31 );
+    // Nearly big unwrap with non-zero ISN
+    test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( 1UL << 31 ), 0 ),
+                    static_cast<uint64_t>( UINT32_MAX ) >> 1 );
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return 1;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/wrapping_integers_unwrap.cc
+++ b/tests/wrapping_integers_unwrap.cc
@@ -34,6 +34,9 @@ int main()
     // Nearly big unwrap with non-zero ISN
     test_should_be( Wrap32( UINT32_MAX ).unwrap( Wrap32( 1UL << 31 ), 0 ),
                     static_cast<uint64_t>( UINT32_MAX ) >> 1 );
+    // Big unwrap with non-zero ISN and low non-zero checkpoint
+    // test credit: Thanawan Atchariyachanvanit
+    test_should_be( Wrap32( 0 ).unwrap( Wrap32( 1 ), 1 ), static_cast<uint64_t>( UINT32_MAX ) );
   } catch ( const exception& e ) {
     cerr << e.what() << "\n";
     return 1;

--- a/tests/wrapping_integers_wrap.cc
+++ b/tests/wrapping_integers_wrap.cc
@@ -1,0 +1,21 @@
+#include "test_should_be.hh"
+#include "wrapping_integers.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    test_should_be( Wrap32::wrap( 3 * ( 1LL << 32 ), Wrap32( 0 ) ), Wrap32( 0 ) );
+    test_should_be( Wrap32::wrap( 3 * ( 1LL << 32 ) + 17, Wrap32( 15 ) ), Wrap32( 32 ) );
+    test_should_be( Wrap32::wrap( 7 * ( 1LL << 32 ) - 2, Wrap32( 15 ) ), Wrap32( 13 ) );
+  } catch ( const exception& e ) {
+    cerr << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/util/arp_message.cc
+++ b/util/arp_message.cc
@@ -1,0 +1,81 @@
+#include "arp_message.hh"
+
+#include <arpa/inet.h>
+#include <sstream>
+
+using namespace std;
+
+bool ARPMessage::supported() const
+{
+  return hardware_type == TYPE_ETHERNET and protocol_type == EthernetHeader::TYPE_IPv4
+         and hardware_address_size == sizeof( EthernetHeader::src )
+         and protocol_address_size == sizeof( IPv4Header::src )
+         and ( ( opcode == OPCODE_REQUEST ) or ( opcode == OPCODE_REPLY ) );
+}
+
+string ARPMessage::to_string() const
+{
+  stringstream ss {};
+  string opcode_str = "(unknown type)";
+  if ( opcode == OPCODE_REQUEST ) {
+    opcode_str = "REQUEST";
+  }
+  if ( opcode == OPCODE_REPLY ) {
+    opcode_str = "REPLY";
+  }
+  ss << "opcode=" << opcode_str << ", sender=" << ::to_string( sender_ethernet_address ) << "/"
+     << inet_ntoa( { htobe32( sender_ip_address ) } ) << ", target=" << ::to_string( target_ethernet_address )
+     << "/" << inet_ntoa( { htobe32( target_ip_address ) } );
+  return ss.str();
+}
+
+void ARPMessage::parse( Parser& parser )
+{
+  parser.integer( hardware_type );
+  parser.integer( protocol_type );
+  parser.integer( hardware_address_size );
+  parser.integer( protocol_address_size );
+  parser.integer( opcode );
+
+  if ( not supported() ) {
+    parser.set_error();
+    return;
+  }
+
+  // read sender addresses (Ethernet and IP)
+  for ( auto& b : sender_ethernet_address ) {
+    parser.integer( b );
+  }
+  parser.integer( sender_ip_address );
+
+  // read target addresses (Ethernet and IP)
+  for ( auto& b : target_ethernet_address ) {
+    parser.integer( b );
+  }
+  parser.integer( target_ip_address );
+}
+
+void ARPMessage::serialize( Serializer& serializer ) const
+{
+  if ( not supported() ) {
+    throw runtime_error( "ARPMessage: unsupported field combination (must be Ethernet/IP, and request or reply)" );
+  }
+
+  serializer.integer( hardware_type );
+  serializer.integer( protocol_type );
+  serializer.integer( hardware_address_size );
+  serializer.integer( protocol_address_size );
+  serializer.integer( opcode );
+
+  // read sender addresses (Ethernet and IP)
+  for ( const auto& b : sender_ethernet_address ) {
+    serializer.integer( b );
+  }
+  serializer.integer( sender_ip_address );
+
+  // read target addresses (Ethernet and IP)
+  for ( const auto& b : target_ethernet_address ) {
+    serializer.integer( b );
+  }
+  serializer.integer( target_ip_address );
+}

--- a/util/arp_message.hh
+++ b/util/arp_message.hh
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "ethernet_header.hh"
+#include "ipv4_header.hh"
+#include "parser.hh"
+
+// [ARP](\ref rfc::rfc826) message
+struct ARPMessage
+{
+  static constexpr size_t LENGTH = 28;         // ARP message length in bytes
+  static constexpr uint16_t TYPE_ETHERNET = 1; // ARP type for Ethernet/Wi-Fi as link-layer protocol
+  static constexpr uint16_t OPCODE_REQUEST = 1;
+  static constexpr uint16_t OPCODE_REPLY = 2;
+
+  uint16_t hardware_type = TYPE_ETHERNET;             // Type of the link-layer protocol (generally Ethernet/Wi-Fi)
+  uint16_t protocol_type = EthernetHeader::TYPE_IPv4; // Type of the Internet-layer protocol (generally IPv4)
+  uint8_t hardware_address_size = sizeof( EthernetHeader::src );
+  uint8_t protocol_address_size = sizeof( IPv4Header::src );
+  uint16_t opcode {}; // Request or reply
+
+  EthernetAddress sender_ethernet_address {};
+  uint32_t sender_ip_address {};
+
+  EthernetAddress target_ethernet_address {};
+  uint32_t target_ip_address {};
+
+  // Return a string containing the ARP message in human-readable format
+  std::string to_string() const;
+
+  // Is this type of ARP message supported by the parser?
+  bool supported() const;
+
+  void parse( Parser& parser );
+  void serialize( Serializer& serializer ) const;
+};

--- a/util/checksum.hh
+++ b/util/checksum.hh
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+#include <ranges>
+
+//! The internet checksum algorithm
+class InternetChecksum
+{
+private:
+  uint32_t sum_;
+  bool parity_ {};
+
+public:
+  explicit InternetChecksum( const uint32_t sum = 0 ) : sum_( sum ) {}
+  void add( std::string_view data )
+  {
+    for ( const uint8_t i : data ) {
+      uint16_t val = i;
+      if ( not parity_ ) {
+        val <<= 8;
+      }
+      sum_ += val;
+      parity_ = !parity_;
+    }
+  }
+
+  uint16_t value() const
+  {
+    uint32_t ret = sum_;
+
+    while ( ret > 0xffff ) {
+      ret = ( ret >> 16 ) + static_cast<uint16_t>( ret );
+    }
+
+    return ~ret;
+  }
+
+  void add( std::ranges::range auto&& data )
+  {
+    for ( const auto& x : data ) {
+      add( std::string_view { x } );
+    }
+  }
+};

--- a/util/debug.cc
+++ b/util/debug.cc
@@ -10,8 +10,10 @@ void default_debug_handler( void* /*unused*/, std::string_view message )
 }
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-static void ( *debug_handler )( void*, std::string_view ) = default_debug_handler;
-static void* debug_arg = nullptr;
+namespace {
+void ( *debug_handler )( void*, std::string_view ) = default_debug_handler;
+void* debug_arg = nullptr;
+} // namespace
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 void debug_str( string_view message )

--- a/util/debug.hh
+++ b/util/debug.hh
@@ -11,7 +11,7 @@
 void debug_str( std::string_view message );
 
 template<typename... Args>
-void debug( std::format_string<Args...> fmt, Args&&... args )
+void debug( std::format_string<Args...> fmt [[maybe_unused]], Args&&... args [[maybe_unused]] )
 {
 #ifndef NDEBUG
   debug_str( format( fmt, std::forward<Args>( args )... ) );

--- a/util/debug.hh
+++ b/util/debug.hh
@@ -11,6 +11,7 @@
 void debug_str( std::string_view message );
 
 template<typename... Args>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
 void debug( std::format_string<Args...> fmt [[maybe_unused]], Args&&... args [[maybe_unused]] )
 {
 #ifndef NDEBUG
@@ -18,5 +19,5 @@ void debug( std::format_string<Args...> fmt [[maybe_unused]], Args&&... args [[m
 #endif
 }
 
-void set_debug_handler( void ( * )( void*, std::string_view ), void* arg );
+void set_debug_handler( void ( *handler )( void*, std::string_view ), void* arg );
 void reset_debug_handler();

--- a/util/ethernet_frame.hh
+++ b/util/ethernet_frame.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ethernet_header.hh"
+#include "parser.hh"
+
+#include <vector>
+
+struct EthernetFrame
+{
+  EthernetHeader header {};
+  std::vector<Ref<std::string>> payload {};
+
+  void parse( Parser& parser )
+  {
+    header.parse( parser );
+    parser.all_remaining( payload );
+  }
+
+  void serialize( Serializer& serializer ) const
+  {
+    header.serialize( serializer );
+    serializer.buffer( payload );
+  }
+};

--- a/util/ethernet_header.cc
+++ b/util/ethernet_header.cc
@@ -1,0 +1,74 @@
+#include "ethernet_header.hh"
+
+#include <iomanip>
+#include <sstream>
+
+using namespace std;
+
+//! \returns A string with a textual representation of an Ethernet address
+string to_string( const EthernetAddress address )
+{
+  stringstream ss {};
+  for ( size_t index = 0; index < address.size(); index++ ) {
+    ss.width( 2 );
+    ss << setfill( '0' ) << hex << static_cast<int>( address.at( index ) );
+    if ( index != address.size() - 1 ) {
+      ss << ":";
+    }
+  }
+  return ss.str();
+}
+
+//! \returns A string with the header's contents
+string EthernetHeader::to_string() const
+{
+  stringstream ss {};
+  ss << "dst=" << ::to_string( dst );
+  ss << " src=" << ::to_string( src );
+  ss << " type=";
+  switch ( type ) {
+    case TYPE_IPv4:
+      ss << "IPv4";
+      break;
+    case TYPE_ARP:
+      ss << "ARP";
+      break;
+    default:
+      ss << "[unknown type " << hex << type << "!]";
+      break;
+  }
+
+  return ss.str();
+}
+
+void EthernetHeader::parse( Parser& parser )
+{
+  // read destination address
+  for ( auto& b : dst ) {
+    parser.integer( b );
+  }
+
+  // read source address
+  for ( auto& b : src ) {
+    parser.integer( b );
+  }
+
+  // read frame type (e.g. IPv4, ARP, or something else)
+  parser.integer( type );
+}
+
+void EthernetHeader::serialize( Serializer& serializer ) const
+{
+  // write destination address
+  for ( const auto& b : dst ) {
+    serializer.integer( b );
+  }
+
+  // write source address
+  for ( const auto& b : src ) {
+    serializer.integer( b );
+  }
+
+  // write frame type (e.g. IPv4, ARP, or something else)
+  serializer.integer( type );
+}

--- a/util/ethernet_header.hh
+++ b/util/ethernet_header.hh
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "parser.hh"
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+// Helper type for an Ethernet address (an array of six bytes)
+using EthernetAddress = std::array<uint8_t, 6>;
+
+// Ethernet broadcast address (ff:ff:ff:ff:ff:ff)
+constexpr EthernetAddress ETHERNET_BROADCAST = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+
+// Printable representation of an EthernetAddress
+std::string to_string( EthernetAddress address );
+
+// Ethernet frame header
+struct EthernetHeader
+{
+  static constexpr uint8_t LENGTH = 14;        //!< Ethernet header length in bytes
+  static constexpr uint16_t TYPE_IPv4 = 0x800; //!< Type number for [IPv4](\ref rfc::rfc791)
+  static constexpr uint16_t TYPE_ARP = 0x806;  //!< Type number for [ARP](\ref rfc::rfc826)
+
+  EthernetAddress dst;
+  EthernetAddress src;
+  uint16_t type;
+
+  // Return a string containing a header in human-readable format
+  std::string to_string() const;
+
+  void parse( Parser& parser );
+  void serialize( Serializer& serializer ) const;
+};

--- a/util/fd_adapter.hh
+++ b/util/fd_adapter.hh
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "tcp_config.hh"
+
+//! \brief Basic functionality for file descriptor adaptors
+//! \details See TCPOverIPv4OverTunFdAdapter for more information.
+class FdAdapterBase
+{
+private:
+  FdAdapterConfig _cfg {}; //!< Configuration values
+  bool _listen = false;    //!< Is the connected TCP FSM in listen state?
+
+protected:
+  FdAdapterConfig& config_mutable() { return _cfg; }
+
+public:
+  //! \brief Set the listening flag
+  //! \param[in] l is the new value for the flag
+  void set_listening( const bool l ) { _listen = l; }
+
+  //! \brief Get the listening flag
+  //! \returns whether the FdAdapter is listening for a new connection
+  bool listening() const { return _listen; }
+
+  //! \brief Get the current configuration
+  //! \returns a const reference
+  const FdAdapterConfig& config() const { return _cfg; }
+
+  //! \brief Get the current configuration (mutable)
+  //! \returns a mutable reference
+  FdAdapterConfig& config_mut() { return _cfg; }
+
+  //! Called periodically when time elapses
+  void tick( const size_t unused [[maybe_unused]] ) {}
+};

--- a/util/helpers.cc
+++ b/util/helpers.cc
@@ -23,7 +23,7 @@ string pretty_print( string_view str, size_t max_length )
   string ret = ss.str();
   if ( truncated ) {
     if ( ret.size() >= 3 ) {
-      ret.substr( ret.size() - 3, 3 ) = "...";
+      ret.replace( ret.size() - 3, 3, "..." );
     } else {
       ret += "...";
     }

--- a/util/helpers.hh
+++ b/util/helpers.hh
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "ethernet_frame.hh"
 #include "ipv4_datagram.hh"
 #include "parser.hh"
 #include "ref.hh"
 
+#include <numeric>
 #include <ranges>
 #include <string>
 #include <vector>
@@ -46,6 +48,16 @@ std::string concat( std::ranges::range auto&& r )
 
 // Pretty-print a string (escaping unprintable characters, and with a maximum length)
 std::string pretty_print( std::string_view str, size_t max_length = 32 );
+
+// Summarize an Ethernet frame into a string
+std::string summary( const EthernetFrame& frame );
+
+// Explicitly copy ("clone") a frame or datagram
+inline EthernetFrame clone( const EthernetFrame& x )
+{
+  auto duplicate_payload = x.payload | std::views::transform( []( auto& i ) { return i.get(); } );
+  return { x.header, { duplicate_payload.begin(), duplicate_payload.end() } };
+}
 
 inline InternetDatagram clone( const InternetDatagram& x )
 {

--- a/util/helpers.hh
+++ b/util/helpers.hh
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "ipv4_datagram.hh"
 #include "parser.hh"
 #include "ref.hh"
 
-#include <numeric>
 #include <ranges>
 #include <string>
 #include <vector>
@@ -46,3 +46,9 @@ std::string concat( std::ranges::range auto&& r )
 
 // Pretty-print a string (escaping unprintable characters, and with a maximum length)
 std::string pretty_print( std::string_view str, size_t max_length = 32 );
+
+inline InternetDatagram clone( const InternetDatagram& x )
+{
+  auto duplicate_payload = x.payload | std::views::transform( []( auto& i ) { return i.get(); } );
+  return { x.header, { duplicate_payload.begin(), duplicate_payload.end() } };
+}

--- a/util/ipv4_datagram.hh
+++ b/util/ipv4_datagram.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "ipv4_header.hh"
+#include "parser.hh"
+#include "ref.hh"
+
+#include <string>
+#include <vector>
+
+//! \brief [IPv4](\ref rfc::rfc791) Internet datagram
+struct IPv4Datagram
+{
+  IPv4Header header {};
+  std::vector<Ref<std::string>> payload {};
+
+  void parse( Parser& parser )
+  {
+    header.parse( parser );
+    parser.truncate( header.payload_length() );
+    parser.all_remaining( payload );
+  }
+
+  void serialize( Serializer& serializer ) const
+  {
+    header.serialize( serializer );
+    serializer.buffer( payload );
+  }
+};
+
+using InternetDatagram = IPv4Datagram;

--- a/util/ipv4_header.cc
+++ b/util/ipv4_header.cc
@@ -1,0 +1,124 @@
+#include "ipv4_header.hh"
+#include "checksum.hh"
+
+#include <arpa/inet.h>
+#include <sstream>
+
+using namespace std;
+
+// Parse from string.
+void IPv4Header::parse( Parser& parser )
+{
+  uint8_t first_byte {};
+  parser.integer( first_byte );
+  ver = first_byte >> 4;    // version
+  hlen = first_byte & 0x0f; // header length
+  parser.integer( tos );    // type of service
+  parser.integer( len );
+  parser.integer( id );
+
+  uint16_t fo_val {};
+  parser.integer( fo_val );
+  df = static_cast<bool>( fo_val & 0x4000 ); // don't fragment
+  mf = static_cast<bool>( fo_val & 0x2000 ); // more fragments
+  offset = fo_val & 0x1fff;                  // offset
+
+  parser.integer( ttl );
+  parser.integer( proto );
+  parser.integer( cksum );
+  parser.integer( src );
+  parser.integer( dst );
+
+  if ( ver != 4 ) {
+    parser.set_error();
+  }
+
+  if ( hlen < 5 ) {
+    parser.set_error();
+  }
+
+  if ( parser.has_error() ) {
+    return;
+  }
+
+  parser.remove_prefix( static_cast<uint64_t>( hlen ) * 4 - IPv4Header::LENGTH );
+
+  // Verify checksum
+  const uint16_t given_cksum = cksum;
+  compute_checksum();
+  if ( cksum != given_cksum ) {
+    parser.set_error();
+  }
+}
+
+// Serialize the IPv4Header (does not recompute the checksum)
+void IPv4Header::serialize( Serializer& serializer ) const
+{
+  // consistency checks
+  if ( ver != 4 ) {
+    throw runtime_error( "wrong IP version" );
+  }
+
+  const uint8_t first_byte = ( static_cast<uint32_t>( ver ) << 4 ) | ( hlen & 0xfU );
+  serializer.integer( first_byte ); // version and header length
+  serializer.integer( tos );
+  serializer.integer( len );
+  serializer.integer( id );
+
+  const uint16_t fo_val = ( df ? 0x4000U : 0 ) | ( mf ? 0x2000U : 0 ) | ( offset & 0x1fffU );
+  serializer.integer( fo_val );
+
+  serializer.integer( ttl );
+  serializer.integer( proto );
+
+  serializer.integer( cksum );
+
+  serializer.integer( src );
+  serializer.integer( dst );
+}
+
+uint16_t IPv4Header::payload_length() const
+{
+  return len - 4 * hlen;
+}
+
+//! \details This value is needed when computing the checksum of an encapsulated TCP segment.
+//! ~~~{.txt}
+//!   0      7 8     15 16    23 24    31
+//!  +--------+--------+--------+--------+
+//!  |          source address           |
+//!  +--------+--------+--------+--------+
+//!  |        destination address        |
+//!  +--------+--------+--------+--------+
+//!  |  zero  |protocol|  payload length |
+//!  +--------+--------+--------+--------+
+//! ~~~
+uint32_t IPv4Header::pseudo_checksum() const
+{
+  uint32_t pcksum = ( src >> 16 ) + static_cast<uint16_t>( src ); // source addr
+  pcksum += ( dst >> 16 ) + static_cast<uint16_t>( dst );
+  pcksum += proto;            // protocol
+  pcksum += payload_length(); // payload length
+  return pcksum;
+}
+
+void IPv4Header::compute_checksum()
+{
+  cksum = 0;
+  Serializer s;
+  serialize( s );
+
+  // calculate checksum -- taken over header only
+  InternetChecksum check;
+  check.add( s.finish() );
+  cksum = check.value();
+}
+
+string IPv4Header::to_string() const
+{
+  stringstream ss {};
+  ss << hex << boolalpha << "IPv" << +ver << " len=" << dec << +len << " proto=" << +proto
+     << " ttl=" + ::to_string( ttl ) << " src=" << inet_ntoa( { htobe32( src ) } )
+     << " dst=" << inet_ntoa( { htobe32( dst ) } );
+  return ss.str();
+}

--- a/util/ipv4_header.hh
+++ b/util/ipv4_header.hh
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "parser.hh"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+// IPv4 Internet datagram header (note: IP options are not supported)
+struct IPv4Header
+{
+  static constexpr uint8_t LENGTH = 20;       // IPv4 header length, not including options
+  static constexpr uint8_t DEFAULT_TTL = 128; // A reasonable default TTL value
+  static constexpr uint8_t PROTO_TCP = 6;     // Protocol number for TCP
+
+  static constexpr uint64_t serialized_length() { return LENGTH; }
+
+  /*
+   *   0                   1                   2                   3
+   *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |Version|  IHL  |Type of Service|          Total Length         |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |         Identification        |Flags|      Fragment Offset    |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |  Time to Live |    Protocol   |         Header Checksum       |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |                       Source Address                          |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |                    Destination Address                        |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   *  |                    Options                    |    Padding    |
+   *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   */
+
+  // IPv4 Header fields
+  uint8_t ver = 4;           // IP version
+  uint8_t hlen = LENGTH / 4; // header length (multiples of 32 bits)
+  uint8_t tos = 0;           // type of service
+  uint16_t len = 0;          // total length of packet
+  uint16_t id = 0;           // identification number
+  bool df = true;            // don't fragment flag
+  bool mf = false;           // more fragments flag
+  uint16_t offset = 0;       // fragment offset field
+  uint8_t ttl = DEFAULT_TTL; // time to live field
+  uint8_t proto = PROTO_TCP; // protocol field
+  uint16_t cksum = 0;        // checksum field
+  uint32_t src = 0;          // src address
+  uint32_t dst = 0;          // dst address
+
+  // Length of the payload
+  uint16_t payload_length() const;
+
+  // Pseudo-header's contribution to the TCP checksum
+  uint32_t pseudo_checksum() const;
+
+  // Set checksum to correct value
+  void compute_checksum();
+
+  // Return a string containing a header in human-readable format
+  std::string to_string() const;
+
+  void parse( Parser& parser );
+  void serialize( Serializer& serializer ) const;
+};

--- a/util/lossy_fd_adapter.hh
+++ b/util/lossy_fd_adapter.hh
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "file_descriptor.hh"
+#include "random.hh"
+#include "tcp_config.hh"
+#include "tcp_segment.hh"
+
+#include <optional>
+#include <random>
+#include <utility>
+
+//! An adapter class that adds random dropping behavior to an FD adapter
+template<typename AdapterT>
+class LossyFdAdapter
+{
+private:
+  //! Fast RNG used by _should_drop()
+  std::default_random_engine _rand { get_random_engine() };
+
+  //! The underlying FD adapter
+  AdapterT _adapter;
+
+  //! \brief Determine whether or not to drop a given read or write
+  //! \param[in] uplink is `true` to use the uplink loss probability, else use the downlink loss probability
+  //! \returns `true` if the segment should be dropped
+  bool _should_drop( bool uplink )
+  {
+    const auto& cfg = _adapter.config();
+    const uint16_t loss = uplink ? cfg.loss_rate_up : cfg.loss_rate_dn;
+    return loss != 0 && static_cast<uint16_t>( _rand() ) < loss;
+  }
+
+public:
+  //! Conversion to a FileDescriptor by returning the underlying AdapterT
+  FileDescriptor& fd() { return _adapter.fd(); }
+
+  //! Construct from a FileDescriptor appropriate to the AdapterT constructor
+  explicit LossyFdAdapter( AdapterT&& adapter ) : _adapter( std::move( adapter ) ) {}
+
+  //! \brief Read from the underlying AdapterT instance, potentially dropping the read datagram
+  //! \returns std::optional<TCPSegment> that is empty if the segment was dropped or if
+  //!          the underlying AdapterT returned an empty value
+  std::optional<TCPMessage> read()
+  {
+    auto ret = _adapter.read();
+    if ( _should_drop( false ) ) {
+      return {};
+    }
+    return ret;
+  }
+
+  //! \brief Write to the underlying AdapterT instance, potentially dropping the datagram to be written
+  //! \param[in] seg is the packet to either write or drop
+  void write( const TCPMessage& seg )
+  {
+    if ( _should_drop( true ) ) {
+      return;
+    }
+    return _adapter.write( seg );
+  }
+
+  //! \name
+  //! Passthrough functions to the underlying AdapterT instance
+
+  void set_listening( const bool l ) { _adapter.set_listening( l ); } //!< FdAdapterBase::set_listening passthrough
+  const FdAdapterConfig& config() const { return _adapter.config(); } //!< FdAdapterBase::config passthrough
+  FdAdapterConfig& config_mut() { return _adapter.config_mut(); }     //!< FdAdapterBase::config_mut passthrough
+  void tick( const size_t ms_since_last_tick ) { _adapter.tick( ms_since_last_tick ); }
+};

--- a/util/parser.cc
+++ b/util/parser.cc
@@ -1,0 +1,168 @@
+#include "parser.hh"
+
+#include <cassert>
+#include <string>
+
+using namespace std;
+
+string_view Parser::BufferList::peek() const
+{
+  if ( buffer_.empty() ) {
+    throw runtime_error( "peek on empty BufferList" );
+  }
+  return string_view { buffer_.front().get() }.substr( skip_ );
+}
+
+void Parser::BufferList::remove_prefix( uint64_t len )
+{
+  while ( len and not buffer_.empty() ) {
+    const uint64_t to_pop_now = min( len, peek().size() );
+    skip_ += to_pop_now;
+    len -= to_pop_now;
+    size_ -= to_pop_now;
+    if ( skip_ == buffer_.front()->size() ) {
+      buffer_.pop_front();
+      skip_ = 0;
+    }
+  }
+}
+
+void Parser::BufferList::truncate( size_t len )
+{
+  if ( size_ <= len ) {
+    return;
+  }
+
+  if ( len == 0 ) {
+    buffer_.clear();
+    size_ = 0;
+    return;
+  }
+
+  size_t size_so_far = 0;
+  auto it = buffer_.begin();
+  while ( it != buffer_.end() ) {
+    if ( size_so_far + it->get().size() < len ) {
+      size_so_far += it->get().size();
+      ++it;
+      continue;
+    }
+
+    if ( size_so_far + it->get().size() == len ) {
+      ++it;
+      break;
+    }
+
+    assert( !it->get().empty() );
+    assert( len > size_so_far );
+    assert( len - size_so_far < it->get().size() );
+    it->get_mut().resize( len - size_so_far );
+    break;
+  }
+
+  while ( it != buffer_.end() ) {
+    it = buffer_.erase( it );
+  }
+
+  size_ = len;
+}
+
+void Parser::BufferList::dump_all( vector<Ref<std::string>>& out )
+{
+  out.clear();
+  if ( empty() ) {
+    return;
+  }
+  if ( skip_ ) {
+    out.emplace_back( buffer_.front()->substr( skip_ ) );
+  } else {
+    out.push_back( move( buffer_.front() ) );
+  }
+  buffer_.pop_front();
+  for ( auto&& x : buffer_ ) {
+    out.emplace_back( move( x ) );
+  }
+}
+
+vector<string_view> Parser::BufferList::buffer() const
+{
+  if ( empty() ) {
+    return {};
+  }
+  vector<string_view> ret;
+  ret.reserve( buffer_segment_count() );
+  auto tmp_skip = skip_;
+  for ( const auto& x : buffer_ ) {
+    ret.push_back( string_view { x.get() }.substr( tmp_skip ) );
+    tmp_skip = 0;
+  }
+  return ret;
+}
+
+void Parser::string( span<char> out )
+{
+  check_size( out.size() );
+  if ( has_error() ) {
+    return;
+  }
+
+  auto next = out.begin();
+  while ( next != out.end() ) {
+    const auto view = input_.peek().substr( 0, out.end() - next );
+    next = copy( view.begin(), view.end(), next );
+    input_.remove_prefix( view.size() );
+  }
+}
+
+void Parser::concatenate_all_remaining( std::string& out )
+{
+  vector<Ref<std::string>> concat;
+  all_remaining( concat );
+  if ( concat.empty() ) {
+    out.clear();
+    return;
+  }
+  out = concat.front().release();
+  if ( concat.size() > 1 ) {
+    for ( auto it = concat.begin() + 1; it != concat.end(); ++it ) {
+      out.append( *it );
+    }
+  }
+}
+
+void Serializer::flush()
+{
+  if ( not buffer_.empty() ) {
+    output_.emplace_back( move( buffer_ ) );
+    buffer_.clear();
+  }
+}
+
+void Serializer::buffer( string buf )
+{
+  if ( not buf.empty() ) {
+    flush();
+    output_.emplace_back( move( buf ) );
+  }
+}
+
+void Serializer::buffer( Ref<string> buf )
+{
+  if ( not buf.get().empty() ) {
+    flush();
+    output_.emplace_back( move( buf ) );
+  }
+}
+
+void Serializer::buffer( const vector<Ref<string>>& bufs )
+{
+  for ( const auto& b : bufs ) {
+    buffer( b.borrow() );
+  }
+}
+
+vector<Ref<string>> Serializer::finish()
+{
+  flush();
+  return move( output_ );
+}

--- a/util/ref.hh
+++ b/util/ref.hh
@@ -57,6 +57,7 @@ public:
       obj_ = other.get();
       borrowed_obj_ = nullptr;
     }
+    return *this;
   }
 #else
   // forbid implicit copies

--- a/util/tcp_config.hh
+++ b/util/tcp_config.hh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "address.hh"
+#include "wrapping_integers.hh"
+
+#include <cstddef>
+#include <cstdint>
+
+//! Config for TCP sender and receiver
+class TCPConfig
+{
+public:
+  static constexpr size_t DEFAULT_CAPACITY = 64000; //!< Default capacity
+  static constexpr size_t MAX_PAYLOAD_SIZE = 1000;  //!< Conservative max payload size for real Internet
+  static constexpr uint16_t TIMEOUT_DFLT = 1000;    //!< Default re-transmit timeout is 1 second
+  static constexpr unsigned MAX_RETX_ATTEMPTS = 8;  //!< Maximum re-transmit attempts before giving up
+
+  uint16_t rt_timeout = TIMEOUT_DFLT;      //!< Initial value of the retransmission timeout, in milliseconds
+  size_t recv_capacity = DEFAULT_CAPACITY; //!< Receive capacity, in bytes
+  size_t send_capacity = DEFAULT_CAPACITY; //!< Sender capacity, in bytes
+  Wrap32 isn { 137 };                      //!< Default initial sequence number
+};
+
+//! Config for classes derived from FdAdapter
+class FdAdapterConfig
+{
+public:
+  Address source { "0", 0 };      //!< Source address and port
+  Address destination { "0", 0 }; //!< Destination address and port
+
+  uint16_t loss_rate_dn = 0; //!< Downlink loss rate (for LossyFdAdapter)
+  uint16_t loss_rate_up = 0; //!< Uplink loss rate (for LossyFdAdapter)
+};

--- a/util/tcp_minnow_socket.hh
+++ b/util/tcp_minnow_socket.hh
@@ -1,0 +1,137 @@
+#pragma once
+
+#include "eventloop.hh"
+#include "file_descriptor.hh"
+#include "socket.hh"
+#include "tcp_config.hh"
+#include "tcp_peer.hh"
+#include "tuntap_adapter.hh"
+
+#include <atomic>
+#include <cstdint>
+#include <optional>
+#include <thread>
+
+//! Multithreaded wrapper around TCPPeer that approximates the Unix sockets API
+template<TCPDatagramAdapter AdaptT>
+class TCPMinnowSocket : public LocalStreamSocket
+{
+public:
+  //! Construct from the interface that the TCPPeer thread will use to read and write datagrams
+  explicit TCPMinnowSocket( AdaptT&& datagram_interface );
+
+  //! Close socket, and wait for TCPPeer to finish
+  //! \note Calling this function is only advisable if the socket has reached EOF,
+  //! or else may wait foreever for remote peer to close the TCP connection.
+  void wait_until_closed();
+
+  //! Connect using the specified configurations; blocks until connect succeeds or fails
+  void connect( const TCPConfig& c_tcp, const FdAdapterConfig& c_ad );
+
+  //! Listen and accept using the specified configurations; blocks until accept succeeds or fails
+  void listen_and_accept( const TCPConfig& c_tcp, const FdAdapterConfig& c_ad );
+
+  //! When a connected socket is destructed, it will send a RST
+  ~TCPMinnowSocket();
+
+  //! \name
+  //! This object cannot be safely moved or copied, since it is in use by two threads simultaneously
+
+  //!@{
+  TCPMinnowSocket( const TCPMinnowSocket& ) = delete;
+  TCPMinnowSocket( TCPMinnowSocket&& ) = delete;
+  TCPMinnowSocket& operator=( const TCPMinnowSocket& ) = delete;
+  TCPMinnowSocket& operator=( TCPMinnowSocket&& ) = delete;
+  //!@}
+
+  //! \name
+  //! Some methods of the parent Socket wouldn't work as expected on the TCP socket, so delete them
+
+  //!@{
+  void bind( const Address& address ) = delete;
+  Address local_address() const = delete;
+  void set_reuseaddr() = delete;
+  //!@}
+
+  // Return peer address from underlying datagram adapter
+  const Address& peer_address() const { return _datagram_adapter.config().destination; }
+
+protected:
+  //! Adapter to underlying datagram socket (e.g., UDP or IP)
+  AdaptT _datagram_adapter;
+
+private:
+  //! Stream socket for reads and writes between owner and TCP thread
+  LocalStreamSocket _thread_data;
+
+  //! Set up the TCPPeer and the event loop
+  void _initialize_TCP( const TCPConfig& config );
+
+  //! TCP state machine
+  std::optional<TCPPeer> _tcp {};
+
+  //! eventloop that handles all the events (new inbound datagram, new outbound bytes, new inbound bytes)
+  EventLoop _eventloop {};
+
+  //! Process events while specified condition is true
+  void _tcp_loop( const std::function<bool()>& condition );
+
+  //! Main loop of TCPPeer thread
+  void _tcp_main();
+
+  //! Handle to the TCPPeer thread; owner thread calls join() in the destructor
+  std::thread _tcp_thread {};
+
+  //! Construct LocalStreamSocket fds from socket pair, initialize eventloop
+  TCPMinnowSocket( std::pair<FileDescriptor, FileDescriptor> data_socket_pair, AdaptT&& datagram_interface );
+
+  std::atomic_bool _abort { false }; //!< Flag used by the owner to force the TCPPeer thread to shut down
+
+  bool _inbound_shutdown { false }; //!< Has TCPMinnowSocket shut down the incoming data to the owner?
+
+  bool _outbound_shutdown { false }; //!< Has the owner shut down the outbound data to the TCP connection?
+
+  bool _fully_acked { false }; //!< Has the outbound data been fully acknowledged by the peer?
+};
+
+using TCPOverIPv4MinnowSocket = TCPMinnowSocket<TCPOverIPv4OverTunFdAdapter>;
+using LossyTCPOverIPv4MinnowSocket = TCPMinnowSocket<LossyFdAdapter<TCPOverIPv4OverTunFdAdapter>>;
+
+//! \class TCPMinnowSocket
+//! This class involves the simultaneous operation of two threads.
+//!
+//! One, the "owner" or foreground thread, interacts with this class in much the
+//! same way as one would interact with a TCPSocket: it connects or listens, writes to
+//! and reads from a reliable data stream, etc. Only the owner thread calls public
+//! methods of this class.
+//!
+//! The other, the "TCPPeer" thread, takes care of the back-end tasks that the kernel would
+//! perform for a TCPSocket: reading and parsing datagrams from the wire, filtering out
+//! segments unrelated to the connection, etc.
+//!
+//! There are a few notable differences between the TCPMinnowSocket and TCPSocket interfaces:
+//!
+//! - a TCPMinnowSocket can only accept a single connection
+//! - listen_and_accept() is a blocking function call that acts as both [listen(2)](\ref man2::listen)
+//!   and [accept(2)](\ref man2::accept)
+//! - if TCPMinnowSocket is destructed while a TCP connection is open, the connection is
+//!   immediately terminated with a RST (call `wait_until_closed` to avoid this)
+
+//! Helper class that makes a TCPOverIPv4MinnowSocket behave more like a (kernel) TCPSocket
+class CS144TCPSocket : public TCPOverIPv4MinnowSocket
+{
+public:
+  CS144TCPSocket() : TCPOverIPv4MinnowSocket( TCPOverIPv4OverTunFdAdapter { TunFD { "tun144" } } ) {}
+  void connect( const Address& address )
+  {
+    TCPConfig tcp_config;
+    tcp_config.rt_timeout = 100;
+
+    FdAdapterConfig multiplexer_config;
+    multiplexer_config.source
+      = { "169.254.144.9", std::to_string( static_cast<uint16_t>( std::random_device()() ) ) };
+    multiplexer_config.destination = address;
+
+    TCPOverIPv4MinnowSocket::connect( tcp_config, multiplexer_config );
+  }
+};

--- a/util/tcp_minnow_socket_impl.hh
+++ b/util/tcp_minnow_socket_impl.hh
@@ -1,0 +1,289 @@
+#include "tcp_minnow_socket.hh"
+
+#include "exception.hh"
+
+#include <cstddef>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <utility>
+
+static constexpr size_t TCP_TICK_MS = 10;
+
+inline uint64_t timestamp_ms()
+{
+  static_assert( std::is_same_v<std::chrono::steady_clock::duration, std::chrono::nanoseconds> );
+
+  return std::chrono::steady_clock::now().time_since_epoch().count() / 1000000;
+}
+
+//! \param[in] condition is a function returning true if loop should continue
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::_tcp_loop( const std::function<bool()>& condition )
+{
+  auto base_time = timestamp_ms();
+  while ( condition() ) {
+    auto ret = _eventloop.wait_next_event( TCP_TICK_MS );
+    if ( ret == EventLoop::Result::Exit or _abort ) {
+      break;
+    }
+
+    if ( not _tcp.has_value() ) {
+      throw std::runtime_error( "_tcp_loop entered before TCPPeer initialized" );
+    }
+
+    if ( _tcp.value().active() ) {
+      const auto next_time = timestamp_ms();
+      _tcp.value().tick( next_time - base_time, [&]( auto x ) { _datagram_adapter.write( x ); } );
+      _datagram_adapter.tick( next_time - base_time );
+      base_time = next_time;
+    }
+  }
+}
+
+//! \param[in] data_socket_pair is a pair of connected AF_UNIX SOCK_STREAM sockets
+//! \param[in] datagram_interface is the interface for reading and writing datagrams
+template<TCPDatagramAdapter AdaptT>
+TCPMinnowSocket<AdaptT>::TCPMinnowSocket( std::pair<FileDescriptor, FileDescriptor> data_socket_pair,
+                                          AdaptT&& datagram_interface )
+  : LocalStreamSocket( std::move( data_socket_pair.first ) )
+  , _datagram_adapter( std::move( datagram_interface ) )
+  , _thread_data( std::move( data_socket_pair.second ) )
+{
+  _thread_data.set_blocking( false );
+  set_blocking( false );
+}
+
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::_initialize_TCP( const TCPConfig& config )
+{
+  _tcp.emplace( config );
+
+  // Set up the event loop
+
+  // There are three events to handle:
+  //
+  // 1) Incoming datagram received (needs to be given to TCPPeer::receive method)
+  //
+  // 2) Outbound bytes received from local application via a write()
+  //    call (needs to be read from the local stream socket and
+  //    given to TCPPeer)
+  //
+  // 3) Incoming bytes reassembled by the Reassembler
+  //    (needs to be read from the inbound_stream and written
+  //    to the local stream socket back to the application)
+
+  // rule 1: read from filtered packet stream and dump into TCPConnection
+  _eventloop.add_rule(
+    "receive TCP segment from the network",
+    _datagram_adapter.fd(),
+    Direction::In,
+    [&] {
+      if ( auto seg = _datagram_adapter.read() ) {
+        _tcp->receive( std::move( seg.value() ), [&]( auto x ) { _datagram_adapter.write( x ); } );
+      }
+
+      // debugging output:
+      if ( _thread_data.eof() and _tcp.value().sender().sequence_numbers_in_flight() == 0 and not _fully_acked ) {
+        std::cerr << "DEBUG: minnow outbound stream to " << _datagram_adapter.config().destination.to_string()
+                  << " has been fully acknowledged.\n";
+        _fully_acked = true;
+      }
+    },
+    [&] { return _tcp->active(); } );
+
+  // rule 2: read from pipe into outbound buffer
+  _eventloop.add_rule(
+    "push bytes to TCPPeer",
+    _thread_data,
+    Direction::In,
+    [&] {
+      std::string data;
+      data.resize( _tcp->outbound_writer().available_capacity() );
+      _thread_data.read( data );
+      _tcp->outbound_writer().push( move( data ) );
+
+      if ( _thread_data.eof() ) {
+        _tcp->outbound_writer().close();
+        _outbound_shutdown = true;
+
+        // debugging output:
+        std::cerr << "DEBUG: minnow outbound stream to " << _datagram_adapter.config().destination.to_string()
+                  << " finished (" << _tcp.value().sender().sequence_numbers_in_flight() << " seqno"
+                  << ( _tcp.value().sender().sequence_numbers_in_flight() == 1 ? "" : "s" )
+                  << " still in flight).\n";
+      }
+
+      _tcp->push( [&]( auto x ) { _datagram_adapter.write( x ); } );
+    },
+    [&] {
+      return ( _tcp->active() ) and ( not _outbound_shutdown )
+             and ( _tcp->outbound_writer().available_capacity() > 0 );
+    },
+    [&] {
+      _tcp->outbound_writer().close();
+      _outbound_shutdown = true;
+    },
+    [&] {
+      std::cerr << "DEBUG: minnow outbound stream had error.\n";
+      _tcp->outbound_writer().set_error();
+    } );
+
+  // rule 3: read from inbound buffer into pipe
+  _eventloop.add_rule(
+    "read bytes from inbound stream",
+    _thread_data,
+    Direction::Out,
+    [&] {
+      Reader& inbound = _tcp->inbound_reader();
+      // Write from the inbound_stream into
+      // the pipe, handling the possibility of a partial
+      // write (i.e., only pop what was actually written).
+      if ( inbound.bytes_buffered() ) {
+        const std::string_view buffer = inbound.peek();
+        const auto bytes_written = _thread_data.write( buffer );
+        inbound.pop( bytes_written );
+      }
+
+      if ( inbound.is_finished() or inbound.has_error() ) {
+        _thread_data.shutdown( SHUT_WR );
+        _inbound_shutdown = true;
+
+        // debugging output:
+        std::cerr << "DEBUG: minnow inbound stream from " << _datagram_adapter.config().destination.to_string()
+                  << " finished " << ( inbound.has_error() ? "uncleanly.\n" : "cleanly.\n" );
+      }
+    },
+    [&] {
+      return _tcp->inbound_reader().bytes_buffered()
+             or ( ( _tcp->inbound_reader().is_finished() or _tcp->inbound_reader().has_error() )
+                  and not _inbound_shutdown );
+    },
+    [&] {},
+    [&] {
+      std::cerr << "DEBUG: minnow inbound stream had error.\n";
+      _tcp->inbound_reader().set_error();
+    } );
+}
+
+//! \brief Call [socketpair](\ref man2::socketpair) and return connected Unix-domain sockets of specified type
+//! \param[in] type is the type of AF_UNIX sockets to create (e.g., SOCK_SEQPACKET)
+//! \returns a std::pair of connected sockets
+template<std::derived_from<Socket> SocketType>
+inline std::pair<SocketType, SocketType> socket_pair_helper( int domain, int type, int protocol = 0 )
+{
+  std::array<int, 2> fds {};
+  CheckSystemCall( "socketpair", ::socketpair( domain, type, protocol, fds.data() ) );
+  return { SocketType { FileDescriptor { fds[0] } }, SocketType { FileDescriptor { fds[1] } } };
+}
+
+//! \param[in] datagram_interface is the underlying interface (e.g. to UDP, IP, or Ethernet)
+template<TCPDatagramAdapter AdaptT>
+TCPMinnowSocket<AdaptT>::TCPMinnowSocket( AdaptT&& datagram_interface )
+  : TCPMinnowSocket( socket_pair_helper<LocalStreamSocket>( AF_UNIX, SOCK_STREAM ),
+                     std::move( datagram_interface ) )
+{}
+
+template<TCPDatagramAdapter AdaptT>
+TCPMinnowSocket<AdaptT>::~TCPMinnowSocket()
+{
+  try {
+    if ( _tcp_thread.joinable() ) {
+      std::cerr << "Warning: unclean shutdown of TCPMinnowSocket\n";
+      // force the other side to exit
+      _abort.store( true );
+      _tcp_thread.join();
+    }
+  } catch ( const std::exception& e ) {
+    std::cerr << "Exception destructing TCPMinnowSocket: " << e.what() << "\n";
+  }
+}
+
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::wait_until_closed()
+{
+  shutdown( SHUT_RDWR );
+  if ( _tcp_thread.joinable() ) {
+    std::cerr << "DEBUG: minnow waiting for clean shutdown... ";
+    _tcp_thread.join();
+    std::cerr << "done.\n";
+  }
+}
+
+//! \param[in] c_tcp is the TCPConfig for the TCPConnection
+//! \param[in] c_ad is the FdAdapterConfig for the FdAdapter
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::connect( const TCPConfig& c_tcp, const FdAdapterConfig& c_ad )
+{
+  if ( _tcp ) {
+    throw std::runtime_error( "connect() with TCPConnection already initialized" );
+  }
+
+  _initialize_TCP( c_tcp );
+
+  _datagram_adapter.config_mut() = c_ad;
+
+  std::cerr << "DEBUG: minnow connecting to " << c_ad.destination.to_string() << "...\n";
+
+  if ( not _tcp.has_value() ) {
+    throw std::runtime_error( "TCPPeer not successfully initialized" );
+  }
+
+  _tcp->push( [&]( auto x ) { _datagram_adapter.write( x ); } );
+
+  if ( _tcp->sender().sequence_numbers_in_flight() != 1 ) {
+    throw std::runtime_error( "After TCPConnection::connect(), expected sequence_numbers_in_flight() == 1" );
+  }
+
+  _tcp_loop( [&] { return _tcp->sender().sequence_numbers_in_flight() == 1; } );
+  if ( _tcp->inbound_reader().has_error() ) {
+    std::cerr << "DEBUG: minnow error on connecting to " << c_ad.destination.to_string() << ".\n";
+  } else {
+    std::cerr << "DEBUG: minnow successfully connected to " << c_ad.destination.to_string() << ".\n";
+  }
+
+  _tcp_thread = std::thread( &TCPMinnowSocket::_tcp_main, this );
+}
+
+//! \param[in] c_tcp is the TCPConfig for the TCPConnection
+//! \param[in] c_ad is the FdAdapterConfig for the FdAdapter
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::listen_and_accept( const TCPConfig& c_tcp, const FdAdapterConfig& c_ad )
+{
+  if ( _tcp ) {
+    throw std::runtime_error( "listen_and_accept() with TCPConnection already initialized" );
+  }
+
+  _initialize_TCP( c_tcp );
+
+  _datagram_adapter.config_mut() = c_ad;
+  _datagram_adapter.set_listening( true );
+
+  std::cerr << "DEBUG: minnow listening for incoming connection...\n";
+  _tcp_loop( [&] { return ( not _tcp->has_ackno() ) or ( _tcp->sender().sequence_numbers_in_flight() ); } );
+  std::cerr << "DEBUG: minnow new connection from " << _datagram_adapter.config().destination.to_string() << ".\n";
+
+  _tcp_thread = std::thread( &TCPMinnowSocket::_tcp_main, this );
+}
+
+template<TCPDatagramAdapter AdaptT>
+void TCPMinnowSocket<AdaptT>::_tcp_main()
+{
+  try {
+    if ( not _tcp.has_value() ) {
+      throw std::runtime_error( "no TCP" );
+    }
+    _tcp_loop( [] { return true; } );
+    shutdown( SHUT_RDWR );
+    if ( not _tcp.value().active() ) {
+      std::cerr << "DEBUG: minnow TCP connection finished "
+                << ( _tcp->inbound_reader().has_error() ? "uncleanly.\n" : "cleanly.\n" );
+    }
+    _tcp.reset();
+  } catch ( const std::exception& e ) {
+    std::cerr << "Exception in TCPConnection runner thread: " << e.what() << "\n";
+    throw e;
+  }
+}

--- a/util/tcp_over_ip.cc
+++ b/util/tcp_over_ip.cc
@@ -1,0 +1,96 @@
+#include "tcp_over_ip.hh"
+
+#include "helpers.hh"
+#include "ipv4_datagram.hh"
+#include "ipv4_header.hh"
+
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <utility>
+
+using namespace std;
+
+//! \details This function attempts to parse a TCP segment from
+//! the IP datagram's payload.
+//!
+//! If this succeeds, it then checks that the received segment is related to the
+//! current connection. When a TCP connection has been established, this means
+//! checking that the source and destination ports in the TCP header are correct.
+//!
+//! If the TCP connection is listening (i.e., TCPOverIPv4OverTunFdAdapter::_listen is `true`)
+//! and the TCP segment read from the wire includes a SYN, this function clears the
+//! `_listen` flag and records the source and destination addresses and port numbers
+//! from the TCP header; it uses this information to filter future reads.
+//! \returns a std::optional<TCPSegment> that is empty if the segment was invalid or unrelated
+optional<TCPMessage> TCPOverIPv4Adapter::unwrap_tcp_in_ip( InternetDatagram ip_dgram )
+{
+  // is the IPv4 datagram for us?
+  // Note: it's valid to bind to address "0" (INADDR_ANY) and reply from actual address contacted
+  if ( not listening() and ( ip_dgram.header.dst != config().source.ipv4_numeric() ) ) {
+    return {};
+  }
+
+  // is the IPv4 datagram from our peer?
+  if ( not listening() and ( ip_dgram.header.src != config().destination.ipv4_numeric() ) ) {
+    return {};
+  }
+
+  // does the IPv4 datagram claim that its payload is a TCP segment?
+  if ( ip_dgram.header.proto != IPv4Header::PROTO_TCP ) {
+    return {};
+  }
+
+  // is the payload a valid TCP segment?
+  TCPSegment tcp_seg;
+  if ( not parse( tcp_seg, move( ip_dgram.payload ), ip_dgram.header.pseudo_checksum() ) ) {
+    return {};
+  }
+
+  // is the TCP segment for us?
+  if ( tcp_seg.udinfo.dst_port != config().source.port() ) {
+    return {};
+  }
+
+  // should we target this source addr/port (and use its destination addr as our source) in reply?
+  if ( listening() ) {
+    if ( tcp_seg.message.sender->SYN and not tcp_seg.message.sender->RST ) {
+      config_mutable().source = Address { inet_ntoa( { htobe32( ip_dgram.header.dst ) } ), config().source.port() };
+      config_mutable().destination
+        = Address { inet_ntoa( { htobe32( ip_dgram.header.src ) } ), tcp_seg.udinfo.src_port };
+      set_listening( false );
+    } else {
+      return {};
+    }
+  }
+
+  // is the TCP segment from our peer?
+  if ( tcp_seg.udinfo.src_port != config().destination.port() ) {
+    return {};
+  }
+
+  return move( tcp_seg.message );
+}
+
+//! Takes a TCP segment, sets port numbers as necessary, and wraps it in an IPv4 datagram
+//! \param[in] seg is the TCP segment to convert
+InternetDatagram TCPOverIPv4Adapter::wrap_tcp_in_ip( const TCPMessage& msg )
+{
+  const size_t payload_size = msg.sender->payload.size();
+  TCPSegment seg { .message = { msg.sender.borrow(), msg.receiver.borrow() } };
+  // set the port numbers in the TCP segment
+  seg.udinfo.src_port = config().source.port();
+  seg.udinfo.dst_port = config().destination.port();
+
+  // create an Internet Datagram and set its addresses and length
+  InternetDatagram ip_dgram;
+  ip_dgram.header.src = config().source.ipv4_numeric();
+  ip_dgram.header.dst = config().destination.ipv4_numeric();
+  ip_dgram.header.len = ip_dgram.header.hlen * 4 + 20 /* tcp header len */ + payload_size;
+
+  // set payload, calculating TCP checksum using information from IP header
+  seg.compute_checksum( ip_dgram.header.pseudo_checksum() );
+  ip_dgram.header.compute_checksum();
+  ip_dgram.payload = serialize( seg );
+
+  return ip_dgram;
+}

--- a/util/tcp_over_ip.hh
+++ b/util/tcp_over_ip.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "fd_adapter.hh"
+#include "ipv4_datagram.hh"
+#include "tcp_segment.hh"
+
+#include <optional>
+
+//! \brief A converter from TCP segments to serialized IPv4 datagrams
+class TCPOverIPv4Adapter : public FdAdapterBase
+{
+public:
+  std::optional<TCPMessage> unwrap_tcp_in_ip( InternetDatagram ip_dgram );
+
+  InternetDatagram wrap_tcp_in_ip( const TCPMessage& msg );
+};

--- a/util/tcp_peer.hh
+++ b/util/tcp_peer.hh
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "tcp_config.hh"
+#include "tcp_receiver.hh"
+#include "tcp_receiver_message.hh"
+#include "tcp_segment.hh"
+#include "tcp_sender.hh"
+#include "tcp_sender_message.hh"
+
+#include <functional>
+#include <optional>
+
+class TCPPeer
+{
+  auto make_send( const auto& transmit )
+  {
+    return [&]( const TCPSenderMessage& x ) { send( x, transmit ); };
+  }
+
+public:
+  explicit TCPPeer( const TCPConfig& cfg ) : cfg_( cfg ) {}
+
+  Writer& outbound_writer() { return sender_.writer(); }
+  Reader& inbound_reader() { return receiver_.reader(); }
+
+  /* Type of the `transmit` function that the push and tick methods can use to send messages */
+  using TransmitFunction = std::function<void( TCPMessage )>;
+
+  /* Passthrough methods */
+  void push( const TransmitFunction& transmit ) { sender_.push( make_send( transmit ) ); }
+  void tick( uint64_t t, const TransmitFunction& transmit )
+  {
+    cumulative_time_ += t;
+    sender_.tick( t, make_send( transmit ) );
+  }
+  bool has_ackno() const { return receiver_.send().ackno.has_value(); }
+
+  /* Is the peer still active? */
+  bool active() const
+  {
+    const bool any_errors = receiver_.reader().has_error() or sender_.writer().has_error();
+    const bool sender_active = sender_.sequence_numbers_in_flight() or not sender_.reader().is_finished();
+    const bool receiver_active = not receiver_.writer().is_closed();
+    const bool lingering
+      = linger_after_streams_finish_ and ( cumulative_time_ < time_of_last_receipt_ + 10UL * cfg_.rt_timeout );
+
+    return ( not any_errors ) and ( sender_active or receiver_active or lingering );
+  }
+
+  void receive( TCPMessage msg, const TransmitFunction& transmit )
+  {
+    if ( not active() ) {
+      return;
+    }
+
+    // Record time in case this peer has to linger after streams finish.
+    time_of_last_receipt_ = cumulative_time_;
+
+    // If SenderMessage occupies a sequence number, make sure to reply.
+    need_send_ |= ( msg.sender->sequence_length() > 0 );
+
+    // If SenderMessage is a "keep-alive" (with intentionally invalid seqno), make sure to reply.
+    // (N.B. orthodox TCP rules require a reply on any unacceptable segment.)
+    const auto our_ackno = receiver_.send().ackno;
+    need_send_ |= ( our_ackno.has_value() and msg.sender->seqno + 1 == our_ackno.value() );
+
+    // Give incoming TCPSenderMessage to receiver.
+    receiver_.receive( std::move( msg.sender ) );
+
+    // Give incoming TCPReceiverMessage to sender.
+    sender_.receive( msg.receiver );
+
+    // Send reply if needed.
+    push( transmit );
+    if ( need_send_ ) {
+      send( sender_.make_empty_message(), transmit );
+    }
+
+    // Did the inbound stream finish before the outbound stream? If so, no need to linger after streams finish.
+    if ( receiver_.writer().is_closed() and not std::as_const( sender_ ).reader().is_finished() ) {
+      linger_after_streams_finish_ = false;
+    }
+  }
+
+  // Testing interface
+  const TCPReceiver& receiver() const { return receiver_; }
+  const TCPSender& sender() const { return sender_; }
+
+private:
+  TCPConfig cfg_;
+  TCPSender sender_ { ByteStream { cfg_.send_capacity }, cfg_.isn, cfg_.rt_timeout };
+  TCPReceiver receiver_ { Reassembler { ByteStream { cfg_.recv_capacity } } };
+
+  bool need_send_ {};
+
+  void send( const TCPSenderMessage& sender_message, const TransmitFunction& transmit )
+  {
+    transmit( { borrow( sender_message ), receiver_.send() } );
+    need_send_ = false;
+  }
+
+  bool linger_after_streams_finish_ { true }; // one peer may need to linger to make sure all closure conditions met
+  uint64_t cumulative_time_ {};
+  uint64_t time_of_last_receipt_ {};
+};

--- a/util/tcp_receiver_message.hh
+++ b/util/tcp_receiver_message.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "wrapping_integers.hh"
+
+#include <optional>
+
+/*
+ * The TCPReceiverMessage structure contains the information sent from a TCP receiver to its sender.
+ *
+ * It contains three fields:
+ *
+ * 1) The acknowledgment number (ackno): the *next* sequence number needed by the TCP Receiver.
+ *    This is an optional field that is empty if the TCPReceiver hasn't yet received the Initial Sequence Number.
+ *
+ * 2) The window size. This is the number of sequence numbers that the TCP receiver is interested
+ *    to receive, starting from the ackno if present. The maximum value is 65,535 (UINT16_MAX from
+ *    the <cstdint> header).
+ *
+ * 3) The RST (reset) flag. If set, the stream has suffered an error and the connection should be aborted.
+ */
+
+struct TCPReceiverMessage
+{
+  std::optional<Wrap32> ackno {};
+  uint16_t window_size {};
+  bool RST {};
+};

--- a/util/tcp_segment.cc
+++ b/util/tcp_segment.cc
@@ -1,0 +1,119 @@
+#include "tcp_segment.hh"
+#include "checksum.hh"
+#include "helpers.hh"
+#include "wrapping_integers.hh"
+
+#include <sstream>
+
+using namespace std;
+
+static_assert( !( TCPSegment::HEADER_LENGTH & 0x03 ) ); // header length must be divisible by 4
+
+void TCPSegment::parse( Parser& parser, uint32_t datagram_layer_pseudo_checksum )
+{
+  /* verify checksum */
+  InternetChecksum check { datagram_layer_pseudo_checksum };
+  check.add( parser.buffer() );
+  if ( check.value() ) {
+    parser.set_error();
+    return;
+  }
+
+  uint32_t raw32 {};
+  uint16_t raw16 {};
+  uint8_t octet {};
+
+  parser.integer( udinfo.src_port );
+  parser.integer( udinfo.dst_port );
+
+  parser.integer( raw32 );
+  message.sender->seqno = Wrap32 { raw32 };
+
+  parser.integer( raw32 );
+  message.receiver->ackno = Wrap32 { raw32 };
+
+  parser.integer( octet );
+  const uint8_t data_offset = octet >> 4;
+
+  parser.integer( octet ); // flags
+  if ( not( octet & 0b0001'0000 ) ) {
+    message.receiver->ackno.reset(); // no ACK
+  }
+
+  message.sender->RST = message.receiver->RST = octet & 0b0000'0100;
+  message.sender->SYN = octet & 0b0000'0010;
+  message.sender->FIN = octet & 0b0000'0001;
+
+  parser.integer( message.receiver->window_size );
+  parser.integer( udinfo.cksum );
+  parser.integer( raw16 ); // urgent pointer
+
+  // skip any options or anything extra in the header
+  if ( data_offset < ( HEADER_LENGTH >> 2 ) ) {
+    parser.set_error();
+    return;
+  }
+  parser.remove_prefix( data_offset * 4 - HEADER_LENGTH );
+
+  parser.concatenate_all_remaining( message.sender->payload );
+}
+
+class Wrap32Serializable : public Wrap32
+{
+public:
+  uint32_t raw_value() const { return raw_value_; }
+};
+
+void TCPSegment::serialize( Serializer& serializer ) const
+{
+  serializer.integer( udinfo.src_port );
+  serializer.integer( udinfo.dst_port );
+  serializer.integer( Wrap32Serializable { message.sender->seqno }.raw_value() );
+  serializer.integer( Wrap32Serializable { message.receiver->ackno.value_or( Wrap32 { 0 } ) }.raw_value() );
+  serializer.integer( uint8_t { ( HEADER_LENGTH >> 2 ) << 4 } ); // data offset
+  const bool reset = message.sender->RST or message.receiver->RST;
+  const uint8_t flags = ( message.receiver->ackno.has_value() ? 0b0001'0000U : 0 ) | ( reset ? 0b0000'0100U : 0 )
+                        | ( message.sender->SYN ? 0b0000'0010U : 0 ) | ( message.sender->FIN ? 0b0000'0001U : 0 );
+  serializer.integer( flags );
+  serializer.integer( message.receiver->window_size );
+  serializer.integer( udinfo.cksum );
+  serializer.integer( uint16_t { 0 } ); // urgent pointer
+  serializer.buffer( message.sender->payload );
+}
+
+void TCPSegment::compute_checksum( uint32_t datagram_layer_pseudo_checksum )
+{
+  udinfo.cksum = 0;
+  Serializer s;
+  serialize( s );
+
+  InternetChecksum check { datagram_layer_pseudo_checksum };
+  check.add( s.finish() );
+  udinfo.cksum = check.value();
+}
+
+string TCPSegment::to_string() const
+{
+  stringstream ss {};
+  ss << "TCP";
+  ss << " seqno=" << Wrap32Serializable { message.sender->seqno }.raw_value();
+  if ( message.sender->SYN ) {
+    ss << " +SYN";
+  }
+  if ( not message.sender->payload.empty() ) {
+    ss << " payload=\"" << pretty_print( message.sender->payload ) << "\"";
+  }
+  if ( message.sender->FIN ) {
+    ss << " +FIN";
+  }
+  if ( message.sender->RST or message.receiver->RST ) {
+    ss << " +RST";
+  }
+  auto ackno = message.receiver->ackno;
+  if ( ackno.has_value() ) {
+    ss << " ACK<" << Wrap32Serializable { *ackno }.raw_value() << ">";
+  }
+  ss << " winsize=" << message.receiver->window_size;
+  ss << " src=" << udinfo.src_port << " dst=" << udinfo.dst_port;
+  return ss.str();
+}

--- a/util/tcp_segment.hh
+++ b/util/tcp_segment.hh
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "parser.hh"
+#include "ref.hh"
+#include "tcp_receiver_message.hh"
+#include "tcp_sender_message.hh"
+#include "udinfo.hh"
+
+// A TCPMessage (a concept used only in CS144) models the full
+// messages sent between TCP endpoints, omitting the multiplexing
+// information and checksum.
+struct TCPMessage
+{
+  Ref<TCPSenderMessage> sender {};
+  Ref<TCPReceiverMessage> receiver {};
+};
+
+// A TCPSegment represents a complete (STD 7 / RFC 9293) TCP segment.
+// It includes a TCPMessage plus the UDP-like information included in the TCP header.
+struct TCPSegment
+{
+  TCPMessage message {};
+  UserDatagramInfo udinfo {};
+
+  void parse( Parser& parser, uint32_t datagram_layer_pseudo_checksum );
+  void serialize( Serializer& serializer ) const;
+
+  void compute_checksum( uint32_t datagram_layer_pseudo_checksum );
+
+  static constexpr uint8_t HEADER_LENGTH = 20; // TCP header length, not including options
+
+  // Return a string containing a summary in human-readable format
+  std::string to_string() const;
+};

--- a/util/tcp_sender_message.hh
+++ b/util/tcp_sender_message.hh
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "wrapping_integers.hh"
+
+#include <string>
+
+/*
+ * The TCPSenderMessage structure contains the information sent from a TCP sender to its receiver.
+ *
+ * It contains five fields:
+ *
+ * 1) The sequence number (seqno) of the beginning of the segment. If the SYN flag is set, this is the
+ *    sequence number of the SYN flag. Otherwise, it's the sequence number of the beginning of the payload.
+ *
+ * 2) The SYN flag. If set, this segment is the beginning of the byte stream, and the seqno field
+ *    contains the Initial Sequence Number (ISN) -- the zero point.
+ *
+ * 3) The payload: a substring (possibly empty) of the byte stream.
+ *
+ * 4) The FIN flag. If set, the payload represents the ending of the byte stream.
+ *
+ * 5) The RST (reset) flag. If set, the stream has suffered an error and the connection should be aborted.
+ */
+
+struct TCPSenderMessage
+{
+  Wrap32 seqno { 0 };
+
+  bool SYN {};
+  std::string payload {};
+  bool FIN {};
+
+  bool RST {};
+
+  // How many sequence numbers does this segment use?
+  size_t sequence_length() const { return SYN + payload.size() + FIN; }
+};

--- a/util/tun.cc
+++ b/util/tun.cc
@@ -1,0 +1,38 @@
+#include "tun.hh"
+#include "exception.hh"
+
+#include <cstring>
+#include <fcntl.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#include <sys/ioctl.h>
+
+static constexpr const char* CLONEDEV = "/dev/net/tun";
+
+using namespace std;
+
+//! \param[in] devname is the name of the TUN or TAP device, specified at its creation.
+//! \param[in] is_tun is `true` for a TUN device (expects IP datagrams), or `false` for a TAP device (expects
+//! Ethernet frames)
+//!
+//! To create a TUN device, you should already have run
+//!
+//!     ip tuntap add mode tun user `username` name `devname`
+//!
+//! as root before calling this function.
+
+TunTapFD::TunTapFD( const string& devname, const bool is_tun )
+  : FileDescriptor( ::CheckSystemCall( "open", open( CLONEDEV, O_RDWR | O_CLOEXEC ) ) )
+{
+  struct ifreq tun_req
+  {};
+
+  tun_req.ifr_flags = static_cast<int16_t>( ( is_tun ? IFF_TUN : IFF_TAP ) | IFF_NO_PI ); // no packetinfo
+
+  // copy devname to ifr_name, making sure to null terminate
+
+  strncpy( static_cast<char*>( tun_req.ifr_name ), devname.data(), IFNAMSIZ - 1 );
+  tun_req.ifr_name[IFNAMSIZ - 1] = '\0';
+
+  CheckSystemCall( "ioctl", ioctl( fd_num(), TUNSETIFF, static_cast<void*>( &tun_req ) ) );
+}

--- a/util/tun.hh
+++ b/util/tun.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "file_descriptor.hh"
+
+#include <string>
+
+//! A FileDescriptor to a [Linux TUN/TAP](https://www.kernel.org/doc/Documentation/networking/tuntap.txt) device
+class TunTapFD : public FileDescriptor
+{
+public:
+  //! Open an existing persistent [TUN or TAP
+  //! device](https://www.kernel.org/doc/Documentation/networking/tuntap.txt).
+  explicit TunTapFD( const std::string& devname, bool is_tun );
+};
+
+//! A FileDescriptor to a [Linux TUN](https://www.kernel.org/doc/Documentation/networking/tuntap.txt) device
+class TunFD : public TunTapFD
+{
+public:
+  //! Open an existing persistent [TUN device](https://www.kernel.org/doc/Documentation/networking/tuntap.txt).
+  explicit TunFD( const std::string& devname ) : TunTapFD( devname, true ) {}
+};
+
+//! A FileDescriptor to a [Linux TAP](https://www.kernel.org/doc/Documentation/networking/tuntap.txt) device
+class TapFD : public TunTapFD
+{
+public:
+  //! Open an existing persistent [TAP device](https://www.kernel.org/doc/Documentation/networking/tuntap.txt).
+  explicit TapFD( const std::string& devname ) : TunTapFD( devname, false ) {}
+};

--- a/util/tuntap_adapter.cc
+++ b/util/tuntap_adapter.cc
@@ -1,0 +1,26 @@
+#include "tuntap_adapter.hh"
+#include "helpers.hh"
+
+using namespace std;
+
+optional<TCPMessage> TCPOverIPv4OverTunFdAdapter::read()
+{
+  vector<string> strs( 3 );
+  strs[0].resize( IPv4Header::LENGTH );
+  strs[1].resize( TCPSegment::HEADER_LENGTH );
+  _tun.read( strs );
+
+  InternetDatagram ip_dgram;
+  if ( parse( ip_dgram, move( strs ) ) ) {
+    return unwrap_tcp_in_ip( move( ip_dgram ) );
+  }
+  return {};
+}
+
+void TCPOverIPv4OverTunFdAdapter::write( const TCPMessage& seg )
+{
+  _tun.write( serialize( wrap_tcp_in_ip( seg ) ) );
+}
+
+//! Specialize LossyFdAdapter to TCPOverIPv4OverTunFdAdapter
+template class LossyFdAdapter<TCPOverIPv4OverTunFdAdapter>;

--- a/util/tuntap_adapter.hh
+++ b/util/tuntap_adapter.hh
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "lossy_fd_adapter.hh"
+#include "tcp_over_ip.hh"
+#include "tcp_segment.hh"
+#include "tun.hh"
+
+#include <optional>
+#include <utility>
+
+template<class T>
+concept TCPDatagramAdapter = requires( T a, TCPMessage seg ) {
+  { a.write( seg ) } -> std::same_as<void>;
+
+  { a.read() } -> std::same_as<std::optional<TCPMessage>>;
+};
+
+//! \brief A FD adapter for IPv4 datagrams read from and written to a TUN device
+class TCPOverIPv4OverTunFdAdapter : public TCPOverIPv4Adapter
+{
+private:
+  TunFD _tun;
+
+public:
+  //! Construct from a TunFD
+  explicit TCPOverIPv4OverTunFdAdapter( TunFD&& tun ) : _tun( std::move( tun ) ) {}
+
+  //! Attempts to read and parse an IPv4 datagram containing a TCP segment related to the current connection
+  std::optional<TCPMessage> read();
+
+  //! Creates an IPv4 datagram from a TCP segment and writes it to the TUN device
+  void write( const TCPMessage& seg );
+
+  //! Access the underlying TUN device
+  explicit operator TunFD&() { return _tun; }
+
+  //! Access the underlying TUN device
+  explicit operator const TunFD&() const { return _tun; }
+
+  //! Access underlying file descriptor
+  FileDescriptor& fd() { return _tun; }
+};
+
+static_assert( TCPDatagramAdapter<TCPOverIPv4OverTunFdAdapter> );
+static_assert( TCPDatagramAdapter<LossyFdAdapter<TCPOverIPv4OverTunFdAdapter>> );

--- a/util/udinfo.hh
+++ b/util/udinfo.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+// Small struct to represent "user datagram" information (UDP, or the "UDP-like" portion of a TCP header)
+
+struct UserDatagramInfo
+{
+  uint16_t src_port;
+  uint16_t dst_port;
+  uint16_t cksum;
+};

--- a/writeups/check1.md
+++ b/writeups/check1.md
@@ -1,0 +1,37 @@
+Checkpoint 1 Writeup
+====================
+
+My name: [your name here]
+
+My SUNet ID: [your sunetid here]
+
+I collaborated with: [list sunetids here]
+
+I would like to thank/reward these classmates for their help: [list sunetids here]
+
+This lab took me about [n] hours to do. I [did/did not] attend the lab session.
+
+I was surprised by or edified to learn that: [describe]
+
+Report from the hands-on component of the lab checkpoint: [include
+information from 2.1(4), and report on your experience in 2.2]
+
+Describe Reassembler structure and design. [Describe data structures and
+approach taken. Describe alternative designs considered or tested.
+Describe benefits and weaknesses of your design compared with
+alternatives -- perhaps in terms of simplicity/complexity, risk of
+bugs, asymptotic performance, empirical performance, required
+implementation time and difficulty, and other factors. Include any
+measurements if applicable.]
+
+Implementation Challenges:
+[]
+
+Remaining Bugs:
+[]
+
+- Optional: I had unexpected difficulty with: [describe]
+
+- Optional: I think you could make this lab better by: [describe]
+
+- Optional: I'm not sure about: [describe]

--- a/writeups/check2.md
+++ b/writeups/check2.md
@@ -1,0 +1,36 @@
+Checkpoint 2 Writeup
+====================
+
+My name: [your name here]
+
+My SUNet ID: [your sunetid here]
+
+I collaborated with: [list sunetids here]
+
+I would like to thank/reward these classmates for their help: [list sunetids here]
+
+This lab took me about [n] hours to do. I [did/did not] attend the lab session.
+
+Describe Wrap32 and TCPReceiver structure and design. [Describe data
+structures and approach taken. Describe alternative designs considered
+or tested.  Describe benefits and weaknesses of your design compared
+with alternatives -- perhaps in terms of simplicity/complexity, risk
+of bugs, asymptotic performance, empirical performance, required
+implementation time and difficulty, and other factors. Include any
+measurements if applicable.]
+
+Implementation Challenges:
+[]
+
+Remaining Bugs:
+[]
+
+- Optional: I had unexpected difficulty with: [describe]
+
+- Optional: I think you could make this lab better by: [describe]
+
+- Optional: I was surprised by: [describe]
+
+- Optional: I'm not sure about: [describe]
+
+- Optional: I made an extra test I think will be helpful in catching bugs: [describe where to find]

--- a/writeups/check3.md
+++ b/writeups/check3.md
@@ -1,0 +1,38 @@
+Checkpoint 3 Writeup
+====================
+
+My name: [your name here]
+
+My SUNet ID: [your sunetid here]
+
+I collaborated with: [list sunetids here]
+
+I would like to thank/reward these classmates for their help: [list sunetids here]
+
+This checkpoint took me about [n] hours to do. I [did/did not] attend the lab session.
+
+Program Structure and Design of the TCPSender [Describe data
+structures and approach taken. Describe alternative designs considered
+or tested.  Describe benefits and weaknesses of your design compared
+with alternatives -- perhaps in terms of simplicity/complexity, risk
+of bugs, asymptotic performance, empirical performance, required
+implementation time and difficulty, and other factors. Include any
+measurements if applicable.]: []
+
+Report from the hands-on component: []
+
+Implementation Challenges:
+[]
+
+Remaining Bugs:
+[]
+
+- Optional: I had unexpected difficulty with: [describe]
+
+- Optional: I think you could make this lab better by: [describe]
+
+- Optional: I was surprised by: [describe]
+
+- Optional: I'm not sure about: [describe]
+
+- Optional: I made an extra test I think will be helpful in catching bugs: [describe where to find]

--- a/writeups/check5.md
+++ b/writeups/check5.md
@@ -1,0 +1,35 @@
+Checkpoint 5 Writeup
+====================
+
+My name: [your name here]
+
+My SUNet ID: [your sunetid here]
+
+I collaborated with: [list sunetids here]
+
+I would like to thank/reward these classmates for their help: [list sunetids here]
+
+This checkpoint took me about [n] hours to do. I [did/did not] attend the lab session.
+
+Program Structure and Design of the NetworkInterface [Describe data
+structures and approach taken. Describe alternative designs considered
+or tested.  Describe benefits and weaknesses of your design compared
+with alternatives -- perhaps in terms of simplicity/complexity, risk
+of bugs, asymptotic performance, empirical performance, required
+implementation time and difficulty, and other factors. Include any
+measurements if applicable.]:
+[]
+
+Implementation Challenges:
+[]
+
+Remaining Bugs:
+[]
+
+- Optional: I had unexpected difficulty with: [describe]
+
+- Optional: I think you could make this lab better by: [describe]
+
+- Optional: I was surprised by: [describe]
+
+- Optional: I'm not sure about: [describe]


### PR DESCRIPTION
The first added test verifies that an IP mapping is made when the interface receives an ARP request for an IP address other than the interface's.

The second added test verifies that an IP mapping is made when the interface receives an ARP reply whose frame was sent to ETHERNET_BROADCAST.

Both tests should pass to meet the assignment specification and neither is covered by existing test cases. 