### PR TITLE
Update router.cc

### DIFF
--- a/tests/router.cc
+++ b/tests/router.cc
@@ -155,7 +155,14 @@ class Network
 private:
   Router _router {};
 
-  vector<shared_ptr<NetworkSegment>> segments_ { 6, make_shared<NetworkSegment>() };
+  vector<shared_ptr<NetworkSegment>> segments_ {
+    make_shared<NetworkSegment>(),
+    make_shared<NetworkSegment>(),
+    make_shared<NetworkSegment>(),
+    make_shared<NetworkSegment>(),
+    make_shared<NetworkSegment>(),
+    make_shared<NetworkSegment>()
+  };
 
   shared_ptr<NetworkSegment> upstream { segments_.at( 0 ) };
   shared_ptr<NetworkSegment> eth0_applesauce { segments_.at( 1 ) };


### PR DESCRIPTION
Fixed a bug in which the `NetworkSegment` smart pointer vector pointed to the same object. This bug caused all hosts and routers to be in the same network segment. This bug had no effect on the final test results, but it caused the data packets to be broadcasted in the entire network segment, which generats a lot of miscellaneous debug informations, making it difficult to debug.
In the debug window we can see that all pointers in `segments_` and members like `upstream` `eth0_` applesauce are pointing to the same object.
![Snipaste_2025-03-15_15-12-04](https://github.com/user-attachments/assets/8ee8d65a-b016-42f9-922c-20e1ad8f25b5)
