### PR TITLE
[Check2] - Added new test case for non-overlapping reassembler behavior

### DIFF
--- a/etc/tests.cmake
+++ b/etc/tests.cmake
@@ -25,6 +25,7 @@ ttest(byte_stream_many_writes)
 ttest(byte_stream_stress_test)
 
 ttest(reassembler_single)
+ttest(reassembler_non_overlap)
 ttest(reassembler_cap)
 ttest(reassembler_seq)
 ttest(reassembler_dup)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_test_exec(byte_stream_many_writes)
 add_test_exec(byte_stream_stress_test)
 
 add_test_exec(reassembler_single)
+add_test_exec(reassembler_non_overlap)
 add_test_exec(reassembler_cap)
 add_test_exec(reassembler_seq)
 add_test_exec(reassembler_dup)

--- a/tests/reassembler_non_overlap.cc
+++ b/tests/reassembler_non_overlap.cc
@@ -1,0 +1,41 @@
+#include "byte_stream_test_harness.hh"
+#include "reassembler_test_harness.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+  try {
+    {
+      ReassemblerTestHarness test { "all within capacity", 600 };
+
+      test.execute( Insert { "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnop", 0 } );
+      test.execute( BytesPushed( 68 ) );
+      test.execute( BytesPending( 0 ) );
+
+      test.execute(
+        Insert { "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                 340 } );
+      test.execute( BytesPushed( 68 ) );
+      test.execute( BytesPending( 260 ) );
+
+      test.execute(
+        Insert { "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                 68 } );
+      test.execute( BytesPushed( 600 ) );
+      test.execute( BytesPending( 0 ) );
+    }
+  } catch ( const exception& e ) {
+    cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Additional test case: Test case/behavior/situaton that didnt get caught in the reassembler test but it did in the receiver tests and thus should be included in the reassembler tests for future: when you have no overlapping segments but they are out of order. When you have a segment that starts late in the stream and its length is exactly to the end of the stream, nothing should get truncated. This should be after you’ve already pushed something. So the available size in the stream changes but the end index of the last possible thing wouldn’t change. 

Capacity 600:
Push at 0 of size 68
Remaining capcity is 532
Push at 340 of size 260, nothing should get truncated since its within the size and last index is before 600 cap
Then push at 68, size 272

This does out of order non-overlapping segments and ensure the right data is stored in reassembler and nothing gets truncated. 

The testcase file can be found under /tests in reassembler_non_overlap.cc

With my previous implementation of Reassembler that I submitted during checkpoint 1, this test case failed and caused the downstream tests in recv to also fail. So I made the fix in my code and added this test case to reassembler so that it checks this ability in reassembler first and then moves on to the recv tests. 